### PR TITLE
Implement revocation

### DIFF
--- a/src/DotNetLightning.Core/Channel/CommitmentToLocalExtension.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentToLocalExtension.fs
@@ -1,0 +1,123 @@
+namespace DotNetLightning.Channel
+
+open NBitcoin
+open NBitcoin.BuilderExtensions
+open DotNetLightning.Utils
+open DotNetLightning.Utils.SeqConsumer
+open DotNetLightning.Crypto
+
+type CommitmentToLocalParameters = {
+    RevocationPubKey: RevocationPubKey
+    ToSelfDelay: BlockHeightOffset16
+    LocalDelayedPubKey: DelayedPaymentPubKey
+}
+    with
+    static member TryExtractParameters (scriptPubKey: Script): Option<CommitmentToLocalParameters> =
+        let ops =
+            scriptPubKey.ToOps()
+            // we have to collect it into a list and convert back to a seq
+            // because the IEnumerable that NBitcoin gives us is internally
+            // mutable.
+            |> List.ofSeq
+            |> Seq.ofList
+        let checkOpCode(opcodeType: OpcodeType) = seqConsumer<Op> {
+            let! op = NextInSeq()
+            if op.Code = opcodeType then
+                return ()
+            else
+                return! AbortSeqConsumer()
+        }
+        let consumeAllResult =
+            SeqConsumer.ConsumeAll ops <| seqConsumer {
+                do! checkOpCode OpcodeType.OP_IF
+                let! opRevocationPubKey = NextInSeq()
+                let! revocationPubKey = seqConsumer {
+                    match opRevocationPubKey.PushData with
+                    | null -> return! AbortSeqConsumer()
+                    | bytes -> return RevocationPubKey.FromBytes bytes      // FIXME: catch exception
+                }
+                do! checkOpCode OpcodeType.OP_ELSE
+                let! opToSelfDelay = NextInSeq()
+                let! toSelfDelay = seqConsumer {
+                    let nullableToSelfDelay = opToSelfDelay.GetLong()
+                    if nullableToSelfDelay.HasValue then
+                        // FIXME: catch exception
+                        return BlockHeightOffset16 (uint16 nullableToSelfDelay.Value)
+                    else
+                        return! AbortSeqConsumer()
+                }
+                do! checkOpCode OpcodeType.OP_CHECKSEQUENCEVERIFY
+                do! checkOpCode OpcodeType.OP_DROP
+                let! opLocalDelayedPubKey = NextInSeq()
+                let! localDelayedPubKey = seqConsumer {
+                    match opLocalDelayedPubKey.PushData with
+                    | null -> return! AbortSeqConsumer()
+                    | bytes -> return DelayedPaymentPubKey.FromBytes bytes  // FIXME: catch exception
+                }
+                do! checkOpCode OpcodeType.OP_ENDIF
+                do! checkOpCode OpcodeType.OP_CHECKSIG
+                return {
+                    RevocationPubKey = revocationPubKey
+                    ToSelfDelay = toSelfDelay
+                    LocalDelayedPubKey = localDelayedPubKey
+                }
+            }
+        match consumeAllResult with
+        | Ok data -> Some data
+        | Error _consumeAllError -> None
+
+type internal CommitmentToLocalExtension() =
+    inherit BuilderExtension()
+        override self.CanGenerateScriptSig (scriptPubKey: Script): bool =
+            (CommitmentToLocalParameters.TryExtractParameters scriptPubKey).IsSome
+
+        override self.GenerateScriptSig(scriptPubKey: Script, keyRepo: IKeyRepository, signer: ISigner): Script =
+            let parameters =
+                match (CommitmentToLocalParameters.TryExtractParameters scriptPubKey) with
+                | Some parameters -> parameters
+                | None ->
+                    failwith
+                        "NBitcoin should not call this unless CanGenerateScriptSig returns true"
+            let pubKey = keyRepo.FindKey scriptPubKey
+            match pubKey with
+            | null -> null
+            | _ when pubKey = parameters.RevocationPubKey.RawPubKey() ->
+                let revocationSig = signer.Sign (parameters.RevocationPubKey.RawPubKey())
+                Script [
+                    Op.GetPushOp (revocationSig.ToBytes())
+                    Op.op_Implicit OpcodeType.OP_TRUE
+                ]
+            | _ when pubKey = parameters.LocalDelayedPubKey.RawPubKey() ->
+                let localDelayedSig = signer.Sign (parameters.LocalDelayedPubKey.RawPubKey())
+                Script [
+                    Op.GetPushOp (localDelayedSig.ToBytes())
+                    Op.op_Implicit OpcodeType.OP_FALSE
+                ]
+            | _ -> null
+
+        override self.CanDeduceScriptPubKey(_scriptSig: Script): bool =
+            false
+
+        override self.DeduceScriptPubKey(_scriptSig: Script): Script =
+            raise <| System.NotSupportedException()
+
+        override self.CanEstimateScriptSigSize(_scriptPubKey: Script): bool =
+            false
+
+        override self.EstimateScriptSigSize(_scriptPubKey: Script): int =
+            raise <| System.NotSupportedException()
+
+        override self.CanCombineScriptSig(_scriptPubKey: Script, _a: Script, _b: Script): bool = 
+            false
+
+        override self.CombineScriptSig(_scriptPubKey: Script, _a: Script, _b: Script): Script =
+            raise <| System.NotSupportedException()
+
+        override self.IsCompatibleKey(pubKey: PubKey, scriptPubKey: Script): bool =
+            match CommitmentToLocalParameters.TryExtractParameters scriptPubKey with
+            | None -> false
+            | Some parameters ->
+                parameters.RevocationPubKey.RawPubKey() = pubKey
+                || parameters.LocalDelayedPubKey.RawPubKey() = pubKey
+
+

