### PR TITLE
Re-add txout shuffling work-around

### DIFF
--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -304,6 +304,7 @@ module Transactions =
         let txb = network.CreateTransactionBuilder()
         txb.ShuffleOutputs <- false
         txb.ShuffleInputs <- false
+        txb.ShuffleRandom <- null
         txb
 
     let UINT32_MAX = 0xffffffffu


### PR DESCRIPTION
This NBitcoin issue: https://github.com/MetacoSA/NBitcoin/issues/931 still hasn't been fixed properly.

To avoid txout shuffling on closing transactions we still have to set `TransactionBuilder.ShuffleRandom` to `null`.