### PR TITLE
Rename BouncyCastle build param to Portability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       # we want to run only once.
       if: startsWith(matrix.os, 'ubuntu-18')
       run: |
-        dotnet build tests/DotNetLightning.Core.Tests -p:BouncyCastle=True
+        dotnet build tests/DotNetLightning.Core.Tests -p:Portability=True
         dotnet run --no-build --project tests/DotNetLightning.Core.Tests
 
     - name: Clean to prepare for NSec build
@@ -41,5 +41,5 @@ jobs:
         DEBIAN_FRONTEND=noninteractive sudo apt install -y msbuild fsharp nuget
 
         nuget restore DotNetLightning.sln
-        msbuild src/DotNetLightning.Core/DotNetLightning.Core.fsproj -p:BouncyCastle=True -p:TargetFramework=netstandard2.0
+        msbuild src/DotNetLightning.Core/DotNetLightning.Core.fsproj -p:Portability=True -p:TargetFramework=netstandard2.0
 

--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -32,6 +32,6 @@ jobs:
     - name: Upload nuget packages (BouncyCastle)
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | head -c 7` -p:BouncyCastle=True
+        dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | head -c 7` -p:Portability=True
         dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.Kiss.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -74,7 +74,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu-18')
         run: |
           echo "releasing BouncyCastle version to nuget..."
-          dotnet pack -p:Configuration=Release src/DotNetLightning.Core -p:BouncyCastle=True
+          dotnet pack -p:Configuration=Release src/DotNetLightning.Core -p:Portability=True
           if [ ${{ secrets.NUGET_API_KEY }} ]; then
             dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.${{ steps.get_version.outputs.VERSION }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
           fi

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -101,7 +101,7 @@
   <Choose>
     <When Condition="'$(Portability)'=='true'">
       <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.0.1.1" />
+        <PackageReference Update="FSharp.Core" Version="4.0.0.1" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -5,15 +5,16 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   
-  <!-->Since NBitcoin.Secp256k1 does not support netstandard 2.0, we will fallback to BouncyCastle build<-->
+  <!-->Since NBitcoin.Secp256k1 does not support netstandard 2.0, we will fallback to Portability build<-->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <BouncyCastle>True</BouncyCastle>
+    <Portability>True</Portability>
   </PropertyGroup>
 
   <Choose>
-    <When Condition="'$(BouncyCastle)'=='true'">
+    <When Condition="'$(Portability)'=='true'">
       <PropertyGroup>
         <OtherFlags>$(OtherFlags) -d:BouncyCastle</OtherFlags>
+        <OtherFlags>$(OtherFlags) -d:OldFsharpCore</OtherFlags>
         <PackageId>DotNetLightning.Kiss</PackageId>
       </PropertyGroup>
     </When>
@@ -24,7 +25,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <ProjectReference Condition="'$(BouncyCastle)'!='true'" Include="..\NSec\Experimental\NSec.Experimental.csproj" PrivateAssets="all" />
+    <ProjectReference Condition="'$(Portability)'!='true'" Include="..\NSec\Experimental\NSec.Experimental.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\ResultUtils\ResultUtils.fsproj" PrivateAssets="all" />
     <ProjectReference Include="..\InternalBech32Encoder\InternalBech32Encoder.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\Macaroons\Macaroons.csproj" PrivateAssets="all" />
@@ -99,8 +100,8 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="NBitcoin" Version="5.0.53" />
-    <PackageReference Condition="'$(BouncyCastle)' != 'true'" Include="NBitcoin.Secp256k1" Version="1.0.3" />
-    <PackageReference Condition="'$(BouncyCastle)'=='true'" Include="Portable.BouncyCastle" Version="1.8.5.2" />
+    <PackageReference Condition="'$(Portability)' != 'true'" Include="NBitcoin.Secp256k1" Version="1.0.3" />
+    <PackageReference Condition="'$(Portability)'=='true'" Include="Portable.BouncyCastle" Version="1.8.5.2" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -97,8 +97,20 @@
     <Compile Include="Routing\RouterTypes.fs" />
     <Compile Include="Routing\Router.fs" />
   </ItemGroup>
+  
+  <Choose>
+    <When Condition="'$(Portability)'=='true'">
+      <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.0.1.1" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="NBitcoin" Version="5.0.53" />
     <PackageReference Condition="'$(Portability)' != 'true'" Include="NBitcoin.Secp256k1" Version="1.0.3" />
     <PackageReference Condition="'$(Portability)'=='true'" Include="Portable.BouncyCastle" Version="1.8.5.2" />

--- a/src/ResultUtils/ResultUtils.fsproj
+++ b/src/ResultUtils/ResultUtils.fsproj
@@ -15,7 +15,16 @@
     <Compile Include="List.fs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.0" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(Portability)'=='true'">
+      <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.0.1.1" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/src/ResultUtils/ResultUtils.fsproj
+++ b/src/ResultUtils/ResultUtils.fsproj
@@ -18,7 +18,7 @@
   <Choose>
     <When Condition="'$(Portability)'=='true'">
       <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.0.1.1" />
+        <PackageReference Update="FSharp.Core" Version="4.0.0.1" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
+++ b/tests/DotNetLightning.Core.Tests/DotNetLightning.Core.Tests.fsproj
@@ -35,10 +35,21 @@
     <Compile Include="PaymentPropertyTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(Portability)'=='true'">
+      <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.0.1.1" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <PackageReference Include="Expecto" Version="8.*" />
     <PackageReference Include="Expecto.FsCheck" Version="8.10.1" />
-    <PackageReference Update="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
   </ItemGroup>


### PR DESCRIPTION
Renames BouncyCastle build param to Portability which also passes `-d:OldFsharpCore` during build if Portability is specified