--- a/src/DotNetLightning.Core/Channel/CommitmentToLocalExtension.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentToLocalExtension.fs
@@ -79,6 +79,10 @@ type internal CommitmentToLocalExtension() =
                     failwith
                         "NBitcoin should not call this unless CanGenerateScriptSig returns true"
             let pubKey = keyRepo.FindKey scriptPubKey
+            // FindKey will return null if it can't find a key for
+            // scriptPubKey. If we can't find a valid key then this method
+            // should return null, indicating to NBitcoin that the sigScript
+            // could not be generated.
             match pubKey with
             | null -> null
             | _ when pubKey = parameters.RevocationPubKey.RawPubKey() ->

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -416,13 +416,19 @@ module internal Commitments =
             }
 
 module RemoteForceClose =
+    // The lightning spec specifies that commitment txs use version 2 bitcoin transactions.
+    let TxVersionNumberOfCommitmentTxs = 2u
+
     let check(thing: bool): Option<unit> =
-        if thing then Some () else None
+        if thing then
+            Some ()
+        else
+            None
 
     let tryGetObscuredCommitmentNumber (fundingOutPoint: OutPoint)
                                        (transaction: Transaction)
                                            : Option<ObscuredCommitmentNumber> = option {
-        do! check (transaction.Version = 2u)
+        do! check (transaction.Version = TxVersionNumberOfCommitmentTxs)
         let! txIn = Seq.tryExactlyOne transaction.Inputs
         do! check (fundingOutPoint = txIn.PrevOut)
         let! obscuredCommitmentNumber =

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -414,3 +414,171 @@ module internal Commitments =
                               OriginChannels = originChannels1 }
                 return [ WeAcceptedCommitmentSigned(nextMsg, nextCommitments) ;]
             }
