### PR TITLE
Separate calculating commitment outpoint amounts logic

### DIFF
--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -194,7 +194,7 @@ type Commitments = {
             | Some _, Some htlcIn -> htlcIn.Add |> Some
             | _ -> None
 
-        member this.RemoteCommitAmount(): Amounts= 
+        member this.RemoteCommitAmount(): Amounts = 
             let commitFee = Transactions.commitTxFee 
                                 this.RemoteParams.DustLimitSatoshis 
                                 this.RemoteCommit.Spec
@@ -204,7 +204,7 @@ type Commitments = {
                     (this.RemoteCommit.Spec.ToLocal.Satoshi
                      |> Money.Satoshis),
                     (this.RemoteCommit.Spec.ToRemote.Satoshi
-                     |> Money.Satoshis) - commitFee 
+                     |> Money.Satoshis) - commitFee
                 else
                     (this.RemoteCommit.Spec.ToLocal.Satoshi
                      |> Money.Satoshis) - commitFee,
@@ -213,7 +213,7 @@ type Commitments = {
 
             {Amounts.ToLocal = toLocalAmount; ToRemote = toRemoteAmount}
 
-        member this.LocalCommitAmount(): Amounts= 
+        member this.LocalCommitAmount(): Amounts = 
             let commitFee = Transactions.commitTxFee 
                                 this.LocalParams.DustLimitSatoshis 
                                 this.LocalCommit.Spec
@@ -221,14 +221,14 @@ type Commitments = {
             let (toLocalAmount, toRemoteAmount) =
                 if (this.LocalParams.IsFunder) then
                     (this.LocalCommit.Spec.ToLocal.Satoshi
-                     |> Money.Satoshis),
-                    (this.LocalCommit.Spec.ToRemote.Satoshi
-                     |> Money.Satoshis) - commitFee 
-                else
-                    (this.LocalCommit.Spec.ToLocal.Satoshi
                      |> Money.Satoshis) - commitFee,
                     (this.LocalCommit.Spec.ToRemote.Satoshi
                      |> Money.Satoshis)
+                else
+                    (this.LocalCommit.Spec.ToLocal.Satoshi
+                     |> Money.Satoshis),
+                    (this.LocalCommit.Spec.ToRemote.Satoshi
+                     |> Money.Satoshis) - commitFee
 
             {Amounts.ToLocal = toLocalAmount; ToRemote = toRemoteAmount}
                     

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -474,33 +474,19 @@ module RemoteForceClose =
 
         let toLocalWitScriptPubKey = toLocalScriptPubKey.WitHash.ScriptPubKey
 
-        let commitFee = commitTxFee 
-                            commitments.RemoteParams.DustLimitSatoshis 
-                            commitments.RemoteCommit.Spec
-
-        let (toLocalAmount, toRemoteAmount) =
-            if (commitments.LocalParams.IsFunder) then
-                (commitments.RemoteCommit.Spec.ToLocal.Satoshi
-                 |> Money.Satoshis),
-                (commitments.RemoteCommit.Spec.ToRemote.Satoshi
-                 |> Money.Satoshis) - commitFee
-            else
-                (commitments.RemoteCommit.Spec.ToLocal.Satoshi
-                 |> Money.Satoshis) - commitFee,
-                (commitments.RemoteCommit.Spec.ToRemote.Satoshi
-                 |> Money.Satoshis)
+        let amounts = commitments.RemoteCommitAmount()
 
         let toLocalTxOut = 
-            TxOut(toLocalAmount, toLocalWitScriptPubKey)
+            TxOut(amounts.ToLocal, toLocalWitScriptPubKey)
         let toRemoteTxOut = 
-            TxOut(toRemoteAmount, toRemoteScriptPubKey)
+            TxOut(amounts.ToRemote, toRemoteScriptPubKey)
 
         let outputs = 
             seq {
-                if toLocalAmount > commitments.RemoteParams.DustLimitSatoshis then
+                if amounts.ToLocal > commitments.RemoteParams.DustLimitSatoshis then
                     yield toLocalTxOut
 
-                if toRemoteAmount > commitments.RemoteParams.DustLimitSatoshis then
+                if amounts.ToRemote > commitments.RemoteParams.DustLimitSatoshis then
                     yield toRemoteTxOut
             }
             |> Seq.sortWith TxOut.LexicographicCompare


### PR DESCRIPTION
Creates a function to calculate outpoint amounts 

Currently, we need to use a couple of internal functions 
to calculate commitment outpoints amounts so we want 
to have this to not only make a public API for this but also
simplify it and reducing the amount of duplicated code