### PR TITLE
Closing tx fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       # we want to run only once.
       if: startsWith(matrix.os, 'ubuntu-18')
       run: |
-        dotnet build tests/DotNetLightning.Core.Tests -p:BouncyCastle=True
+        dotnet build tests/DotNetLightning.Core.Tests -p:Portability=True
         dotnet run --no-build --project tests/DotNetLightning.Core.Tests
 
     - name: Clean to prepare for NSec build
@@ -41,5 +41,5 @@ jobs:
         DEBIAN_FRONTEND=noninteractive sudo apt install -y msbuild fsharp nuget
 
         nuget restore DotNetLightning.sln
-        msbuild src/DotNetLightning.Core/DotNetLightning.Core.fsproj -p:BouncyCastle=True -p:TargetFramework=netstandard2.0
+        msbuild src/DotNetLightning.Core/DotNetLightning.Core.fsproj -p:Portability=True -p:TargetFramework=netstandard2.0
 

--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -32,6 +32,6 @@ jobs:
     - name: Upload nuget packages (BouncyCastle)
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | head -c 7` -p:BouncyCastle=True
+        dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | head -c 7` -p:Portability=True
         dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.Kiss.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 

--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -33,9 +33,5 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | head -c 7` -p:BouncyCastle=True
-        dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+        dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.Kiss.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
 
-    - name: Upload nuget packages (native)
-      run: |
-        bash -c "dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date$(date +%Y%m%d-%H%M)-git-$(echo $GITHUB_SHA | head -c 7)-${{ matrix.RID }}"
-        bash -c "dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.Core.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -74,7 +74,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu-18')
         run: |
           echo "releasing BouncyCastle version to nuget..."
-          dotnet pack -p:Configuration=Release src/DotNetLightning.Core -p:BouncyCastle=True
+          dotnet pack -p:Configuration=Release src/DotNetLightning.Core -p:Portability=True
           if [ ${{ secrets.NUGET_API_KEY }} ]; then
             dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.${{ steps.get_version.outputs.VERSION }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
           fi

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -1,7 +1,5 @@
 namespace DotNetLightning.Channel
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Utils.NBitcoinExtensions
 open DotNetLightning.Utils.Aether
@@ -12,6 +10,8 @@ open DotNetLightning.Serialize.Msgs
 open NBitcoin
 open System
 
+open ResultUtils
+open ResultUtils.Portability
 
 type ProvideFundingTx = IDestination * Money * FeeRatePerKw -> Result<FinalizedTx * TxOutIndex, string> 
 type Channel = {

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -409,6 +409,32 @@ module Channel =
                 [] |> Ok
 
         // ---------- normal operation ---------
+        | ChannelState.Normal state, MonoHopUnidirectionalPayment op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
+            sprintf "Could not send mono-hop unidirectional payment %A since shutdown is already in progress." op
+            |> apiMisuse
+        | ChannelState.Normal state, MonoHopUnidirectionalPayment op ->
+            result {
+                let payment: MonoHopUnidirectionalPaymentMsg = {
+                    ChannelId = state.Commitments.ChannelId
+                    Amount = op.Amount
+                }
+                let commitments1 = state.Commitments.AddLocalProposal(payment)
+
+                let remoteCommit1 =
+                    match commitments1.RemoteNextCommitInfo with
+                    | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
+                    | RemoteNextCommitInfo.Revoked _info -> commitments1.RemoteCommit
+                let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
+                do! Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 payment
+                return [ WeAcceptedOperationMonoHopUnidirectionalPayment(payment, commitments1) ]
+            }
+        | ChannelState.Normal state, ApplyMonoHopUnidirectionalPayment msg ->
+            result {
+                let commitments1 = state.Commitments.AddRemoteProposal(msg)
+                let! reduced = commitments1.LocalCommit.Spec.Reduce (commitments1.LocalChanges.ACKed, commitments1.RemoteChanges.Proposed) |> expectTransactionError
+                do! Validation.checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 msg
+                return [ WeAcceptedMonoHopUnidirectionalPayment commitments1 ]
+            }
         | ChannelState.Normal state, AddHTLC op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
             sprintf "Could not add new HTLC %A since shutdown is already in progress." op
             |> apiMisuse
@@ -514,8 +540,8 @@ module Channel =
                                                  RemoteCommit = theirNextCommit
                                                  RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
                                                  RemotePerCommitmentSecrets = remotePerCommitmentSecrets }
-                    let result = Ok [ WeAcceptedRevokeAndACK(commitments1) ]
-                    failwith "needs update"
+                    Console.WriteLine("WARNING: revocation is not implemented yet")
+                    Ok [ WeAcceptedRevokeAndACK(commitments1) ]
 
         | ChannelState.Normal state, ChannelCommand.Close cmd ->
             let localSPK = cmd.ScriptPubKey |> Option.defaultValue (state.Commitments.LocalParams.DefaultFinalScriptPubKey)
@@ -762,8 +788,12 @@ module Channel =
             { c with State = ChannelState.Normal data }
 
         // ----- normal operation --------
+        | WeAcceptedOperationMonoHopUnidirectionalPayment(_, newCommitments), ChannelState.Normal normalData ->
+            { c with State = ChannelState.Normal({ normalData with Commitments = newCommitments }) }
         | WeAcceptedOperationAddHTLC(_, newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
+        | WeAcceptedMonoHopUnidirectionalPayment(newCommitments), ChannelState.Normal normalData ->
+            { c with State = ChannelState.Normal({ normalData with Commitments = newCommitments }) }
         | WeAcceptedUpdateAddHTLC(newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -714,6 +714,9 @@ module Channel =
                                                     MaybeBestUnpublishedTx = Some(finalizedTx) }
                         return! Closing.handleMutualClose (finalizedTx, negoData)
                     else
+                        let! closingTx, closingSignedMsg =
+                            Closing.makeClosingTx (cs.KeysRepository, cm, state.LocalShutdown.ScriptPubKey, state.RemoteShutdown.ScriptPubKey, nextClosingFee, cm.LocalParams.ChannelPubKeys.FundingPubKey, cs.Network)
+                            |> expectTransactionError
                         let closingTxProposed1 =
                             let newProposed = [ { ClosingTxProposed.UnsignedTx = closingTx
                                                   LocalClosingSigned = closingSignedMsg } ]

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -1,6 +1,5 @@
 namespace DotNetLightning.Channel
 
-open ResultUtils
 open DotNetLightning.Utils
 open NBitcoinExtensions
 open DotNetLightning.Utils.OnionError
@@ -10,6 +9,9 @@ open DotNetLightning.Serialize.Msgs
 open DotNetLightning.Transactions
 
 open NBitcoin
+
+open ResultUtils
+open ResultUtils.Portability
 
 type ChannelError =
     | CryptoError of CryptoError

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -12,6 +12,10 @@ open DotNetLightning.Serialize
 
 open NBitcoin
 
+type OperationMonoHopUnidirectionalPayment = {
+    Amount: LNMoney
+}
+
 type OperationAddHTLC = {
     Amount: LNMoney
     PaymentHash: PaymentHash
@@ -197,6 +201,8 @@ type ChannelCommand =
     | CreateChannelReestablish
 
     // normal
+    | MonoHopUnidirectionalPayment of OperationMonoHopUnidirectionalPayment
+    | ApplyMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg
     | AddHTLC of OperationAddHTLC
     | ApplyUpdateAddHTLC of msg: UpdateAddHTLCMsg * currentHeight: BlockHeight
     | FulfillHTLC of OperationFulfillHTLC

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -267,6 +267,9 @@ type ChannelEvent =
     | BothFundingLocked of nextState: Data.NormalData
 
     // -------- normal operation ------
+    | WeAcceptedOperationMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg * newCommitments: Commitments
+    | WeAcceptedMonoHopUnidirectionalPayment of newCommitments: Commitments
+
     | WeAcceptedOperationAddHTLC of msg: UpdateAddHTLCMsg * newCommitments: Commitments
     | WeAcceptedUpdateAddHTLC of newCommitments: Commitments
 
@@ -358,6 +361,26 @@ type ChannelState =
             (fun v cc -> match cc with
                          | Normal _ -> Normal v
                          | _ -> cc )
+        member this.ChannelId: Option<ChannelId> =
+            match this with
+            | WaitForInitInternal
+            | WaitForOpenChannel _
+            | WaitForAcceptChannel _
+            | WaitForFundingCreated _ -> None
+            | WaitForFundingSigned data -> Some data.ChannelId
+            | WaitForFundingConfirmed data -> Some data.ChannelId
+            | WaitForFundingLocked data -> Some data.ChannelId
+            | Normal data -> Some data.ChannelId
+            | Shutdown data -> Some data.ChannelId
+            | Negotiating data -> Some data.ChannelId
+            | Closing data -> Some data.ChannelId
+            | Closed _
+            | Offline _
+            | Syncing _
+            | ErrFundingLost _
+            | ErrFundingTimeOut _
+            | ErrInformationLeak _ -> None
+
         member this.Phase =
             match this with
             | WaitForInitInternal
@@ -377,3 +400,24 @@ type ChannelState =
             | ErrFundingLost _
             | ErrFundingTimeOut _
             | ErrInformationLeak _ -> Abnormal
+
+        member this.Commitments: Option<Commitments> =
+            match this with
+            | WaitForInitInternal
+            | WaitForOpenChannel _
+            | WaitForAcceptChannel _
+            | WaitForFundingCreated _
+            | WaitForFundingSigned _ -> None
+            | WaitForFundingConfirmed data -> Some (data :> IHasCommitments).Commitments
+            | WaitForFundingLocked data -> Some (data :> IHasCommitments).Commitments
+            | Normal data -> Some (data :> IHasCommitments).Commitments
+            | Shutdown data -> Some (data :> IHasCommitments).Commitments
+            | Negotiating data -> Some (data :> IHasCommitments).Commitments
+            | Closing data -> Some (data :> IHasCommitments).Commitments
+            | Closed _
+            | Offline _
+            | Syncing _
+            | ErrFundingLost _
+            | ErrFundingTimeOut _
+            | ErrInformationLeak _ -> None
+

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -1,6 +1,5 @@
 namespace DotNetLightning.Channel
 
-open ResultUtils
 open NBitcoin
 
 open DotNetLightning.Chain
@@ -9,6 +8,9 @@ open DotNetLightning.Utils
 open DotNetLightning.Utils.NBitcoinExtensions
 open DotNetLightning.Serialize.Msgs
 open DotNetLightning.Transactions
+
+open ResultUtils
+open ResultUtils.Portability
 
 exception ChannelException of ChannelError
 module internal ChannelHelpers =

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -182,6 +182,13 @@ module internal Validation =
         *> AcceptChannelMsgValidation.checkConfigPermits conf.PeerChannelConfigLimits msg
         |> Result.mapError(InvalidAcceptChannelError.Create msg >> InvalidAcceptChannel)
 
+    let checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =
+        Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+        |> Result.mapError(fun errs -> InvalidMonoHopUnidirectionalPayment { NetworkMsg = payment; Errors = errs })
+
+    let checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =
+        Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+        |> Result.mapError(fun errs -> InvalidMonoHopUnidirectionalPayment { NetworkMsg = payment; Errors = errs })
 
     let checkOperationAddHTLC (state: NormalData) (op: OperationAddHTLC) =
         Validation.ofResult(UpdateAddHTLCValidation.checkExpiryIsNotPast op.CurrentHeight op.Expiry)

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -8,6 +8,9 @@ open DotNetLightning.Crypto
 open DotNetLightning.Transactions
 open DotNetLightning.Serialize.Msgs
 
+open ResultUtils
+open ResultUtils.Portability
+
 type LocalChanges = {
     Proposed: IUpdateMsg list
     Signed: IUpdateMsg list

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -2,13 +2,14 @@ namespace DotNetLightning.Channel
 
 open NBitcoin
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Transactions
 open DotNetLightning.Crypto
 open DotNetLightning.Chain
 open DotNetLightning.Serialize.Msgs
+
+open ResultUtils
+open ResultUtils.Portability
 
 [<RequireQualifiedAccess; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module internal Commitments =

--- a/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
+++ b/src/DotNetLightning.Core/Crypto/CryptoUtils.fs
@@ -13,6 +13,8 @@ open NBitcoin.Secp256k1
 
 #endif
 
+open ResultUtils.Portability
+
 type CryptoError =
     | BadMac
     | InvalidErrorPacketLength of expected: int * actual: int

--- a/src/DotNetLightning.Core/Crypto/RevocationSet.fs
+++ b/src/DotNetLightning.Core/Crypto/RevocationSet.fs
@@ -4,6 +4,8 @@ open NBitcoin
 open NBitcoin.Crypto
 open DotNetLightning.Utils
 
+open ResultUtils.Portability
+
 type InsertRevocationKeyError =
     | UnexpectedCommitmentNumber of got: CommitmentNumber * expected: CommitmentNumber
     | KeyMismatch of previousCommitmentNumber: CommitmentNumber * newCommitmentNumber: CommitmentNumber

--- a/src/DotNetLightning.Core/Crypto/ShaChain.fs
+++ b/src/DotNetLightning.Core/Crypto/ShaChain.fs
@@ -1,5 +1,7 @@
 namespace DotNetLightning.Crypto
 
+open System
+
 type Node = {
     Value: byte[]
     Height: int32
@@ -16,8 +18,9 @@ module ShaChain =
     let flip (_input: byte[]) (_index: uint64): byte[] =
         failwith "Not implemented: ShaChain::flip"
 
-    let addHash (_receiver: ShaChain) (_hash: byte[]) (_index: uint64) =
-        failwith "Not implemented: ShaChain::addHash"
+    let addHash (receiver: ShaChain) (_hash: byte[]) (_index: uint64) =
+        Console.WriteLine("WARNING: Not implemented: ShaChain::addHash")
+        receiver
 
     let getHash (_receiver: ShaChain)(_index: uint64) =
         failwith "Not implemented: ShaChain::getHash"

--- a/src/DotNetLightning.Core/Crypto/Sphinx.fs
+++ b/src/DotNetLightning.Core/Crypto/Sphinx.fs
@@ -2,11 +2,12 @@ namespace DotNetLightning.Crypto
 open System
 open NBitcoin
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Serialize
 open DotNetLightning.Serialize.Msgs
+
+open ResultUtils
+open ResultUtils.Portability
 
 module Sphinx =
     open NBitcoin.Crypto

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -7,13 +7,13 @@
   
   <!-->Since NBitcoin.Secp256k1 does not support netstandard 2.0, we will fallback to BouncyCastle build<-->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <BouncyCastle>True</BouncyCastle>
+    <Portability>True</Portability>
   </PropertyGroup>
 
   <Choose>
-    <When Condition="'$(BouncyCastle)'=='true'">
+    <When Condition="'$(Portability)'=='true'">
       <PropertyGroup>
-        <OtherFlags>$(OtherFlags) -d:BouncyCastle</OtherFlags>
+        <OtherFlags>$(OtherFlags) -d:NoDUsAsStructs -d:BouncyCastle</OtherFlags>
         <PackageId>DotNetLightning.Kiss</PackageId>
       </PropertyGroup>
     </When>
@@ -24,7 +24,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <ProjectReference Condition="'$(BouncyCastle)'!='true'" Include="..\NSec\Experimental\NSec.Experimental.csproj" PrivateAssets="all" />
+    <ProjectReference Condition="'$(Portability)'!='true'" Include="..\NSec\Experimental\NSec.Experimental.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\ResultUtils\ResultUtils.fsproj" PrivateAssets="all" />
     <ProjectReference Include="..\InternalBech32Encoder\InternalBech32Encoder.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\Macaroons\Macaroons.csproj" PrivateAssets="all" />
@@ -99,8 +99,8 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="NBitcoin" Version="5.0.53" />
-    <PackageReference Condition="'$(BouncyCastle)' != 'true'" Include="NBitcoin.Secp256k1" Version="1.0.3" />
-    <PackageReference Condition="'$(BouncyCastle)'=='true'" Include="Portable.BouncyCastle" Version="1.8.5.2" />
+    <PackageReference Condition="'$(Portability)' != 'true'" Include="NBitcoin.Secp256k1" Version="1.0.3" />
+    <PackageReference Condition="'$(Portability)' == 'true'" Include="Portable.BouncyCastle" Version="1.8.5.2" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -14,7 +14,7 @@
     <When Condition="'$(BouncyCastle)'=='true'">
       <PropertyGroup>
         <OtherFlags>$(OtherFlags) -d:BouncyCastle</OtherFlags>
-        <PackageId>DotNetLightning</PackageId>
+        <PackageId>DotNetLightning.Kiss</PackageId>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/src/DotNetLightning.Core/Payment/Amount.fs
+++ b/src/DotNetLightning.Core/Payment/Amount.fs
@@ -3,6 +3,9 @@ namespace DotNetLightning.Payment
 open System
 open DotNetLightning.Utils
 
+open ResultUtils
+open ResultUtils.Portability
+
 [<RequireQualifiedAccess>]
 module Amount =
     let unit (amount: LNMoney): char =

--- a/src/DotNetLightning.Core/Payment/LSAT/CaveatsExtensions.fs
+++ b/src/DotNetLightning.Core/Payment/LSAT/CaveatsExtensions.fs
@@ -3,6 +3,7 @@ namespace DotNetLightning.Payment.LSAT
 open Macaroons
 open System.Runtime.CompilerServices
 
+open ResultUtils.Portability
 
 [<Extension;AbstractClass;Sealed>]
 type CaveatsExtensions() =

--- a/src/DotNetLightning.Core/Payment/LSAT/MacaroonIdentifier.fs
+++ b/src/DotNetLightning.Core/Payment/LSAT/MacaroonIdentifier.fs
@@ -7,6 +7,8 @@ open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Utils
 open NBitcoin.Crypto
 
+open ResultUtils.Portability
+
 module private Helpers =
     let hex = DataEncoders.HexEncoder()   
     

--- a/src/DotNetLightning.Core/Payment/LSAT/Satisfier.fs
+++ b/src/DotNetLightning.Core/Payment/LSAT/Satisfier.fs
@@ -1,11 +1,13 @@
 namespace DotNetLightning.Payment.LSAT
 
-open ResultUtils
 open DotNetLightning.Utils
 open Macaroons
 open System.Collections.Generic
 open System.Runtime.CompilerServices
 open NBitcoin
+
+open ResultUtils
+open ResultUtils.Portability
 
 /// When we verify a macaroon for its caveats, usually it check each caveats independently.
 /// In case of LSAT, this does not work since the validity of a caveat depends on a previous caveat

--- a/src/DotNetLightning.Core/Payment/LSAT/Service.fs
+++ b/src/DotNetLightning.Core/Payment/LSAT/Service.fs
@@ -4,10 +4,12 @@ open System
 open System.Collections.Generic
 
 open Macaroons
-open ResultUtils
 
 open System.Text
 open DotNetLightning.Utils
+
+open ResultUtils
+open ResultUtils.Portability
 
 /// See: https://github.com/lightninglabs/LSAT/blob/master/macaroons.md#target-services
 type Service = {

--- a/src/DotNetLightning.Core/Payment/PaymentRequest.fs
+++ b/src/DotNetLightning.Core/Payment/PaymentRequest.fs
@@ -6,8 +6,6 @@ open System.Text
 open System.Collections
 open System.Diagnostics
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Serialize
@@ -15,6 +13,9 @@ open DotNetLightning.Serialize
 open NBitcoin
 open NBitcoin.Crypto
 open NBitcoin.DataEncoders
+
+open ResultUtils
+open ResultUtils.Portability
 
 
 module private Helpers =

--- a/src/DotNetLightning.Core/Peer/Peer.fs
+++ b/src/DotNetLightning.Core/Peer/Peer.fs
@@ -2,13 +2,14 @@ namespace DotNetLightning.Peer
 
 open NBitcoin
 
-open ResultUtils
-
 open DotNetLightning.Serialize
 open System.Collections
 open DotNetLightning.Utils
 open DotNetLightning.Serialize.Msgs
 open DotNetLightning.Utils.Aether
+
+open ResultUtils
+open ResultUtils.Portability
 
 type PeerHandleError = {
     /// Used to indicate that we probably can't make any future connections to this peer, implying

--- a/src/DotNetLightning.Core/Peer/PeerChannelEncryptor.fs
+++ b/src/DotNetLightning.Core/Peer/PeerChannelEncryptor.fs
@@ -5,13 +5,13 @@ open System
 open NBitcoin
 open NBitcoin.Crypto
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Utils.Aether
 open DotNetLightning.Utils.Aether.Operators
 open DotNetLightning.Crypto
 
+open ResultUtils
+open ResultUtils.Portability
 
 [<AutoOpen>]
 module PeerChannelEncryptor =

--- a/src/DotNetLightning.Core/Routing/Graph.fs
+++ b/src/DotNetLightning.Core/Routing/Graph.fs
@@ -6,6 +6,9 @@ open DotNetLightning.Utils
 open DotNetLightning.Serialize.Msgs
 open NBitcoin
 
+open ResultUtils
+open ResultUtils.Portability
+
 // Graph algorithms are based on eclair
 
 module Graph =

--- a/src/DotNetLightning.Core/Routing/Router.fs
+++ b/src/DotNetLightning.Core/Routing/Router.fs
@@ -1,6 +1,5 @@
 namespace DotNetLightning.Routing
 
-open ResultUtils
 open DotNetLightning.Utils.Primitives
 open DotNetLightning.Utils
 
@@ -10,6 +9,9 @@ open System
 open DotNetLightning.Payment
 open DotNetLightning.Routing.Graph
 open NBitcoin
+
+open ResultUtils
+open ResultUtils.Portability
 
 module Routing =
     

--- a/src/DotNetLightning.Core/Routing/RouterPrimitives.fs
+++ b/src/DotNetLightning.Core/Routing/RouterPrimitives.fs
@@ -3,10 +3,12 @@ namespace DotNetLightning.Routing
 open DotNetLightning.Payment
 open System
 open NBitcoin
-open ResultUtils
 open DotNetLightning.Utils
 open DotNetLightning.Serialize.Msgs
 open Graph
+
+open ResultUtils
+open ResultUtils.Portability
 
 [<AutoOpen>]
 module RouterPrimitives =

--- a/src/DotNetLightning.Core/Routing/RouterState.fs
+++ b/src/DotNetLightning.Core/Routing/RouterState.fs
@@ -1,12 +1,13 @@
 namespace DotNetLightning.Routing
 
-open ResultUtils
 open System.Collections.Generic
 open DotNetLightning.Payment
 open DotNetLightning.Serialize.Msgs
 open DotNetLightning.Utils
 open Graph
 
+open ResultUtils
+open ResultUtils.Portability
         
 type RouteParams = {
     Randomize: bool

--- a/src/DotNetLightning.Core/Routing/RouterTypes.fs
+++ b/src/DotNetLightning.Core/Routing/RouterTypes.fs
@@ -8,8 +8,8 @@ open System.Collections.Generic
 open DotNetLightning.Utils
 open DotNetLightning.Serialize.Msgs
 open NBitcoin
-open ResultUtils
 
+open ResultUtils.Portability
 
 type NetworkEvent =
     | NodeDiscovered of msg: NodeAnnouncementMsg

--- a/src/DotNetLightning.Core/Serialize/BitWriter.fs
+++ b/src/DotNetLightning.Core/Serialize/BitWriter.fs
@@ -5,6 +5,8 @@ open System.Collections
 open System.Text
 open System.Text
 
+open ResultUtils.Portability
+
 type BitReader(ba: BitArray, bitCount: int) =
     
     member val Count = bitCount with get

--- a/src/DotNetLightning.Core/Serialize/EncodedTypes.fs
+++ b/src/DotNetLightning.Core/Serialize/EncodedTypes.fs
@@ -2,6 +2,8 @@ namespace DotNetLightning.Serialize
 
 open System.IO
 
+open ResultUtils.Portability
+
 type QueryFlags = private QueryFlags of uint8
     with
     static member Create (data) = QueryFlags(data)

--- a/src/DotNetLightning.Core/Serialize/Encoding.fs
+++ b/src/DotNetLightning.Core/Serialize/Encoding.fs
@@ -5,11 +5,12 @@ namespace DotNetLightning.Serialize
 
 open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Utils.Primitives
-open ResultUtils
 open System
 open System.IO
 open System.IO.Compression
 
+open ResultUtils
+open ResultUtils.Portability
 
 module Decoder =
     let private tryDecode (encodingType: EncodingType) (bytes : byte[]) =

--- a/src/DotNetLightning.Core/Serialize/Features.fs
+++ b/src/DotNetLightning.Core/Serialize/Features.fs
@@ -1,12 +1,12 @@
 namespace DotNetLightning.Serialize
 
 open System.Collections
-
-open ResultUtils
-
 open System
 open System.Text
 open DotNetLightning.Core.Utils.Extensions
+
+open ResultUtils
+open ResultUtils.Portability
 
 type FeaturesSupport =
     | Mandatory

--- a/src/DotNetLightning.Core/Serialize/GenericTLV.fs
+++ b/src/DotNetLightning.Core/Serialize/GenericTLV.fs
@@ -1,8 +1,9 @@
 namespace DotNetLightning.Serialize
 
 open System
-open ResultUtils
 open DotNetLightning.Core.Utils.Extensions
+open ResultUtils
+open ResultUtils.Portability
 
 type GenericTLV = {
     Type: uint64

--- a/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialize/Msgs/Msgs.fs
@@ -14,6 +14,9 @@ open DotNetLightning.Core.Utils.Extensions
 
 open DotNetLightning.Serialize
 
+open ResultUtils
+open ResultUtils.Portability
+
 // #region serialization
 type P2PDecodeError =
     | UnknownVersion

--- a/src/DotNetLightning.Core/Serialize/OnionPayload.fs
+++ b/src/DotNetLightning.Core/Serialize/OnionPayload.fs
@@ -1,10 +1,12 @@
 namespace DotNetLightning.Serialize
 
 open System
-open ResultUtils
 open NBitcoin
 open DotNetLightning.Utils
 open DotNetLightning.Core.Utils.Extensions
+
+open ResultUtils
+open ResultUtils.Portability
 
 type OnionRealm0HopData = {
     ShortChannelId: ShortChannelId

--- a/src/DotNetLightning.Core/Transactions/CommitmentSpec.fs
+++ b/src/DotNetLightning.Core/Transactions/CommitmentSpec.fs
@@ -1,11 +1,12 @@
 namespace DotNetLightning.Transactions
 
-open ResultUtils
-
 open DotNetLightning.Serialize.Msgs
 open DotNetLightning.Utils.Primitives
 open DotNetLightning.Utils
 open DotNetLightning.Utils.Aether
+
+open ResultUtils
+open ResultUtils.Portability
 
 type internal Direction =
     | In

--- a/src/DotNetLightning.Core/Transactions/Scripts.fs
+++ b/src/DotNetLightning.Core/Transactions/Scripts.fs
@@ -5,6 +5,7 @@ open NBitcoin
 open NBitcoin.Crypto
 open DotNetLightning.Utils
 
+open ResultUtils.Portability
 
 module Scripts =
 

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -5,13 +5,14 @@ open System.Linq
 
 open NBitcoin
 
-open ResultUtils
-
 open DotNetLightning.Utils.Primitives
 open DotNetLightning.Utils
 open DotNetLightning.Core.Utils.Extensions
 open DotNetLightning.Utils.Aether
 open DotNetLightning.Serialize.Msgs
+
+open ResultUtils
+open ResultUtils.Portability
 
 /// We define all possible txs here.
 /// internal representation is psbt. But this is just for convenience since

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -1,6 +1,7 @@
 namespace DotNetLightning.Transactions
 
 open System
+open System.IO
 open System.Linq
 
 open NBitcoin
@@ -736,19 +737,26 @@ module Transactions =
                 else
                     spec.ToLocal.ToMoney(), spec.ToRemote.ToMoney() - closingFee
 
-            let maybeToLocalOutput = if (toLocalAmount >= dustLimit) then Some(toLocalAmount, localDestination) else None
-            let maybeToRemoteOutput = if (toRemoteAmount >= dustLimit) then Some(toRemoteAmount, remoteDestination) else None
-            let outputs = seq [maybeToLocalOutput; maybeToRemoteOutput] |> Seq.choose id
+            let outputs =
+                seq {
+                    if toLocalAmount >= dustLimit then
+                        yield TxOut(toLocalAmount, localDestination)
+                    if toRemoteAmount >= dustLimit then
+                        yield TxOut(toRemoteAmount, remoteDestination)
+                }
+                |> Seq.sortBy (fun txOut ->
+                    use memoryStream = new MemoryStream()
+                    let stream = NBitcoin.BitcoinStream(memoryStream, true)
+                    txOut.ReadWrite stream
+                    memoryStream.ToArray()
+                )
             let psbt = 
-                let txb = n.CreateTransactionBuilder()
-                           .AddCoins(commitTxInput)
-                           .SendFees(closingFee)
-                           .SetLockTime(!> 0u)
-                for (money, dest) in outputs do
-                    txb.Send(dest, money) |> ignore
-                let tx =  txb.BuildTransaction(false)
+                let tx = Transaction.Create n
                 tx.Version <- 2u
-                tx.Inputs.[0].Sequence <- !> 0xffffffffu
+                tx.LockTime <- !> 0u
+                tx.Inputs.Add <| TxIn(Sequence = !> UInt32.MaxValue, PrevOut = commitTxInput.Outpoint)
+                for txOut in outputs do
+                    tx.Outputs.Add txOut
                 PSBT.FromTransaction(tx, n)
                     .AddCoins(commitTxInput)
             psbt |> ClosingTx |> Ok

--- a/src/DotNetLightning.Core/Utils/Aether.fs
+++ b/src/DotNetLightning.Core/Utils/Aether.fs
@@ -1,5 +1,7 @@
 namespace DotNetLightning.Utils
 
+open ResultUtils
+open ResultUtils.Portability
 
 module Aether =
     type Lens<'a, 'b> =

--- a/src/DotNetLightning.Core/Utils/Errors.fs
+++ b/src/DotNetLightning.Core/Utils/Errors.fs
@@ -101,7 +101,9 @@ module OnionError =
     let CHANNEL_DISABLED = UPDATE ||| 20us
 
     [<Flags>]
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type FailureCode = | FailureCode of uint16 with
 
         member this.Value = let (FailureCode v) = this in v

--- a/src/DotNetLightning.Core/Utils/Extensions.fs
+++ b/src/DotNetLightning.Core/Utils/Extensions.fs
@@ -8,6 +8,8 @@ open System.Collections.Generic
 open System.Runtime.CompilerServices
 open System.Text
 
+open ResultUtils.Portability
+
 module Dict =
     let tryGetValue key (dict: IDictionary<_,_>)=
        match dict.TryGetValue key with

--- a/src/DotNetLightning.Core/Utils/LNMoney.fs
+++ b/src/DotNetLightning.Core/Utils/LNMoney.fs
@@ -37,6 +37,8 @@ type LNMoney = | LNMoney of int64 with
         let satoshi = Checked.op_Multiply (amount) (decimal lnUnit)
         LNMoney(Checked.int64 satoshi)
 
+    static member FromMoney (money: Money) =
+        LNMoney.Satoshis money.Satoshi
 
     static member Coins(coins: decimal) =
         LNMoney.FromUnit(coins * (decimal LNMoneyUnit.BTC), LNMoneyUnit.MilliSatoshi)

--- a/src/DotNetLightning.Core/Utils/LNMoney.fs
+++ b/src/DotNetLightning.Core/Utils/LNMoney.fs
@@ -20,8 +20,11 @@ type LNMoneyUnit =
 /// Why not use the package directly? because it might cause circular dependency in the future.
 /// (i.e. We might want to support this package in BTCPayServer.Lightning)
 /// refs: https://github.com/btcpayserver/BTCPayServer.Lightning/blob/f65a883a63bf607176a3b7b0baa94527ac592f5e/src/BTCPayServer.Lightning.Common/LightMoney.cs
+#if !NoDUsAsStructs
 [<Struct>]
-type LNMoney = | LNMoney of int64 with
+#endif
+type LNMoney = | LNMoney of int64
+    with
 
     static member private BitcoinStyle =
         NumberStyles.AllowLeadingWhite ||| NumberStyles.AllowTrailingWhite |||

--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -10,6 +10,7 @@ open System.Linq
 open System.Diagnostics
 open DotNetLightning.Core.Utils.Extensions
 open ResultUtils
+open ResultUtils.Portability
 
 [<AutoOpen>]
 module Primitives =
@@ -32,7 +33,9 @@ module Primitives =
             output
 
     /// Absolute block height
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type BlockHeight = | BlockHeight of uint32 with
         static member Zero = 0u |> BlockHeight
         static member One = 1u |> BlockHeight
@@ -58,7 +61,11 @@ module Primitives =
     /// 16bit relative block height used for `OP_CSV` locks,
     /// Since OP_CSV allow only block number of 0 ~ 65535, it is safe
     /// to restrict into the range smaller than BlockHeight
-    and  [<Struct>] BlockHeightOffset16 = | BlockHeightOffset16 of uint16 with
+    and
+#if !NoDUsAsStructs
+        [<Struct>]
+#endif
+        BlockHeightOffset16 = | BlockHeightOffset16 of uint16 with
         member x.Value = let (BlockHeightOffset16 v) = x in v
 
         static member ofBlockHeightOffset32(bho32: BlockHeightOffset32) =
@@ -77,7 +84,11 @@ module Primitives =
     ///
     /// 32bit relative block height. For `OP_CSV` locks, BlockHeightOffset16
     /// should be used instead.
-    and  [<Struct>] BlockHeightOffset32 = | BlockHeightOffset32 of uint32 with
+    and
+#if !NoDUsAsStructs
+        [<Struct>]
+#endif
+        BlockHeightOffset32 = | BlockHeightOffset32 of uint32 with
         member x.Value = let (BlockHeightOffset32 v) = x in v
 
         static member ofBlockHeightOffset16(bho16: BlockHeightOffset16) =
@@ -336,23 +347,32 @@ module Primitives =
     type BlockId = | BlockId of uint256 with
         member x.Value = let (BlockId v) = x in v
 
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type HTLCId = | HTLCId of uint64 with
         static member Zero = HTLCId(0UL)
         member x.Value = let (HTLCId v) = x in v
 
         static member (+) (a: HTLCId, b: uint64) = (a.Value + b) |> HTLCId
 
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type TxOutIndex = | TxOutIndex of uint16 with
         member x.Value = let (TxOutIndex v) = x in v
 
+#if !NoDUsAsStructs
     [<Struct>]
+#endif
     type TxIndexInBlock = | TxIndexInBlock of uint32 with
         member x.Value = let (TxIndexInBlock v) = x in v
 
 
-    [<Struct;StructuredFormatDisplay("{AsString}")>]
+#if !NoDUsAsStructs
+    [<Struct>]
+#endif
+    [<StructuredFormatDisplay("{AsString}")>]
     type ShortChannelId = {
         BlockHeight: BlockHeight
         BlockIndex: TxIndexInBlock
@@ -413,8 +433,9 @@ module Primitives =
     type EncodingType =
         | SortedPlain = 0uy
         | ZLib = 1uy
-    
-    [<StructAttribute>]
+
+    // FIXME: change to DU or record instead of adding [<Struct>]?
+    [<Struct>]
     type CommitmentNumber(index: UInt48) =
         member this.Index = index
 
@@ -473,7 +494,8 @@ module Primitives =
                     remotePaymentBasePoint
             ObscuredCommitmentNumber((UInt48.MaxValue - this.Index) ^^^ obscureFactor)
 
-    and [<StructAttribute>] ObscuredCommitmentNumber(obscuredIndex: UInt48) =
+    // FIXME: change to DU or record instead of adding [<Struct>]?
+    and [<Struct>] ObscuredCommitmentNumber(obscuredIndex: UInt48) =
         member this.ObscuredIndex: UInt48 = obscuredIndex
 
         override this.ToString() =
@@ -513,7 +535,8 @@ module Primitives =
                     remotePaymentBasePoint
             CommitmentNumber(UInt48.MaxValue - (this.ObscuredIndex ^^^ obscureFactor))
 
-    [<StructAttribute>]
+    // FIXME: change to DU or record instead of adding [<Struct>]?
+    [<Struct>]
     type RevocationKey(key: Key) =
         member this.Key = key
 
@@ -545,7 +568,8 @@ module Primitives =
         member this.CommitmentPubKey: CommitmentPubKey =
             CommitmentPubKey this.Key.PubKey
 
-    and [<StructAttribute>] CommitmentPubKey(pubKey: PubKey) =
+    // FIXME: change to DU or record instead of adding [<Struct>]?
+    and [<Struct>] CommitmentPubKey(pubKey: PubKey) =
         member this.PubKey = pubKey
 
         static member BytesLength: int = PubKey.BytesLength
@@ -556,8 +580,8 @@ module Primitives =
         member this.ToByteArray(): array<byte> =
             this.PubKey.ToBytes()
 
-
-    [<StructAttribute>]
+    // FIXME: change to DU or record instead of adding [<Struct>]?
+    [<Struct>]
     type CommitmentSeed(masterRevocationKey: RevocationKey) =
         new(key: Key) =
             CommitmentSeed(RevocationKey key)

--- a/src/DotNetLightning.Core/Utils/UInt48.fs
+++ b/src/DotNetLightning.Core/Utils/UInt48.fs
@@ -3,7 +3,9 @@ namespace DotNetLightning.Utils
 open System
 open DotNetLightning.Core.Utils.Extensions
 
+#if !NoDUsAsStructs
 [<Struct>]
+#endif
 type UInt48 = {
     UInt64: uint64
 } with

--- a/src/DotNetLightning.Infrastructure/ActorManagers/ChannelManager.fs
+++ b/src/DotNetLightning.Infrastructure/ActorManagers/ChannelManager.fs
@@ -203,6 +203,8 @@ type ChannelManager(log: ILogger<ChannelManager>,
                     return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.RemoteShutdown m)
                 | :? ClosingSignedMsg as m ->
                     return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.ApplyClosingSigned m)
+                | :? MonoHopUnidirectionalPaymentMsg as m ->
+                    return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.ApplyMonoHopUnidirectionalPayment m)
                 | :? UpdateAddHTLCMsg as m ->
                     return! (this.Actors.[e.NodeId.Value] :> IActor<_>).Put(ChannelCommand.ApplyUpdateAddHTLC (m, this.CurrentBlockHeight))
                 | :? UpdateFulfillHTLCMsg as m ->

--- a/src/DotNetLightning.Infrastructure/ActorManagers/PeerManager.fs
+++ b/src/DotNetLightning.Infrastructure/ActorManagers/PeerManager.fs
@@ -190,15 +190,20 @@ type PeerManager(eventAggregator: IEventAggregator,
                 | WeSentFundingLocked fundingLockedMsg ->
                     return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg fundingLockedMsg)
                 | BothFundingLocked _ -> ()
+                | WeAcceptedMonoHopUnidirectionalPayment _
                 | WeAcceptedUpdateAddHTLC _
                 | WeAcceptedFulfillHTLC _
                 | WeAcceptedFailHTLC _ -> ()
                 | WeAcceptedFailMalformedHTLC _ -> ()
                 | WeAcceptedUpdateFee _ -> ()
-                | WeAcceptedCommitmentSigned  _ -> failwith "TODO: route"
-                | WeAcceptedRevokeAndACK _ -> failwith "TODO: route"
+                | WeAcceptedCommitmentSigned (msg, _) ->
+                    return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg msg)
+                | WeAcceptedRevokeAndACK _ ->
+                    Console.WriteLine "WARNING: revoke_and_ack handling is not implemented"
                 // The one which includes `Operation` in its names is the one started by us.
                 // So there are no need to think about routing, just send it to specified peer.
+                | ChannelEvent.WeAcceptedOperationMonoHopUnidirectionalPayment (msg, _) ->
+                    return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg msg)
                 | ChannelEvent.WeAcceptedOperationAddHTLC (msg, _) ->
                     return! (this.KnownPeers.[peerId] :> IActor<_>).Put(EncodeMsg msg)
                 | ChannelEvent.WeAcceptedOperationFulfillHTLC (msg, _) ->

--- a/src/DotNetLightning.Infrastructure/ActorManagers/PeerManager.fs
+++ b/src/DotNetLightning.Infrastructure/ActorManagers/PeerManager.fs
@@ -28,6 +28,8 @@ open DotNetLightning.Serialize
 open NBitcoin
 open Microsoft.Extensions.Logging
 
+open ResultUtils.Portability
+
 type IPeerManager =
     inherit IActorManager<PeerCommandWithContext>
     abstract member ReadAsync: PeerId * IDuplexPipe -> ValueTask

--- a/src/DotNetLightning.Infrastructure/Actors/Actor.fs
+++ b/src/DotNetLightning.Infrastructure/Actors/Actor.fs
@@ -9,6 +9,8 @@ open DotNetLightning.Utils
 open DotNetLightning.Infrastructure
 open Microsoft.Extensions.Logging
     
+open ResultUtils.Portability
+
 type IActor<'TCommand> =
     inherit IDisposable
     abstract member StartAsync: unit -> Task

--- a/src/DotNetLightning.Infrastructure/ChainConfig.fs
+++ b/src/DotNetLightning.Infrastructure/ChainConfig.fs
@@ -2,8 +2,6 @@ namespace DotNetLightning.Infrastructure
 
 open System
 
-open ResultUtils
-
 open DotNetLightning.Utils
 open DotNetLightning.Serialize.Msgs
 open DotNetLightning.Channel
@@ -13,6 +11,9 @@ open System.Collections.Generic
 open DotNetLightning.Transactions
 open DotNetLightning.Transactions
 open NBitcoin
+
+open ResultUtils
+open ResultUtils.Portability
 
 [<AutoOpen>]
 module SupportedTypes =

--- a/src/DotNetLightning.Infrastructure/DomainTypes.fs
+++ b/src/DotNetLightning.Infrastructure/DomainTypes.fs
@@ -5,6 +5,8 @@ open DotNetLightning.Peer
 open DotNetLightning.Channel
 open DotNetLightning.Channel
 
+open ResultUtils.Portability
+
 type ChannelEventWithContext = {
     NodeId: NodeId
     ChannelEvent: ChannelEvent

--- a/src/DotNetLightning.Infrastructure/Interfaces/IFundingTxProvider.fs
+++ b/src/DotNetLightning.Infrastructure/Interfaces/IFundingTxProvider.fs
@@ -4,5 +4,7 @@ open DotNetLightning.Utils
 open DotNetLightning.Transactions
 open NBitcoin
 
+open ResultUtils.Portability
+
 type IFundingTxProvider =
     abstract member ProvideFundingTx: IDestination * Money * FeeRatePerKw -> Result<FinalizedTx * TxOutIndex, string> 

--- a/src/ResultUtils/List.fs
+++ b/src/ResultUtils/List.fs
@@ -1,5 +1,7 @@
 namespace ResultUtils
 
+open ResultUtils.Portability
+
 [<RequireQualifiedAccess>]
 module List =
     let rec private traverseResultM' (state: Result<_, _>) (f: _ -> Result<_, _>) xs =

--- a/src/ResultUtils/Result.fs
+++ b/src/ResultUtils/Result.fs
@@ -1,7 +1,29 @@
+namespace ResultUtils.Portability
+
+#if NoDUsAsStructs
+[<StructuralEquality; StructuralComparison>]
+[<CompiledName("FSharpResult`2")>]
+type Result<'T,'TError> = 
+    | Ok of ResultValue: 'T
+    | Error of ErrorValue: 'TError
+#endif
+
+
 namespace ResultUtils