+
+module RemoteForceClose =
+    let check(thing: bool): Option<unit> =
+        if thing then Some () else None
+
+    let tryGetObscuredCommitmentNumber (fundingOutPoint: OutPoint)
+                                       (transaction: Transaction)
+                                           : Option<ObscuredCommitmentNumber> = option {
+        do! check (transaction.Version = 2u)
+        let! txIn = Seq.tryExactlyOne transaction.Inputs
+        do! check (fundingOutPoint = txIn.PrevOut)
+        let! obscuredCommitmentNumber =
+            ObscuredCommitmentNumber.TryFromLockTimeAndSequence transaction.LockTime txIn.Sequence
+        return obscuredCommitmentNumber
+    }
+
+    let tryGetFundsFromRemoteCommitmentTx (commitments: Commitments)
+                                          (localChannelPrivKeys: ChannelPrivKeys)
+                                          (network: Network)
+                                          (transaction: Transaction)
+                                              : Option<TransactionBuilder> = option {
+        let! obscuredCommitmentNumber =
+            tryGetObscuredCommitmentNumber
+                commitments.FundingScriptCoin.Outpoint
+                transaction
+        let localChannelPubKeys = commitments.LocalParams.ChannelPubKeys
+        let remoteChannelPubKeys = commitments.RemoteParams.ChannelPubKeys
+        let commitmentNumber =
+            obscuredCommitmentNumber.Unobscure
+                false
+                localChannelPubKeys.PaymentBasepoint
+                remoteChannelPubKeys.PaymentBasepoint
+        let perCommitmentSecretOpt =
+            commitments.RemotePerCommitmentSecrets.GetPerCommitmentSecret commitmentNumber
+        let! perCommitmentPoint =
+            match perCommitmentSecretOpt with
+            | Some perCommitmentSecret -> Some <| perCommitmentSecret.PerCommitmentPoint()
+            | None ->
+                if commitments.RemoteCommit.Index = commitmentNumber then
+                    Some commitments.RemoteCommit.RemotePerCommitmentPoint
+                else
+                    None
+
+        let localCommitmentPubKeys =
+            perCommitmentPoint.DeriveCommitmentPubKeys localChannelPubKeys
+        let remoteCommitmentPubKeys =
+            perCommitmentPoint.DeriveCommitmentPubKeys remoteChannelPubKeys
+
+        let transactionBuilder = network.CreateTransactionBuilder()
+
+        let toRemoteScriptPubKey =
+            localCommitmentPubKeys.PaymentPubKey.RawPubKey().WitHash.ScriptPubKey
+        let toRemoteIndexOpt =
+            Seq.tryFindIndex
+                (fun (txOut: TxOut) -> txOut.ScriptPubKey = toRemoteScriptPubKey)
+                transaction.Outputs
+        let spentToRemoteOutput =
+            match toRemoteIndexOpt with
+            | None -> false
+            | Some toRemoteIndex ->
+                let localPaymentPrivKey =
+                    perCommitmentPoint.DerivePaymentPrivKey
+                        localChannelPrivKeys.PaymentBasepointSecret
+                transactionBuilder.AddKeys (localPaymentPrivKey.RawKey())
+                transactionBuilder.AddCoins
+                    (Coin(transaction, uint32 toRemoteIndex))
+                true
+
+        let spentToLocalOutput =
+            match perCommitmentSecretOpt with
+            | None -> false
+            | Some perCommitmentSecret ->
+                let toLocalScriptPubKey =
+                    Scripts.toLocalDelayed
+                        localCommitmentPubKeys.RevocationPubKey
+                        commitments.RemoteParams.ToSelfDelay
+                        remoteCommitmentPubKeys.DelayedPaymentPubKey
+                let toLocalIndexOpt =
+                    let toLocalWitScriptPubKey = toLocalScriptPubKey.WitHash.ScriptPubKey
+                    Seq.tryFindIndex
+                        (fun (txOut: TxOut) -> txOut.ScriptPubKey = toLocalWitScriptPubKey)
+                        transaction.Outputs
+                match toLocalIndexOpt with
+                | None -> false
+                | Some toLocalIndex ->
+                    let revocationPrivKey =
+                        perCommitmentSecret.DeriveRevocationPrivKey
+                            localChannelPrivKeys.RevocationBasepointSecret
+                    transactionBuilder.Extensions.Add (CommitmentToLocalExtension())
+                    transactionBuilder.AddKeys (revocationPrivKey.RawKey())
+                    transactionBuilder.AddCoins
+                        (ScriptCoin(transaction, uint32 toLocalIndex, toLocalScriptPubKey))
+                    true
+
+        do! check (spentToRemoteOutput || spentToLocalOutput)
+
+        return transactionBuilder
+    }
+
+    let tryGetFundsFromLocalCommitmentTx (commitments: Commitments)
+                                         (localChannelPrivKeys: ChannelPrivKeys)
+                                         (network: Network)
+                                         (transaction: Transaction)
+                                             : Option<TransactionBuilder> = option {
+        let! obscuredCommitmentNumber =
+            tryGetObscuredCommitmentNumber
+                commitments.FundingScriptCoin.Outpoint
+                transaction
+        let localChannelPubKeys = commitments.LocalParams.ChannelPubKeys
+        let remoteChannelPubKeys = commitments.RemoteParams.ChannelPubKeys
+        let commitmentNumber =
+            obscuredCommitmentNumber.Unobscure
+                true
+                localChannelPubKeys.PaymentBasepoint
+                remoteChannelPubKeys.PaymentBasepoint
+
+        let perCommitmentPoint =
+            localChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint commitmentNumber
+        let localCommitmentPubKeys =
+            perCommitmentPoint.DeriveCommitmentPubKeys localChannelPubKeys
+        let remoteCommitmentPubKeys =
+            perCommitmentPoint.DeriveCommitmentPubKeys remoteChannelPubKeys
+
+        let transactionBuilder = network.CreateTransactionBuilder()
+
+        let toLocalScriptPubKey =
+            Scripts.toLocalDelayed
+                remoteCommitmentPubKeys.RevocationPubKey
+                commitments.LocalParams.ToSelfDelay
+                localCommitmentPubKeys.DelayedPaymentPubKey
+        let! toLocalIndex =
+            let toLocalWitScriptPubKey = toLocalScriptPubKey.WitHash.ScriptPubKey
+            Seq.tryFindIndex
+                (fun (txOut: TxOut) -> txOut.ScriptPubKey = toLocalWitScriptPubKey)
+                transaction.Outputs
+
+        let delayedPaymentPrivKey =
+            perCommitmentPoint.DeriveDelayedPaymentPrivKey
+                localChannelPrivKeys.DelayedPaymentBasepointSecret
+        transactionBuilder.Extensions.Add (CommitmentToLocalExtension())
+        transactionBuilder.AddKeys (delayedPaymentPrivKey.RawKey())
+        transactionBuilder.AddCoins
+            (ScriptCoin(transaction, uint32 toLocalIndex, toLocalScriptPubKey))
+
+        return transactionBuilder
+    }
+
+    let getFundsFromForceClosingTransaction (commitments: Commitments)
+                                            (localChannelPrivKeys: ChannelPrivKeys)
+                                            (network: Network)
+                                            (transaction: Transaction)
+                                                : Option<TransactionBuilder> =
+        let attemptsSeq = seq {
+            yield
+                tryGetFundsFromRemoteCommitmentTx
+                    commitments
+                    localChannelPrivKeys
+                    network
+                    transaction
+            yield
+                tryGetFundsFromLocalCommitmentTx
+                    commitments
+                    localChannelPrivKeys
+                    network
+                    transaction
+        }
+        Seq.tryPick (fun opt -> opt) attemptsSeq
+

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -27,6 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Utils/SeqConsumer.fs" />
     <Compile Include="Utils/LNMoney.fs" />
     <Compile Include="Utils\Extensions.fs" />
     <Compile Include="Utils/UInt48.fs" />
