### PR TITLE
Removing to_remote input from penalty Tx

### DIFF
--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -502,25 +502,6 @@ module RemoteForceClose =
             }
             |> Seq.sortWith TxOut.LexicographicCompare
 
-        let toRemoteIndexOpt =
-            outputs
-            |> Seq.tryFindIndex (fun out -> out.ScriptPubKey = toRemoteScriptPubKey)
-
-        match toRemoteIndexOpt with
-        | None -> ()
-        | Some toRemoteIndex ->
-            let localPaymentPrivKey =
-                perCommitmentPoint.DerivePaymentPrivKey localChannelPrivKeys.PaymentBasepointSecret
-
-            (transactionBuilder.AddKeys(localPaymentPrivKey.RawKey()))
-                .AddCoins(Coin
-                                (commitments.RemoteCommit.TxId.Value,
-                                toRemoteIndex |> uint32,
-                                toRemoteTxOut.Value,
-                                toRemoteTxOut.ScriptPubKey)) 
-                |> ignore
-            ()
-
         let toLocalIndexOpt =
             outputs
             |> Seq.tryFindIndex (fun out -> out.ScriptPubKey = toLocalWitScriptPubKey)

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -442,7 +442,7 @@ module RemoteForceClose =
                            (commitments: Commitments)
                            (localChannelPrivKeys: ChannelPrivKeys)
                            (network: Network) 
-                               : TransactionBuilder =
+                               : Option<TransactionBuilder> =
 
         let localChannelPubKeys = commitments.LocalParams.ChannelPubKeys
         let remoteChannelPubKeys = commitments.RemoteParams.ChannelPubKeys
@@ -507,7 +507,7 @@ module RemoteForceClose =
             |> Seq.tryFindIndex (fun out -> out.ScriptPubKey = toLocalWitScriptPubKey)
 
         match toLocalIndexOpt with
-        | None -> ()
+        | None -> None
         | Some toLocalIndex -> 
             let revocationPrivKey =
                 perCommitmentSecret.DeriveRevocationPrivKey localChannelPrivKeys.RevocationBasepointSecret
@@ -523,9 +523,9 @@ module RemoteForceClose =
                                 toLocalWitScriptPubKey,
                                 toLocalScriptPubKey))
                 |> ignore
-            ()
-
-        transactionBuilder
+            
+            transactionBuilder |> Some
+            
 
     let tryGetFundsFromRemoteCommitmentTx (commitments: Commitments)
                                           (localChannelPrivKeys: ChannelPrivKeys)


### PR DESCRIPTION
Let's not add to_remote coins into penalty tx since they are normal P2WPKH and they will be automatically added to our account balance also with removing to_remote input it's possible for a revoked transaction to not have a to_local outpoint (if the amount is less than dust), In this case, we don't have to create a penalty Tx