+
+open ResultUtils.Portability
 
 [<RequireQualifiedAccess>]
 module Result =
+
+  let ToFSharpCoreResult res =
+#if NoDUsAsStructs
+    match res with
+    | Ok o -> FSharp.Core.Result.Ok o
+    | Error e -> FSharp.Core.Result.Error e
+#else
+    res
+#endif
 
   let isOk x =
     match x with
@@ -17,11 +39,20 @@ module Result =
     | Error err -> errorF err
 
   let eitherMap okF errorF x =
-    either (okF >> Result.Ok) (errorF >> Result.Error) x
+    either (okF >> Ok) (errorF >> Error) x
+
+  let bind binder result =
+    match result with Error e -> Error e | Ok x -> binder x
+
+  let map mapping result =
+    match result with Error e -> Error e | Ok x -> Ok (mapping x)
+
+  let mapError mapping result =
+    match result with Error x -> Error (mapping x) | Ok v -> Ok v
 
   let apply f x =
-    Result.bind (fun f' ->
-      Result.bind (fun x' -> Ok (f' x')) x) f
+    bind (fun f' ->
+        bind (fun x' -> Ok (f' x')) x) f
 
   let map2 f x y =
     (apply (apply (Ok f) x) y)
@@ -43,11 +74,11 @@ module Result =
     let tryCreate' x =
       (^b : (static member TryCreate : 'a -> Result< ^b, 'c>) x)
     tryCreate' x
-    |> Result.mapError (fun z -> (fieldName, z))
+    |> mapError (fun z -> (fieldName, z))
 
   /// Replaces the wrapped value with unit
   let ignore result =
-    result |> Result.map ignore
+    result |> map ignore
 
   /// Returns the specified error if the value is false.
   let requireTrue error value =
@@ -104,12 +135,12 @@ module Result =
 
   /// Replaces an error value with a custom error value.
   let setError error result =
-    result |> Result.mapError (fun _ -> error)
+    result |> mapError (fun _ -> error)
 
   /// Replaces a unit error value with a custom error value. Safer than setError
   /// since you're not losing any information.
   let withError error result =
-    result |> Result.mapError (fun () -> error)
+    result |> mapError (fun () -> error)
 
   /// Returns the contained value if Ok, otherwise returns ifError.
   let defaultValue ifError result =

--- a/src/ResultUtils/ResultCE.fs
+++ b/src/ResultUtils/ResultCE.fs
@@ -1,6 +1,7 @@
 namespace ResultUtils
 
 open System
+open ResultUtils.Portability
 
 [<AutoOpen>]
 module ResultCE =

--- a/src/ResultUtils/ResultOption.fs
+++ b/src/ResultUtils/ResultOption.fs
@@ -1,5 +1,7 @@
 namespace ResultUtils
 
+open ResultUtils.Portability
+
 [<RequireQualifiedAccess>]
 module ResultOption =
   let map f ro =

--- a/src/ResultUtils/ResultUtils.fsproj
+++ b/src/ResultUtils/ResultUtils.fsproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Portability)'=='true'">
+    <OtherFlags>$(OtherFlags) -d:NoDUsAsStructs -d:BouncyCastle</OtherFlags>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Option.fs" />
     <Compile Include="Result.fs" />

--- a/src/ResultUtils/Validation.fs
+++ b/src/ResultUtils/Validation.fs
@@ -1,5 +1,7 @@
 namespace ResultUtils
 
+open ResultUtils.Portability
+
 [<RequireQualifiedAccess>]
 module Validation =
   let ofResult x =

--- a/src/ResultUtils/ValidationOp.fs
+++ b/src/ResultUtils/ValidationOp.fs
@@ -1,5 +1,7 @@
 namespace ResultUtils
 
+open ResultUtils.Portability
+
 [<AutoOpen>]
 module ValidationOp =
   let inline (<!>) f (x: Result<'a, 'b list>) = Result.map f x

--- a/src/TaskUtils/Result.fs
+++ b/src/TaskUtils/Result.fs
@@ -3,6 +3,7 @@ namespace TaskUtils
 open System.Threading.Tasks
 open FSharp.Control.Tasks
 open ResultUtils
+open ResultUtils.Portability
 
 [<RequireQualifiedAccess>]
 module Result =

--- a/tests/DotNetLightning.Core.Tests/EncryptDecrypt.fs
+++ b/tests/DotNetLightning.Core.Tests/EncryptDecrypt.fs
@@ -5,6 +5,8 @@ open DotNetLightning.Crypto
 open DotNetLightning.Utils
 open Expecto
 
+open ResultUtils.Portability
+
 let hex = NBitcoin.DataEncoders.HexEncoder()
 
 let encryptTest(cryptoImpl: ICryptoImpl) =

--- a/tests/DotNetLightning.Core.Tests/LSATTests.fs
+++ b/tests/DotNetLightning.Core.Tests/LSATTests.fs
@@ -102,24 +102,24 @@ let lsatTests =
     testList "LSAT tests" [
         testCase "service decode tests" <| fun _ ->
             let r = Service.ParseMany("a:0")
-            Expect.isOk r "can parse single service"
+            Expect.isOk (Result.ToFSharpCoreResult r) "can parse single service"
             Expect.equal 1 (r |> Result.deref).Count ""
             Expect.equal "a" (r |> Result.deref).[0].Name ""
             let r = Service.ParseMany("a:0,b:1,c:0")
-            Expect.isOk r "can parse multiple service"
+            Expect.isOk (Result.ToFSharpCoreResult r) "can parse multiple service"
             Expect.equal 3 (r |> Result.deref).Count ""
             Expect.equal "c" (r |> Result.deref).[2].Name ""
             Expect.equal 0uy (r |> Result.deref).[2].ServiceTier ""
             let r = Service.ParseMany ""
-            Expect.isError r "can not parse empty service"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse empty service"
             let r = Service.ParseMany ":a"
-            Expect.isError r "can not parse service missing name"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse service missing name"
             let r = Service.ParseMany "a"
-            Expect.isError r "can not parse service missing tier"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse service missing tier"
             let r = Service.ParseMany "a:"
-            Expect.isError r "can not parse service with empty tier"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse service with empty tier"
             let r = Service.ParseMany ",,"
-            Expect.isError r "can not parse empty services"
+            Expect.isError (Result.ToFSharpCoreResult r) "can not parse empty services"
             ()
             
         testList "check macaroon verification works in LSAT compliant way" [

--- a/tests/DotNetLightning.Core.Tests/PaymentTests.fs
+++ b/tests/DotNetLightning.Core.Tests/PaymentTests.fs
@@ -11,6 +11,8 @@ open Expecto
 open NBitcoin
 open NBitcoin.Crypto
 
+open ResultUtils.Portability
+
 [<Tests>]
 let tests =
     let hex = NBitcoin.DataEncoders.HexEncoder()
@@ -184,7 +186,7 @@ let tests =
         testCase "Same, but adding invalid unknown feature 100" <| fun _ ->
             let data = "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqpqsqq40wa3khl49yue3zsgm26jrepqr2eghqlx86rttutve3ugd05em86nsefzh4pfurpd9ek9w2vp95zxqnfe2u7ckudyahsa52q66tgzcp6t2dyk"
             let pr = PaymentRequest.Parse(data)
-            Expect.isError(pr) ""
+            Expect.isError(Result.ToFSharpCoreResult  pr) ""
     ]
     
 [<Tests>]
@@ -218,12 +220,12 @@ let unitTest =
                                with
                                    member this.SignMessage(data) = nodeSecret.SignCompact(data, false) }
             let r = PaymentRequest.TryCreate("lnbc", None, DateTimeOffset.UnixEpoch, nodeId, taggedFields, msgSigner)
-            Expect.isOk r ""
+            Expect.isOk (Result.ToFSharpCoreResult r) ""
             let r2 = PaymentRequest.Parse(r |> Result.deref |> fun x -> x.ToString())
-            Expect.isOk r2 ""
+            Expect.isOk (Result.ToFSharpCoreResult r2) ""
             Expect.equal r r2 "Should not change by de/serializing it"
             let r3 = PaymentRequest.TryCreate("lnbc", None, DateTimeOffset.UnixEpoch, nodeId, {Fields = [dht; dt]}, msgSigner)
-            Expect.isError r3 "Field contains both description and description hash! this must be invalid"
+            Expect.isError (Result.ToFSharpCoreResult r3) "Field contains both description and description hash! this must be invalid"
         testCase "PaymentSecret can get correct PaymentHash by its .Hash field" <| fun _ ->
             let p = Primitives.PaymentPreimage.Create(hex.DecodeData "60ba77a7f0174a3dd0f4fc8c1b28cda6aa9fab0e87c87e936af40b34cca40883")
             let h = p.Hash

--- a/tests/DotNetLightning.Core.Tests/PeerChannelEncryptorTests.fs
+++ b/tests/DotNetLightning.Core.Tests/PeerChannelEncryptorTests.fs
@@ -9,6 +9,8 @@ open DotNetLightning.Utils.Aether
 open DotNetLightning.Utils
 open DotNetLightning.Peer
 
+open ResultUtils
+
 let hex = NBitcoin.DataEncoders.HexEncoder()
 let logger = Log.create "PeerChannelEncryptor tests"
 
@@ -37,7 +39,7 @@ let peerChannelEncryptorTests =
                 let outboundPeer = getOutBoundPeerForInitiatorTestVectors()
                 let actTwo = hex.DecodeData("0002466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae")
                 let res = outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId
-                Expect.isOk (res) ""
+                Expect.isOk (Result.ToFSharpCoreResult res) ""
 
                 let (actual, _nodeid), nextPCE = res |> Result.deref
                 let expected = "0x00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba"
@@ -67,7 +69,7 @@ let peerChannelEncryptorTests =
             let testCase3() =
                 let outboundPeer = getOutBoundPeerForInitiatorTestVectors()
                 let actTwo = hex.DecodeData("0102466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae")
-                Expect.isError (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId) ""
+                Expect.isError (Result.ToFSharpCoreResult (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId)) ""
 
             testCase3()
 
@@ -75,14 +77,14 @@ let peerChannelEncryptorTests =
             let testCase4() =
                 let outboundPeer = getOutBoundPeerForInitiatorTestVectors()
                 let actTwo = hex.DecodeData("0004466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae")
-                Expect.isError (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId) ""
+                Expect.isError (Result.ToFSharpCoreResult (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId)) ""
             testCase4()
 
             /// transport-initiator act2 bad MAC test
             let testCase5() =
                 let outboundPeer = getOutBoundPeerForInitiatorTestVectors()
                 let actTwo = hex.DecodeData("0002466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730af")
-                Expect.isError(outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId) ""
+                Expect.isError (Result.ToFSharpCoreResult (outboundPeer |> PeerChannelEncryptor.processActTwo actTwo ourNodeId)) ""
             testCase5()
 
         testCase "noise responder test vectors" <| fun _ ->
@@ -95,14 +97,14 @@ let peerChannelEncryptorTests =
                 let actOne = hex.DecodeData("00036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6a")
                 let actTwoExpected = hex.DecodeData("0002466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae")
                 let actualR  = inboundPeer1 |> PeerChannelEncryptor.processActOneWithEphemeralKey actOne  ourNodeSecret ourEphemeral
-                Expect.isOk (actualR) ""
+                Expect.isOk (Result.ToFSharpCoreResult actualR) ""
                 let actual, inboundPeer2  = actualR |> Result.deref
                 Expect.equal (actual) (actTwoExpected) ""
 
                 let actThree = hex.DecodeData("00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba")
                 let theirNodeIdExpected = hex.DecodeData("034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa") |> PubKey |> NodeId
                 let actualRR = inboundPeer2 |> PeerChannelEncryptor.processActThree(actThree)
-                Expect.isOk (actualRR) ""
+                Expect.isOk (Result.ToFSharpCoreResult actualRR) ""
                 let actual, nextState = actualRR |> Result.deref
                 Expect.equal (actual) (theirNodeIdExpected) ""
                 match nextState.NoiseState with
@@ -126,21 +128,21 @@ let peerChannelEncryptorTests =
                 let inboundPeer = PeerChannelEncryptor.newInBound( ourNodeSecret)
                 let actOne = "01036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6a" |> hex.DecodeData
                 let actualR = inboundPeer |> PeerChannelEncryptor.processActOneWithEphemeralKey actOne  ourNodeSecret ourEphemeral
-                Expect.isError (actualR) ""
+                Expect.isError (Result.ToFSharpCoreResult actualR) ""
 
             /// Transport responder act1 babd key serialization test
             let _testCase4 =
                 let inboundPeer =  ourNodeSecret |> PeerChannelEncryptor.newInBound
                 let actOne = hex.DecodeData("00046360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6a")
                 let actualR = inboundPeer |> PeerChannelEncryptor.processActOneWithEphemeralKey actOne  ourNodeSecret ourEphemeral
-                Expect.isError  (actualR) ""
+                Expect.isError  (Result.ToFSharpCoreResult actualR) ""
 
             /// Transport-responder act1 bad MAC test
             let _testCase5 =
                 let inboundPeer =  ourNodeSecret |> PeerChannelEncryptor.newInBound
                 let actOne = hex.DecodeData("00036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6b")
                 let actualRR = inboundPeer |> PeerChannelEncryptor.processActOneWithEphemeralKey actOne  ourNodeSecret ourEphemeral
-                Expect.isError (actualRR) ""
+                Expect.isError (Result.ToFSharpCoreResult actualRR) ""
 
             /// Transport responder act3 bad version test
             let _testCase6 =
@@ -150,7 +152,7 @@ let peerChannelEncryptorTests =
 
                 let actThree = hex.DecodeData("01b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba")
                 let actualR = inboundPeer2 |> PeerChannelEncryptor.processActThree actThree
-                Expect.isError (actualR) ""
+                Expect.isError (Result.ToFSharpCoreResult actualR) ""
 
             /// Transport responder act3 short read test
             let _testCase7 =
@@ -171,7 +173,7 @@ let peerChannelEncryptorTests =
                 Expect.equal actualActOneResult expectedActOneResult ""
                 let actThree = hex.DecodeData("00c9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba")
                 let r = PeerChannelEncryptor.processActThree actThree inboundPeer2
-                Expect.isError r ""
+                Expect.isError (Result.ToFSharpCoreResult r) ""
 
             /// transport-responder act3 bad rx
             let _testCase9 =
@@ -183,7 +185,7 @@ let peerChannelEncryptorTests =
 
                 let actThree = hex.DecodeData("00bfe3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa2235536ad09a8ee351870c2bb7f78b754a26c6cef79a98d25139c856d7efd252c2ae73c")
                 let r = PeerChannelEncryptor.processActThree actThree inboundPeer2
-                Expect.isError r ""
+                Expect.isError (Result.ToFSharpCoreResult r) ""
 
             /// transport-responder act3 abd MAC text
             let _testCase10 =
@@ -195,7 +197,7 @@ let peerChannelEncryptorTests =
 
                 let actThree = hex.DecodeData("00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139bb")
                 let r = PeerChannelEncryptor.processActThree actThree inboundPeer2
-                Expect.isError (r) ""
+                Expect.isError (Result.ToFSharpCoreResult r) ""
             ()
 
         testCase "message encryption decryption test vectors" <| fun _ ->
@@ -268,7 +270,7 @@ let peerChannelEncryptorTests =
                             return header
                         }
                         runP instruction localInbound
-                    Expect.isOk (actualLengthR) ""
+                    Expect.isOk (Result.ToFSharpCoreResult actualLengthR) ""
                     let actualLength, inbound2 = actualLengthR |> Result.deref
                     log (sprintf "new inbound is %A" inbound2)
                     let expectedLength = uint16 msg.Length

--- a/tests/DotNetLightning.Core.Tests/RevocationSetTests.fs
+++ b/tests/DotNetLightning.Core.Tests/RevocationSetTests.fs
@@ -6,6 +6,8 @@ open ResultUtils
 open DotNetLightning.Utils
 open DotNetLightning.Crypto
 
+open ResultUtils.Portability
+
 [<Tests>]
 let tests =
     let insert (commitmentNumber: uint64)

--- a/tests/DotNetLightning.Core.Tests/RouteCalculationTests.fs
+++ b/tests/DotNetLightning.Core.Tests/RouteCalculationTests.fs
@@ -149,7 +149,7 @@ let tests = testList "Route Calculation" [
         
         let route2 =
             Routing.findRoute(graphWithRemovedEdge) a e DEFAULT_AMOUNT_MSAT 1 (Set.empty) (Set.empty)(Set.empty)DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))
-        Expect.isError (route2) ""
+        Expect.isError (Result.ToFSharpCoreResult route2) ""
         
     testCase "calculate the shortest path (select direct channel)" <| fun _ ->
         let updates = [
@@ -189,7 +189,7 @@ let tests = testList "Route Calculation" [
         let graph = DirectedLNGraph.Create().AddEdges(updates)
         let route =
             Routing.findRoute graph f i DEFAULT_AMOUNT_MSAT 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))
-        Expect.isError (route) ""
+        Expect.isError (Result.ToFSharpCoreResult route) ""
         
     testCase "if there are multiple channels between the same node, select the cheapest" <| fun _ ->
         let updates = [
@@ -225,7 +225,7 @@ let tests = testList "Route Calculation" [
         
         let g = DirectedLNGraph.Create().AddEdges(updates)
         let route = Routing.findRoute(g) a e DEFAULT_AMOUNT_MSAT 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))
-        Expect.isError route ""
+        Expect.isError (Result.ToFSharpCoreResult route) ""
         
     testCase "route not found (source OR target node not connected)" <| fun _ ->
         let updates = [
@@ -233,8 +233,8 @@ let tests = testList "Route Calculation" [
             makeUpdateSimple(4UL, c, d)
         ]
         let g = DirectedLNGraph.Create().AddEdges(updates).AddVertex(a).AddVertex(e)
-        Expect.isError(Routing.findRoute g a d DEFAULT_AMOUNT_MSAT 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))) ""
-        Expect.isError(Routing.findRoute g b e DEFAULT_AMOUNT_MSAT 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))) ""
+        Expect.isError (Result.ToFSharpCoreResult (Routing.findRoute g a d DEFAULT_AMOUNT_MSAT 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u)))) ""
+        Expect.isError (Result.ToFSharpCoreResult (Routing.findRoute g b e DEFAULT_AMOUNT_MSAT 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u)))) ""
         
     testCase "route not found (amount too high OR too low)" <| fun _ ->
         let highAmount = DEFAULT_AMOUNT_MSAT * 10