@@ -68,6 +69,7 @@
     <Compile Include="Peer\PeerChannelEncryptor.fs" />
     <Compile Include="Peer\PeerTypes.fs" />
     <Compile Include="Peer\Peer.fs" />
+    <Compile Include="Channel\CommitmentToLocalExtension.fs" />
     <Compile Include="Channel\HTLCChannelType.fs" />
     <Compile Include="Channel\ChannelConstants.fs" />
     <Compile Include="Channel\ChannelOperations.fs" />

--- a/src/DotNetLightning.Core/Utils/Keys.fs
+++ b/src/DotNetLightning.Core/Utils/Keys.fs
@@ -59,6 +59,9 @@ type RevocationPubKey =
         let (RevocationPubKey pubKey) = this
         pubKey
 
+    static member FromBytes(bytes: array<byte>): RevocationPubKey =
+        RevocationPubKey <| PubKey bytes
+
     member this.ToBytes(): array<byte> =
         this.RawPubKey().ToBytes()
 
@@ -150,6 +153,9 @@ type DelayedPaymentPubKey =
     member this.RawPubKey(): PubKey =
         let (DelayedPaymentPubKey pubKey) = this
         pubKey
+
+    static member FromBytes(bytes: array<byte>): DelayedPaymentPubKey =
+        DelayedPaymentPubKey <| PubKey bytes
 
     member this.ToBytes(): array<byte> =
         this.RawPubKey().ToBytes()

