### PR TITLE
We shouldn't use hardcoded values here

### DIFF
--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -559,7 +559,7 @@ module RemoteForceClose =
         let remoteChannelPubKeys = commitments.RemoteParams.ChannelPubKeys
         let commitmentNumber =
             obscuredCommitmentNumber.Unobscure
-                false
+                commitments.LocalParams.IsFunder
                 localChannelPubKeys.PaymentBasepoint
                 remoteChannelPubKeys.PaymentBasepoint
         let perCommitmentSecretOpt =
@@ -643,7 +643,7 @@ module RemoteForceClose =
         let remoteChannelPubKeys = commitments.RemoteParams.ChannelPubKeys
         let commitmentNumber =
             obscuredCommitmentNumber.Unobscure
-                true
+                commitments.LocalParams.IsFunder
                 localChannelPubKeys.PaymentBasepoint
                 remoteChannelPubKeys.PaymentBasepoint
 


### PR DESCRIPTION
This code assumes that the person who broadcasted the commitment
transaction is always the funder and the person who tried to spend
the broadcasted remote commitment is always funder.
This passed our test because that's the only case we test in our
end-to-end tests.