@@ -253,8 +253,8 @@ let tests = testList "Route Calculation" [
         let gHigh = DirectedLNGraph.Create().AddEdges(updatesHi)
         let gLow = DirectedLNGraph.Create().AddEdges(updatesLow)
         
-        Expect.isError (Routing.findRoute gHigh a d highAmount 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))) ""
-        Expect.isError (Routing.findRoute gLow a d lowAmount 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))) ""
+        Expect.isError (Result.ToFSharpCoreResult (Routing.findRoute gHigh a d highAmount 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u)))) ""
+        Expect.isError (Result.ToFSharpCoreResult (Routing.findRoute gLow a d lowAmount 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u)))) ""
         
     testCase "route to self" <| fun _ ->
         let updates = [
@@ -266,7 +266,7 @@ let tests = testList "Route Calculation" [
         let g = DirectedLNGraph.Create().AddEdges(updates)
         let route =
             Routing.findRoute g a a DEFAULT_AMOUNT_MSAT 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))
-        Expect.isError route ""
+        Expect.isError (Result.ToFSharpCoreResult route) ""
         
     testCase "route to immediate neighbor" <| fun _ ->
         let updates = [
@@ -298,7 +298,7 @@ let tests = testList "Route Calculation" [
         Expect.sequenceEqual (hops2Ids(route1)) [1UL; 2UL; 3UL; 4UL] ""
         let route2 =
             Routing.findRoute g e e DEFAULT_AMOUNT_MSAT 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))