--- a/src/DotNetLightning.Core/Utils/SeqConsumer.fs
+++ b/src/DotNetLightning.Core/Utils/SeqConsumer.fs
@@ -1,0 +1,58 @@
+namespace DotNetLightning.Utils
+
+type SeqConsumer<'S, 'T> = {
+    Consume: seq<'S> -> Option<seq<'S> * 'T>
+}
+
+type SeqConsumerBuilder<'S>() =
+    member __.Bind<'T0, 'T1>(seqConsumer0: SeqConsumer<'S, 'T0>, func: 'T0 -> SeqConsumer<'S, 'T1>)
+                                : SeqConsumer<'S, 'T1> = {
+        Consume = fun (sequence0: seq<'S>) ->
+            match seqConsumer0.Consume sequence0 with
+            | None -> None
+            | Some (sequence1, value0) ->
+                let seqConsumer1 = func value0
+                seqConsumer1.Consume sequence1
+    }
+
+    member __.Return<'T>(value: 'T)
+                            : SeqConsumer<'S, 'T> = {
+        Consume = fun (sequence: seq<'S>) -> Some (sequence, value)
+    }
+
+    member __.ReturnFrom<'T>(seqConsumer: SeqConsumer<'S, 'T>): SeqConsumer<'S, 'T> =
+        seqConsumer
+
+    member __.Zero(): SeqConsumer<'S, unit> = {
+        Consume = fun (sequence: seq<'S>) -> Some (sequence, ())
+    }
+
+module SeqConsumer =
+    let seqConsumer<'S> = SeqConsumerBuilder<'S>()
+
+    let NextInSeq<'S>(): SeqConsumer<'S, 'S> = {
+        Consume = fun (sequence: seq<'S>) ->
+            match Seq.tryHead sequence with
+            | None -> None
+            | Some value -> Some (Seq.tail sequence, value)
+    }
+
+    let AbortSeqConsumer<'S, 'T>(): SeqConsumer<'S, 'T> = {
+        Consume = fun (_sequence: seq<'S>) -> None
+    }
+
+    type ConsumeAllError =
+        | SequenceEndedTooEarly
+        | SequenceNotReadToEnd
+
+    let ConsumeAll<'S, 'T>(sequence: seq<'S>) (seqConsumer: SeqConsumer<'S, 'T>)
+                              : Result<'T, ConsumeAllError> =
+        match seqConsumer.Consume sequence with
+        | None -> Error SequenceEndedTooEarly
+        | Some (consumedSequence, value) ->
+            if Seq.isEmpty consumedSequence then
+                Ok value
+            else
+                Error SequenceNotReadToEnd
+
+

--- a/src/ResultUtils/OptionCE.fs
+++ b/src/ResultUtils/OptionCE.fs
@@ -1,0 +1,70 @@
+namespace ResultUtils
+
+open System
+
+[<AutoOpen>]
+module OptionCE =
+  type OptionBuilder() =
+    member __.Return<'T>(value: 'T): Option<'T> =
+        Some value
+
+    member __.ReturnFrom<'T>(opt: Option<'T>): Option<'T> =
+        opt
+
+    member this.Zero(): Option<unit> =
+        Some ()
+
+    member __.Bind<'T, 'U>(opt: Option<'T>, binder: 'T -> Option<'U>)
+                              : Option<'U> =
+        Option.bind binder opt
+
+    member __.Delay<'T>(continuation: unit -> Option<'T>)
+                           : unit -> Option<'T> =
+        continuation
+
+    member __.Run<'T>(continuation: unit -> Option<'T>)
+                         : Option<'T> =
+        continuation()
+
+    member this.Combine<'T>(opt: Option<unit>, binder: unit -> Option<'T>)
+                               : Option<'T> =
+        this.Bind(opt, binder)
+
+    member this.TryWith<'T>(generator: unit -> Option<'T>, handler: exn -> Option<'T>)
+                               : Option<'T> =
+        try
+          this.Run generator
+        with
+        | e -> handler e
+
+    member this.TryFinally<'T>(generator: unit -> Option<'T>, final: unit -> unit)
+                                  : Option<'T> =
+        try
+            this.Run generator
+        finally
+            final()
+
+    member this.Using<'T, 'U when 'T :> IDisposable>(resource: 'T, binder: 'T -> Option<'U>)
+                                                        : Option<'U> =
+      this.TryFinally (
+        (fun () -> binder resource),
+        (fun () -> if not <| obj.ReferenceEquals(resource, null) then resource.Dispose ())
+      )
+
+    member this.While(guard: unit -> bool, generator: unit -> Option<unit>)
+                         : Option<unit> =
+      if not <| guard () then
+          this.Zero ()
+      else
+          this.Bind(this.Run generator, fun () -> this.While (guard, generator))
+
+    member this.For<'T>(sequence: #seq<'T>, binder: 'T -> Option<unit>)
+                           : Option<unit> =
+      this.Using(sequence.GetEnumerator (), fun enumerator ->
+        this.While(enumerator.MoveNext,
+          this.Delay(fun () -> binder enumerator.Current)))
+
+[<AutoOpen>]
+module OptionCEExtensions =
+  let option = OptionBuilder()
+

