### PR TITLE
Use correct channel ID in WaitForFundingSigned

### DIFF
--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -32,10 +32,5 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
         dotnet pack . -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | cut -c 1-7` -p:BouncyCastle=True
-        dotnet nuget push ./bin/Release/DotNetLightning.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+        dotnet nuget push ./bin/Release/DotNetLightning.Kiss.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
-    - name: Upload nuget packages (native)
-      run: |
-        cd $GITHUB_WORKSPACE/src/DotNetLightning.Core
-        dotnet pack . -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | cut -c 1-7`-${{ matrix.RID }}
-        dotnet nuget push ./bin/Release/DotNetLightning.Core.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -169,6 +169,7 @@ module Channel =
                 assert (state.LastSent.FundingPubKey = localParams.ChannelPubKeys.FundingPubKey)
                 let commitmentSpec = state.InputInitFunder.DeriveCommitmentSpec()
                 let commitmentSeed = state.InputInitFunder.ChannelKeys.CommitmentSeed
+                let fundingTxId = fundingTx.Value.GetTxId()
                 let! (_localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
                     ChannelHelpers.makeFirstCommitTxs localParams
                                                remoteParams
@@ -176,7 +177,7 @@ module Channel =
                                                state.LastSent.PushMSat
                                                state.LastSent.FeeRatePerKw
                                                outIndex
-                                               (fundingTx.Value.GetHash() |> TxId)
+                                               fundingTxId
                                                (ChannelUtils.buildCommitmentPoint(commitmentSeed, 0UL))
                                                msg.FirstPerCommitmentPoint
                                                cs.Secp256k1Context
@@ -184,11 +185,12 @@ module Channel =
                 let localSigOfRemoteCommit, _ = (cs.KeysRepository.GetSignatureFor(remoteCommitTx.Value, state.LastSent.FundingPubKey))
                 let nextMsg: FundingCreatedMsg = {
                     TemporaryChannelId = msg.TemporaryChannelId
-                    FundingTxId = fundingTx.Value.GetTxId()
+                    FundingTxId = fundingTxId
                     FundingOutputIndex = outIndex
                     Signature = !>localSigOfRemoteCommit.Signature
                 }
-                let data = { Data.WaitForFundingSignedData.ChannelId = msg.TemporaryChannelId
+                let channelId = OutPoint(fundingTxId.Value, uint32 outIndex.Value).ToChannelId()
+                let data = { Data.WaitForFundingSignedData.ChannelId = channelId
                              LocalParams = localParams
                              RemoteParams = remoteParams
                              Data.WaitForFundingSignedData.FundingTx = fundingTx

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -399,6 +399,32 @@ module Channel =
                 [] |> Ok
 
         // ---------- normal operation ---------
+        | ChannelState.Normal state, MonoHopUnidirectionalPayment op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
+            sprintf "Could not send mono-hop unidirectional payment %A since shutdown is already in progress." op
+            |> apiMisuse
+        | ChannelState.Normal state, MonoHopUnidirectionalPayment op ->
+            result {
+                let payment: MonoHopUnidirectionalPaymentMsg = {
+                    ChannelId = state.Commitments.ChannelId
+                    Amount = op.Amount
+                }
+                let commitments1 = state.Commitments.AddLocalProposal(payment)
+
+                let remoteCommit1 =
+                    match commitments1.RemoteNextCommitInfo with
+                    | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
+                    | RemoteNextCommitInfo.Revoked _info -> commitments1.RemoteCommit
+                let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
+                do! Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 payment
+                return [ WeAcceptedOperationMonoHopUnidirectionalPayment(payment, commitments1) ]
+            }
+        | ChannelState.Normal state, ApplyMonoHopUnidirectionalPayment msg ->
+            result {
+                let commitments1 = state.Commitments.AddRemoteProposal(msg)
+                let! reduced = commitments1.LocalCommit.Spec.Reduce (commitments1.LocalChanges.ACKed, commitments1.RemoteChanges.Proposed) |> expectTransactionError
+                do! Validation.checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 msg
+                return [ WeAcceptedMonoHopUnidirectionalPayment commitments1 ]
+            }
         | ChannelState.Normal state, AddHTLC op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
             sprintf "Could not add new HTLC %A since shutdown is already in progress." op
             |> apiMisuse
@@ -497,10 +523,9 @@ module Channel =
                                              RemoteCommit = theirNextCommit
                                              RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint)
                                              RemotePerCommitmentSecrets = cm.RemotePerCommitmentSecrets.AddHash (msg.PerCommitmentSecret.ToByteArray(), 0xffffffffffffUL - cm.RemoteCommit.Index) }
+                Console.WriteLine("WARNING: revocation is not implemented yet")
                 let result = [ WeAcceptedRevokeAndACK(commitments1) ]
                 result |> Ok
-                failwith "needs update"
-
 
         | ChannelState.Normal state, ChannelCommand.Close cmd ->
             let localSPK = cmd.ScriptPubKey |> Option.defaultValue (state.Commitments.LocalParams.DefaultFinalScriptPubKey)
@@ -747,8 +772,12 @@ module Channel =
             { c with State = ChannelState.Normal data }
 
         // ----- normal operation --------
+        | WeAcceptedOperationMonoHopUnidirectionalPayment(_, newCommitments), ChannelState.Normal normalData ->
+            { c with State = ChannelState.Normal({ normalData with Commitments = newCommitments }) }
         | WeAcceptedOperationAddHTLC(_, newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
+        | WeAcceptedMonoHopUnidirectionalPayment(newCommitments), ChannelState.Normal normalData ->
+            { c with State = ChannelState.Normal({ normalData with Commitments = newCommitments }) }
         | WeAcceptedUpdateAddHTLC(newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
 

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -36,6 +36,7 @@ type ChannelError =
     // --- case they sent unacceptable msg ---
     | InvalidOpenChannel of InvalidOpenChannelError
     | InvalidAcceptChannel of InvalidAcceptChannelError
+    | InvalidMonoHopUnidirectionalPayment of InvalidMonoHopUnidirectionalPaymentError
     | InvalidUpdateAddHTLC of InvalidUpdateAddHTLCError
     | InvalidRevokeAndACK of InvalidRevokeAndACKError
     | InvalidUpdateFee of InvalidUpdateFeeError
@@ -69,6 +70,7 @@ type ChannelError =
         | TheyCannotAffordFee (_, _, _) -> Close
         | InvalidOpenChannel _ -> DistrustPeer
         | InvalidAcceptChannel _ -> DistrustPeer
+        | InvalidMonoHopUnidirectionalPayment _ -> Close
         | InvalidUpdateAddHTLC _ -> Close
         | InvalidRevokeAndACK _ -> Close
         | InvalidUpdateFee _ -> Close
@@ -179,6 +181,18 @@ and InvalidAcceptChannelError = {
     member this.Message =
         String.concat "; " this.Errors
     
+and InvalidMonoHopUnidirectionalPaymentError = {
+    NetworkMsg: MonoHopUnidirectionalPaymentMsg
+    Errors: string list
+}
+    with
+    static member Create msg e = {
+        NetworkMsg = msg
+        Errors = e
+    }
+    member this.Message =
+        String.concat "; " this.Errors
+
 and InvalidUpdateAddHTLCError = {
     Msg: UpdateAddHTLCMsg
     Errors: string list
@@ -507,6 +521,22 @@ module internal AcceptChannelMsgValidation =
 
         (check1 |> Validation.ofResult) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7
         
+module UpdateMonoHopUnidirectionalPaymentWithContext =
+    let internal checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
+        let fees =
+            if state.LocalParams.IsFunder then
+                Transactions.commitTxFee state.RemoteParams.DustLimitSatoshis currentSpec
+            else
+                Money.Zero
+        let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
+        if missing < Money.Zero then
+            sprintf "We don't have sufficient funds to send mono-hop unidirectional payment. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"
+                    (currentSpec.ToRemote.ToMoney())
+                    state.RemoteParams.ChannelReserveSatoshis
+                    fees
+            |> Error
+        else
+            Ok()
 
 module UpdateAddHTLCValidation =
     let internal checkExpiryIsNotPast (current: BlockHeight) (expiry) =
@@ -521,7 +551,23 @@ module UpdateAddHTLCValidation =
     let internal checkAmountIsLargerThanMinimum (htlcMinimum: LNMoney) (amount) =
         check (amount) (<) (htlcMinimum) "htlc value (%A) is too small. must be greater or equal to %A"
 
-    
+module internal MonoHopUnidirectionalPaymentValidationWithContext =
+    let checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
+        let fees =
+            if state.LocalParams.IsFunder then
+                Transactions.commitTxFee state.RemoteParams.DustLimitSatoshis currentSpec
+            else
+                Money.Zero
+        let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
+        if missing < Money.Zero then
+            sprintf "We don't have sufficient funds to send mono-hop unidirectional payment. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"
+                    (currentSpec.ToRemote.ToMoney())
+                    state.RemoteParams.ChannelReserveSatoshis
+                    fees
+            |> Error
+        else
+            Ok()
+
 module internal UpdateAddHTLCValidationWithContext =
     let checkLessThanHTLCValueInFlightLimit (currentSpec: CommitmentSpec) (limit) (add: UpdateAddHTLCMsg) =
         let htlcValueInFlight = currentSpec.HTLCs |> Map.toSeq |> Seq.sumBy (fun (_, v) -> v.Add.Amount)

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -12,6 +12,10 @@ open DotNetLightning.Serialize
 
 open NBitcoin
 
+type OperationMonoHopUnidirectionalPayment = {
+    Amount: LNMoney
+}
+
 type OperationAddHTLC = {
     Amount: LNMoney
     PaymentHash: PaymentHash
@@ -197,6 +201,8 @@ type ChannelCommand =
     | CreateChannelReestablish
 
     // normal
+    | MonoHopUnidirectionalPayment of OperationMonoHopUnidirectionalPayment
+    | ApplyMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg
     | AddHTLC of OperationAddHTLC
     | ApplyUpdateAddHTLC of msg: UpdateAddHTLCMsg * currentHeight: BlockHeight
     | FulfillHTLC of OperationFulfillHTLC

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -264,6 +264,9 @@ type ChannelEvent =
     | BothFundingLocked of nextState: Data.NormalData
 
     // -------- normal operation ------
+    | WeAcceptedOperationMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg * newCommitments: Commitments
+    | WeAcceptedMonoHopUnidirectionalPayment of newCommitments: Commitments
+
     | WeAcceptedOperationAddHTLC of msg: UpdateAddHTLCMsg * newCommitments: Commitments
     | WeAcceptedUpdateAddHTLC of newCommitments: Commitments
 
@@ -355,6 +358,26 @@ type ChannelState =
             (fun v cc -> match cc with
                          | Normal _ -> Normal v
                          | _ -> cc )
+        member this.ChannelId: Option<ChannelId> =
+            match this with
+            | WaitForInitInternal
+            | WaitForOpenChannel _
+            | WaitForAcceptChannel _
+            | WaitForFundingCreated _ -> None
+            | WaitForFundingSigned data -> Some data.ChannelId
+            | WaitForFundingConfirmed data -> Some data.ChannelId
+            | WaitForFundingLocked data -> Some data.ChannelId
+            | Normal data -> Some data.ChannelId
+            | Shutdown data -> Some data.ChannelId
+            | Negotiating data -> Some data.ChannelId
+            | Closing data -> Some data.ChannelId
+            | Closed _
+            | Offline _
+            | Syncing _
+            | ErrFundingLost _
+            | ErrFundingTimeOut _
+            | ErrInformationLeak _ -> None
+
         member this.Phase =
             match this with
             | WaitForInitInternal
@@ -374,3 +397,24 @@ type ChannelState =
             | ErrFundingLost _
             | ErrFundingTimeOut _
             | ErrInformationLeak _ -> Abnormal
+
+        member this.Commitments: Option<Commitments> =
+            match this with
+            | WaitForInitInternal
+            | WaitForOpenChannel _
+            | WaitForAcceptChannel _
+            | WaitForFundingCreated _
+            | WaitForFundingSigned _ -> None
+            | WaitForFundingConfirmed data -> Some (data :> IHasCommitments).Commitments
+            | WaitForFundingLocked data -> Some (data :> IHasCommitments).Commitments
+            | Normal data -> Some (data :> IHasCommitments).Commitments
+            | Shutdown data -> Some (data :> IHasCommitments).Commitments
+            | Negotiating data -> Some (data :> IHasCommitments).Commitments
+            | Closing data -> Some (data :> IHasCommitments).Commitments
+            | Closed _
+            | Offline _
+            | Syncing _
+            | ErrFundingLost _
+            | ErrFundingTimeOut _
+            | ErrInformationLeak _ -> None
+

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -182,6 +182,13 @@ module internal Validation =
         *> AcceptChannelMsgValidation.checkConfigPermits conf.PeerChannelConfigLimits msg
         |> Result.mapError(InvalidAcceptChannelError.Create msg >> InvalidAcceptChannel)
 
+    let checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =
+        Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+        |> Result.mapError(fun errs -> InvalidMonoHopUnidirectionalPayment { NetworkMsg = payment; Errors = errs })
+
+    let checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =
+        Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+        |> Result.mapError(fun errs -> InvalidMonoHopUnidirectionalPayment { NetworkMsg = payment; Errors = errs })
 
     let checkOperationAddHTLC (state: NormalData) (op: OperationAddHTLC) =
         Validation.ofResult(UpdateAddHTLCValidation.checkExpiryIsNotPast op.CurrentHeight op.Expiry)

--- a/src/DotNetLightning.Core/Crypto/ShaChain.fs
+++ b/src/DotNetLightning.Core/Crypto/ShaChain.fs
@@ -1,5 +1,7 @@
 namespace DotNetLightning.Crypto
 
+open System
+
 type Node = {
     Value: byte[]
     Height: int32
@@ -16,8 +18,9 @@ module ShaChain =
     let flip (_input: byte[]) (_index: uint64): byte[] =
         failwith "Not implemented: ShaChain::flip"
 
-    let addHash (_receiver: ShaChain) (_hash: byte[]) (_index: uint64) =
-        failwith "Not implemented: ShaChain::addHash"
+    let addHash (receiver: ShaChain) (_hash: byte[]) (_index: uint64) =
+        Console.WriteLine("WARNING: Not implemented: ShaChain::addHash")
+        receiver
 
     let getHash (_receiver: ShaChain)(_index: uint64) =
         failwith "Not implemented: ShaChain::getHash"

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -8,7 +8,7 @@
     <When Condition="'$(BouncyCastle)'=='true'">
       <PropertyGroup>
         <OtherFlags>$(OtherFlags) -d:BouncyCastle</OtherFlags>
-        <PackageId>DotNetLightning</PackageId>
+        <PackageId>DotNetLightning.Kiss</PackageId>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
@@ -100,6 +100,8 @@ module internal TypeFlag =
     let ReplyChannelRange = 264us
     [<Literal>]
     let GossipTimestampFilter = 265us
+    [<Literal>]
+    let MonoHopUnidirectionalPayment = 42198us
 
 type ILightningMsg = interface end
 type ISetupMsg = inherit ILightningMsg
@@ -191,6 +193,8 @@ module ILightningSerializable =
             deserialize<ReplyChannelRangeMsg>(ls) :> ILightningMsg
         | TypeFlag.GossipTimestampFilter ->
             deserialize<GossipTimestampFilterMsg>(ls) :> ILightningMsg
+        | TypeFlag.MonoHopUnidirectionalPayment ->
+            deserialize<MonoHopUnidirectionalPaymentMsg>(ls) :> ILightningMsg
         | x ->
             raise <| FormatException(sprintf "Unknown message type %d" x)
     let serializeWithFlags (ls: LightningWriterStream) (data: ILightningMsg) =
@@ -279,6 +283,9 @@ module ILightningSerializable =
         | :? GossipTimestampFilterMsg as d ->
             ls.Write(TypeFlag.GossipTimestampFilter, false)
             (d :> ILightningSerializable<GossipTimestampFilterMsg>).Serialize(ls)
+        | :? MonoHopUnidirectionalPaymentMsg as d ->
+            ls.Write(TypeFlag.MonoHopUnidirectionalPayment, false)
+            (d :> ILightningSerializable<MonoHopUnidirectionalPaymentMsg>).Serialize(ls)
         | x -> failwithf "%A is not known lightning message. This should never happen" x
 
 module LightningMsg =
@@ -1560,3 +1567,19 @@ type GossipTimestampFilterMsg = {
             ls.Write(this.FirstTimestamp, false)
             ls.Write(this.TimestampRange, false)
             
+[<CLIMutable>]
+type MonoHopUnidirectionalPaymentMsg = {
+    mutable ChannelId: ChannelId
+    mutable Amount: LNMoney
+}
+with
+    interface IHTLCMsg
+    interface IUpdateMsg
+    interface ILightningSerializable<MonoHopUnidirectionalPaymentMsg> with
+        member this.Deserialize(ls) =
+            this.ChannelId <- ls.ReadUInt256(true) |> ChannelId
+            this.Amount <- ls.ReadUInt64(false) |> LNMoney.MilliSatoshis
+        member this.Serialize(ls) =
+            ls.Write(this.ChannelId.Value.ToBytes())
+            ls.Write(this.Amount.MilliSatoshi, false)
+

--- a/src/DotNetLightning.Core/Utils/LNMoney.fs
+++ b/src/DotNetLightning.Core/Utils/LNMoney.fs
@@ -37,6 +37,8 @@ type LNMoney = | LNMoney of int64 with
         let satoshi = Checked.op_Multiply (amount) (decimal lnUnit)
         LNMoney(Checked.int64 satoshi)
 
+    static member FromMoney (money: Money) =
+        LNMoney.Satoshis money.Satoshi
 
     static member Coins(coins: decimal) =
         LNMoney.FromUnit(coins * (decimal LNMoneyUnit.BTC), LNMoneyUnit.MilliSatoshi)

--- a/src/DotNetLightning.Infrastructure/ActorManagers/ChannelManager.fs
+++ b/src/DotNetLightning.Infrastructure/ActorManagers/ChannelManager.fs
@@ -202,6 +202,8 @@ type ChannelManager(log: ILogger<ChannelManager>,
                     return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.RemoteShutdown m)
                 | :? ClosingSignedMsg as m ->
                     return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.ApplyClosingSigned m)
+                | :? MonoHopUnidirectionalPaymentMsg as m ->
+                    return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.ApplyMonoHopUnidirectionalPayment m)
                 | :? UpdateAddHTLCMsg as m ->
                     return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.ApplyUpdateAddHTLC (m, this.CurrentBlockHeight))
                 | :? UpdateFulfillHTLCMsg as m ->

--- a/src/DotNetLightning.Infrastructure/ActorManagers/PeerManager.fs
+++ b/src/DotNetLightning.Infrastructure/ActorManagers/PeerManager.fs
@@ -190,15 +190,20 @@ type PeerManager(eventAggregator: IEventAggregator,
                 | WeSentFundingLocked fundingLockedMsg ->
                     return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg fundingLockedMsg)
                 | BothFundingLocked _ -> ()
+                | WeAcceptedMonoHopUnidirectionalPayment _
                 | WeAcceptedUpdateAddHTLC _
                 | WeAcceptedFulfillHTLC _
                 | WeAcceptedFailHTLC _ -> ()
                 | WeAcceptedFailMalformedHTLC _ -> ()
                 | WeAcceptedUpdateFee _ -> ()
-                | WeAcceptedCommitmentSigned  _ -> failwith "TODO: route"
-                | WeAcceptedRevokeAndACK _ -> failwith "TODO: route"
+                | WeAcceptedCommitmentSigned (msg, _) ->
+                    return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg msg)
+                | WeAcceptedRevokeAndACK _ ->
+                    Console.WriteLine "WARNING: revoke_and_ack handling is not implemented"
                 // The one which includes `Operation` in its names is the one started by us.
                 // So there are no need to think about routing, just send it to specified peer.
+                | ChannelEvent.WeAcceptedOperationMonoHopUnidirectionalPayment (msg, _) ->
+                    return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg msg)
                 | ChannelEvent.WeAcceptedOperationAddHTLC (msg, _) ->
                     return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg msg)
                 | ChannelEvent.WeAcceptedOperationFulfillHTLC (msg, _) ->

--- a/tests/DotNetLightning.Infrastructure.Tests/Constants.fs
+++ b/tests/DotNetLightning.Infrastructure.Tests/Constants.fs
@@ -16,6 +16,7 @@ type TestEntity =
         NodeParams: ChainConfig
     }
 
+let monoHopPaymentAmount = 1000L |> LNMoney.MilliSatoshis
 let fundingSatoshis = 1000000L |> Money.Satoshis
 let pushMsat = 200000000L |> LNMoney.MilliSatoshis
 let feeratePerKw = 10000u |> FeeRatePerKw 


### PR DESCRIPTION
This makes geewallet's `OutgoingUnfundedChannel` report the correct/true channel id, rather than the temporary channel id used during the initial stage of channel opening.