### PR TITLE
WIP: Geewallet payments

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelCommands.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelCommands.fs
@@ -21,6 +21,10 @@ open NBitcoin
 //      Y88b  d88P Y88b. .d88P 888   "   888 888   "   888  d8888888888 888   Y8888 888  .d88P Y88b  d88P
 //       "Y8888P"   "Y88888P"  888       888 888       888 d88P     888 888    Y888 8888888P"   "Y8888P"
 
+type CMDGeewalletPayment = {
+    Amount: LNMoney
+}
+
 type CMDAddHTLC = {
     AmountMSat: LNMoney
     PaymentHash: PaymentHash
@@ -206,6 +210,8 @@ type ChannelCommand =
     | CreateChannelReestablish
 
     // normal
+    | GeewalletPayment of CMDGeewalletPayment
+    | ApplyGeewalletPayment of msg: GeewalletPayment
     | AddHTLC of CMDAddHTLC
     | ApplyUpdateAddHTLC of msg: UpdateAddHTLC * currentHeight: BlockHeight
     | FulfillHTLC of CMDFulfillHTLC

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -36,6 +36,7 @@ type ChannelError =
     // --- case they sent unacceptable msg ---
     | InvalidOpenChannel of InvalidOpenChannelError
     | InvalidAcceptChannel of InvalidAcceptChannelError
+    | InvalidGeewalletPayment of InvalidGeewalletPaymentError
     | InvalidUpdateAddHTLC of InvalidUpdateAddHTLCError
     | InvalidRevokeAndACK of InvalidRevokeAndACKError
     | InvalidUpdateFee of InvalidUpdateFeeError
@@ -69,6 +70,7 @@ type ChannelError =
         | TheyCannotAffordFee (_, _, _) -> Close
         | InvalidOpenChannel _ -> DistrustPeer
         | InvalidAcceptChannel _ -> DistrustPeer
+        | InvalidGeewalletPayment _ -> Close
         | InvalidUpdateAddHTLC _ -> Close
         | InvalidRevokeAndACK _ -> Close
         | InvalidUpdateFee _ -> Close
@@ -145,6 +147,15 @@ and InvalidAcceptChannelError = {
         Errors = e
     }
     
+and InvalidGeewalletPaymentError = {
+    Msg: GeewalletPayment
+    Errors: string list
+}
+    with
+    static member Create msg e = {
+        Msg = msg
+        Errors = e
+    }
 and InvalidUpdateAddHTLCError = {
     Msg: UpdateAddHTLC
     Errors: string list
@@ -458,6 +469,18 @@ module internal AcceptChannelMsgValidation =
 
         (check1 |> Validation.ofResult) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7
         
+module UpdateGeewalletPaymentWithContext =
+    let internal checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
+        let fees = if (state.LocalParams.IsFunder) then (Transactions.commitTxFee (state.RemoteParams.DustLimitSatoshis) currentSpec) else Money.Zero
+        let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
+        if (missing < Money.Zero) then
+            sprintf "We don't have sufficient funds to send geewallet payment. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"
+                    (currentSpec.ToRemote.ToMoney())
+                    (state.RemoteParams.ChannelReserveSatoshis)
+                    (fees)
+            |> Error
+        else
+            Ok()
 
 module UpdateAddHTLCValidation =
     let internal checkExpiryIsNotPast (current: BlockHeight) (expiry) =
@@ -472,7 +495,23 @@ module UpdateAddHTLCValidation =
     let internal checkAmountIsLargerThanMinimum (htlcMinimum: LNMoney) (amount) =
         check (amount) (<) (htlcMinimum) "htlc value (%A) is too small. must be greater or equal to %A"
 
-    
+module internal GeewalletPaymentValidationWithContext =
+    let checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
+        let fees =
+            if state.LocalParams.IsFunder then
+                Transactions.commitTxFee state.RemoteParams.DustLimitSatoshis currentSpec
+            else
+                Money.Zero
+        let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
+        if (missing < Money.Zero) then
+            sprintf "We don't have sufficient funds to send geewallet payment. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"
+                    (currentSpec.ToRemote.ToMoney())
+                    (state.RemoteParams.ChannelReserveSatoshis)
+                    (fees)
+            |> Error
+        else
+            Ok()
+
 module internal UpdateAddHTLCValidationWithContext =
     let checkLessThanHTLCValueInFlightLimit (currentSpec: CommitmentSpec) (limit) (add: UpdateAddHTLC) =
         let htlcValueInFlight = currentSpec.HTLCs |> Map.toSeq |> Seq.sumBy (fun (_, v) -> v.Add.AmountMSat)

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -264,6 +264,9 @@ type ChannelEvent =
     | BothFundingLocked of nextState: Data.NormalData
 
     // -------- normal operation ------
+    | WeAcceptedCMDGeewalletPayment of msg: GeewalletPayment * newCommitments: Commitments
+    | WeAcceptedGeewalletPayment of newCommitments: Commitments
+
     | WeAcceptedCMDAddHTLC of msg: UpdateAddHTLC * newCommitments: Commitments
     | WeAcceptedUpdateAddHTLC of newCommitments: Commitments
 

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -169,6 +169,13 @@ module internal Validation =
         *> AcceptChannelMsgValidation.checkConfigPermits conf.PeerChannelConfigLimits msg
         |> Result.mapError(InvalidAcceptChannelError.Create msg >> InvalidAcceptChannel)
 
+    let checkOurGeewalletPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: GeewalletPayment) =
+        Validation.ofResult(GeewalletPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+        |> Result.mapError(InvalidGeewalletPaymentError.Create payment >> InvalidGeewalletPayment)
+
+    let checkTheirGeewalletPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: GeewalletPayment) =
+        Validation.ofResult(GeewalletPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+        |> Result.mapError(InvalidGeewalletPaymentError.Create payment >> InvalidGeewalletPayment)
 
     let checkCMDAddHTLC (state: NormalData) (cmd: CMDAddHTLC) =
         Validation.ofResult(UpdateAddHTLCValidation.checkExpiryIsNotPast cmd.CurrentHeight cmd.Expiry)

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -88,6 +88,30 @@ type WaitingForRevocation = {
             (fun w -> w.ReSignASAP),
             (fun v w -> { w with ReSignASAP = v })
 
+type RemoteNextCommitInfo =
+    | WaitingForRevocation of WaitingForRevocation
+    | Revoked of PubKey
+    with
+        static member WaitingForRevocation_: Prism<RemoteNextCommitInfo, WaitingForRevocation> =
+            (fun remoteNextCommitInfo ->
+                match remoteNextCommitInfo with
+                | WaitingForRevocation waitingForRevocation -> Some waitingForRevocation
+                | Revoked _ -> None),
+            (fun waitingForRevocation remoteNextCommitInfo ->
+                match remoteNextCommitInfo with
+                | WaitingForRevocation _ -> WaitingForRevocation waitingForRevocation
+                | Revoked _ -> remoteNextCommitInfo)
+
+        static member Revoked_: Prism<RemoteNextCommitInfo, PubKey> =
+            (fun remoteNextCommitInfo ->
+                match remoteNextCommitInfo with
+                | WaitingForRevocation _ -> None
+                | Revoked pubKey -> Some pubKey),
+            (fun pubKey remoteNextCommitInfo ->
+                match remoteNextCommitInfo with
+                | WaitingForRevocation _ -> remoteNextCommitInfo
+                | Revoked pubKey -> Revoked pubKey)
+
 type Commitments = {
     LocalParams: LocalParams
     RemoteParams: RemoteParams
@@ -100,7 +124,7 @@ type Commitments = {
     LocalNextHTLCId: HTLCId
     RemoteNextHTLCId: HTLCId
     OriginChannels: Map<HTLCId, HTLCSource>
-    RemoteNextCommitInfo: Choice<WaitingForRevocation, PubKey>
+    RemoteNextCommitInfo: RemoteNextCommitInfo
     RemotePerCommitmentSecrets: ShaChain
     ChannelId: ChannelId
 }
@@ -140,7 +164,7 @@ type Commitments = {
             this.RemoteChanges.Proposed |> List.exists(fun p -> match p with | :? UpdateAddHTLC -> true | _ -> false)
 
         member internal this.HasNoPendingHTLCs() =
-            this.LocalCommit.Spec.HTLCs.IsEmpty && this.RemoteCommit.Spec.HTLCs.IsEmpty && (this.RemoteNextCommitInfo |> function Choice1Of2 _ -> false | Choice2Of2 _ -> true)
+            this.LocalCommit.Spec.HTLCs.IsEmpty && this.RemoteCommit.Spec.HTLCs.IsEmpty && (this.RemoteNextCommitInfo |> function WaitingForRevocation _ -> false | Revoked _ -> true)
 
         member internal this.GetHTLCCrossSigned(directionRelativeToLocal: Direction, htlcId: HTLCId): UpdateAddHTLC option =
             let remoteSigned =
@@ -148,7 +172,10 @@ type Commitments = {
                 |> Map.tryPick (fun k v -> if v.Direction = directionRelativeToLocal && v.Add.HTLCId = htlcId then Some v else None)
 
             let localSigned =
-                let lens = Commitments.RemoteNextCommitInfo_ >-> Choice.choice1Of2_ >?> WaitingForRevocation.NextRemoteCommit_
+                let lens =
+                    Commitments.RemoteNextCommitInfo_
+                    >-> RemoteNextCommitInfo.WaitingForRevocation_
+                    >?> WaitingForRevocation.NextRemoteCommit_
                 match Optic.get lens this with
                 | Some v -> v
                 | None -> this.RemoteCommit

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -272,7 +272,7 @@ module internal Commitments =
 
     let sendCommit (ctx: ISecp256k1) (keyRepo: IKeysRepository) (n: Network) (cm: Commitments) =
         match cm.RemoteNextCommitInfo with
-        | Choice2Of2 remoteNextPerCommitmentPoint ->
+        | RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint ->
             result {
                 // remote commitment will include all local changes + remote acked changes
                 let! spec = cm.RemoteCommit.Spec.Reduce(cm.RemoteChanges.ACKed, cm.LocalChanges.Proposed) |> expectTransactionError
@@ -309,12 +309,12 @@ module internal Commitments =
                                                  SentAfterLocalCommitmentIndex = cm.LocalCommit.Index
                                                  ReSignASAP = false }
 
-                    { cm with RemoteNextCommitInfo = Choice1Of2(nextRemoteCommitInfo)
+                    { cm with RemoteNextCommitInfo = RemoteNextCommitInfo.WaitingForRevocation(nextRemoteCommitInfo)
                               LocalChanges = { cm.LocalChanges with Proposed = []; Signed = cm.LocalChanges.Proposed }
                               RemoteChanges = { cm.RemoteChanges with ACKed = []; Signed = cm.RemoteChanges.ACKed } }
                 return [ WeAcceptedCMDSign (msg, nextCommitments) ]
             }
-        | Choice1Of2 _ ->
+        | RemoteNextCommitInfo.WaitingForRevocation _ ->
             CanNotSignBeforeRevocation |> Error
 
     let private checkSignatureCountMismatch(sortedHTLCTXs: IHTLCTx list) (msg) =

--- a/src/DotNetLightning.Core/Serialize/Features.fs
+++ b/src/DotNetLightning.Core/Serialize/Features.fs
@@ -181,6 +181,11 @@ type FeatureBit private (bitArray) =
                 bytes <- this.BitArray.ToByteArray()
             bytes
         and set(v: byte[]) = bytes <- v
+    new() =
+        FeatureBit(
+            let b: bool array = [||]
+            BitArray(b)
+        )
     static member TryCreate(ba: BitArray) =
         result {
             do! Feature.validateFeatureGraph(ba)
@@ -192,9 +197,7 @@ type FeatureBit private (bitArray) =
             else
                 return (FeatureBit(ba))
         }
-    static member Zero =
-        let b: bool array = [||]
-        b |> BitArray |> FeatureBit
+    static member Zero = FeatureBit()
     static member TryCreate(bytes: byte[]) =
         result {
             let! fb = FeatureBit.TryCreate(BitArray.FromBytes(bytes))

--- a/src/DotNetLightning.Infrastructure/ActorManagers/ChannelManager.fs
+++ b/src/DotNetLightning.Infrastructure/ActorManagers/ChannelManager.fs
@@ -202,6 +202,8 @@ type ChannelManager(log: ILogger<ChannelManager>,
                     return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.RemoteShutdown m)
                 | :? ClosingSigned as m ->
                     return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.ApplyClosingSigned m)
+                | :? GeewalletPayment as m ->
+                    return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.ApplyGeewalletPayment m)
                 | :? UpdateAddHTLC as m ->
                     return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.ApplyUpdateAddHTLC (m, this.CurrentBlockHeight))
                 | :? UpdateFulfillHTLC as m ->

--- a/src/DotNetLightning.Infrastructure/ActorManagers/PeerManager.fs
+++ b/src/DotNetLightning.Infrastructure/ActorManagers/PeerManager.fs
@@ -190,15 +190,19 @@ type PeerManager(eventAggregator: IEventAggregator,
                 | WeSentFundingLocked fundingLockedMsg ->
                     return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg fundingLockedMsg)
                 | BothFundingLocked _ -> ()
+                | WeAcceptedGeewalletPayment _
                 | WeAcceptedUpdateAddHTLC _
                 | WeAcceptedFulfillHTLC _
                 | WeAcceptedFailHTLC _ -> ()
                 | WeAcceptedFailMalformedHTLC _ -> ()
                 | WeAcceptedUpdateFee _ -> ()
-                | WeAcceptedCommitmentSigned  _ -> failwith "TODO: route"
+                | WeAcceptedCommitmentSigned (msg, _) ->
+                    return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg msg)
                 | WeAcceptedRevokeAndACK _ -> failwith "TODO: route"
                 // The one which includes `CMD` in its names is the one started by us.
                 // So there are no need to think about routing, just send it to specified peer.
+                | ChannelEvent.WeAcceptedCMDGeewalletPayment (msg, _) ->
+                    return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg msg)
                 | ChannelEvent.WeAcceptedCMDAddHTLC (msg, _) ->
                     return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg msg)
                 | ChannelEvent.WeAcceptedCMDFulfillHTLC (msg, _) ->

--- a/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
+++ b/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
@@ -45,6 +45,5 @@
     <ProjectReference Condition="'$(BouncyCastle)'!='true'" Include="..\..\src\NSec\Experimental\NSec.Experimental.csproj" />
     <ProjectReference Include="..\..\src\ResultUtils\ResultUtils.fsproj" />
   </ItemGroup>
-  <Import Project="..\..\fsc.props" />
   <Import Project="..\..\netfx.props" />
 </Project>


### PR DESCRIPTION
This is a work-in-progress PR for the implementation for the geewallet payments. Geewallet payments are implemented as their own lightning message type. Sending a payment requires sending a `geewallet_payment` message followed immediately by a `commitment_signed` which should be responded to with a `revoke_and_ack` and a `commitment_signed` from the counterparty.

The `geewallet_payment` message will evolve into `update_add_htlc` once we are able to get revocations (and therefore non-routable payments) working.

There are two tests in `DotNetLightning.Infrastructure.Tests/ChannelOperationTests.fs` for geewallet payments - one which does not send the `revoke_and_ack` but which passes, and one that does send it but doesn't pass.