-        Expect.isError route2 ""
+        Expect.isError (Result.ToFSharpCoreResult route2) ""
         
     testCase "calculate route and return metadata" <| fun _ ->
         let uab =
@@ -451,7 +451,7 @@ let tests = testList "Route Calculation" [
         let g = DirectedLNGraph.Create().AddEdges(updates)
         let ignoredE = Set.singleton({ ShortChannelId = ShortChannelId.FromUInt64(3UL); A = c; B = d })
         let route1 = Routing.findRoute(g) a e DEFAULT_AMOUNT_MSAT 1 (Set.empty) (ignoredE) (Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))
-        Expect.isError (route1) ""
+        Expect.isError (Result.ToFSharpCoreResult route1) ""
         
         // verify that we left the graph untouched
         Expect.isTrue(g.ContainsEdge(makeUpdateSimple(3UL, c, d) |> fst)) ""
@@ -473,7 +473,7 @@ let tests = testList "Route Calculation" [
         let g = DirectedLNGraph.Create().AddEdges(updates)
         let route =
             Routing.findRoute(g) a e DEFAULT_AMOUNT_MSAT 1 (Set.empty)(Set.empty)(Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u))
-        Expect.isError(route) "there should be no e node in the graph"
+        Expect.isError(Result.ToFSharpCoreResult route) "there should be no e node in the graph"
         
         // now we add the missing edge to reach the destination
         let (extraDesc, extraUpdate) = makeUpdate(4UL, d, e, LNMoney.MilliSatoshis(5L), 5u, None, None, None)