--- a/src/ResultUtils/ResultUtils.fsproj
+++ b/src/ResultUtils/ResultUtils.fsproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Option.fs" />
+    <Compile Include="OptionCE.fs" />
     <Compile Include="Result.fs" />
     <Compile Include="ResultCE.fs" />
     <Compile Include="ResultOp.fs" />


### PR DESCRIPTION
This commit adds the following:

* `getFundsFromForceClosingTransaction`

This function takes an on-chain transaction which spends the channel funds and tries to extract spendable utxos out of it. If successful, it returns a `TransactionBuilder` with txins added for each spendable output of the closing transaction and with the necessary keys and `BuilderExtension` added. To recover funds from a broadcast commitment transaction you just need to call this function, add outputs to the returned `TransactionBuilder` to send the money where you want it to go, then broadcast the transaction.

* `CommitmentToLocalBuilderExtension`

This is an NBitcoin `BuilderExtension` that tells `TransactionBuilder` how to recognise and sign lightning commitment transaction to_local outputs.  `getFundsFromForceClosingTransaction` adds this extension to the `TransactionBuilder` it returns if it's needed to sign the transaction.

* `SeqConsumer`

A computation expression which makes it easy to write code that consumes a sequence one element at a time.

* `OptionCE`

A computation expression for creation options. Similar to the `result` computation expression.