@@ -567,7 +567,7 @@ let tests = testList "Route Calculation" [
         Expect.sequenceEqual (hops2Ids(r20)) [ for i in 0..19 -> (uint64 i) ] ""
         let r21 =
             (Routing.findRoute g (nodes.[0]) nodes.[21] DEFAULT_AMOUNT_MSAT 1 (Set.empty) (Set.empty) (Set.empty) DEFAULT_ROUTE_PARAMS (BlockHeight(400000u)))
-        Expect.isError(r21) ""
+        Expect.isError(Result.ToFSharpCoreResult r21) ""
         
     testCase "ignore cheaper route when it has more than 20 hops" <| fun _ ->
         let nodes = [ for _ in 0..50 -> (new Key()).PubKey |> NodeId ]
@@ -740,7 +740,7 @@ let tests = testList "Route Calculation" [
         let strictFeeParams = { DEFAULT_ROUTE_PARAMS with MaxFeeBase = LNMoney.MilliSatoshis(7); MaxFeePCT = 0. }
         for _ in 0..10 do
             let r = Routing.findRoute graph a d DEFAULT_AMOUNT_MSAT 3 (Set.empty) (Set.empty) (Set.empty) strictFeeParams (BlockHeight(400000u))
-            Expect.isOk r ""
+            Expect.isOk (Result.ToFSharpCoreResult r) ""
             let someRoute = r |> Result.deref
             let routeCost =
                 (Graph.pathWeight (hops2Edges(someRoute)) DEFAULT_AMOUNT_MSAT false (BlockHeight 0u) None).Cost - DEFAULT_AMOUNT_MSAT

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -12,6 +12,8 @@ open System
 open System.Collections
 open FsCheck
 
+open ResultUtils.Portability
+
 module SerializationTest =
 
     open Utils
@@ -797,9 +799,9 @@ module SerializationTest =
                     let ba = testCase |> parseBitArray
                     let result = Feature.validateFeatureGraph (ba)
                     if valid then
-                        Expect.isOk(result) (testCase)
+                        Expect.isOk(Result.ToFSharpCoreResult result) (testCase)
                     else
-                        Expect.isError(result) (testCase)
+                        Expect.isError(Result.ToFSharpCoreResult result) (testCase)
                     )
                 
             testCase "features compatibility (in int64)" <| fun _ ->

--- a/tests/DotNetLightning.Core.Tests/SerializationPropertyTests.fs
+++ b/tests/DotNetLightning.Core.Tests/SerializationPropertyTests.fs
@@ -9,6 +9,8 @@ open DotNetLightning.Serialize
 open DotNetLightning.Serialize.Msgs
 open Generators
 
+open ResultUtils.Portability
+
 let config =
     { FsCheckConfig.defaultConfig with
             arbitrary = [ typeof<P2PMsgGenerators>; typeof<PrimitiveGenerators> ]

--- a/tests/DotNetLightning.Core.Tests/SphinxTests.fs
+++ b/tests/DotNetLightning.Core.Tests/SphinxTests.fs
@@ -82,7 +82,7 @@ let bolt4Tests1 =
             let { Payload = payload0; NextPacket = nextPacket0; SharedSecret = _ss0 }: ParsedPacket =
                 Sphinx.parsePacket (privKeys.[0]) (associatedData) (onion.ToBytes())
                 |> fun rr -> 
-                    Expect.isOk(rr) ""
+                    Expect.isOk(Result.ToFSharpCoreResult rr) ""
                     Result.defaultWith (fun _ -> failwith "Unreachable") rr
             let { Payload = payload1; NextPacket = nextPacket1; }: ParsedPacket =
                 Sphinx.parsePacket (privKeys.[1]) (associatedData) (nextPacket0.ToBytes())
@@ -113,7 +113,7 @@ let bolt4Tests1 =
             let { NextPacket = packet1; SharedSecret = ss0 }: ParsedPacket =
                 Sphinx.parsePacket (privKeys.[0]) (associatedData) (onion.ToBytes())
                 |> fun r -> 
-                    Expect.isOk(r) ""
+                    Expect.isOk(Result.ToFSharpCoreResult r) ""
                     Result.defaultWith(fun _ -> failwith "Fail: bolt4 last node replies with err msg defaultClosure0") r
             let { NextPacket = packet2; SharedSecret = ss1 }: ParsedPacket =
                 Sphinx.parsePacket (privKeys.[1]) (associatedData) (packet1.ToBytes())

--- a/tests/DotNetLightning.Core.Tests/TransactionBolt3TestVectorTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TransactionBolt3TestVectorTests.fs
@@ -14,6 +14,8 @@ open Expecto
 open GeneratorsTests
 open NBitcoin
 
+open ResultUtils.Portability
+
 let newSecp256k1 = DotNetLightning.Crypto.CryptoUtils.impl.newSecp256k1
 
 // let logger = Log.create "bolt3-transaction tests"

--- a/tests/DotNetLightning.Infrastructure.Tests/Constants.fs
+++ b/tests/DotNetLightning.Infrastructure.Tests/Constants.fs
@@ -16,6 +16,7 @@ type TestEntity =
         NodeParams: ChainConfig
     }
 
+let monoHopPaymentAmount = 1000L |> LNMoney.MilliSatoshis
 let fundingSatoshis = 1000000L |> Money.Satoshis
 let pushMsat = 200000000L |> LNMoney.MilliSatoshis
 let feeratePerKw = 10000u |> FeeRatePerKw 

--- a/tests/DotNetLightning.Infrastructure.Tests/Constants.fs
+++ b/tests/DotNetLightning.Infrastructure.Tests/Constants.fs
@@ -9,6 +9,8 @@ open DotNetLightning.Transactions
 open System.Net
 open Foq
 
+open ResultUtils.Portability
+
 type TestEntity =
     {
         Seed: uint256


### PR DESCRIPTION
The lightning spec decrees that the closing tx's outputs need to be in lexicographical order. Instead, they were ending up in the wrong order thanks to (a) not being added in the correct order and (b) `TransactionBuilder` shuffling them anyway when calling `BuildTransaction`.

`makeClosingTx` now makes the closing tx using `Transaction` directly rather than `TransactionBuilder`. This allows us to set the order of the outputs explicitly.

This PR also includes an earlier fix from joe.