### PR TITLE
Channel refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         dotnet run --project tests/DotNetLightning.Core.Tests
     - name: Run other tests
       run: |
-        dotnet test
+        dotnet test --filter FullyQualifiedName\!~Macaroons
 
   build_with_fsharp_from_mono:
     runs-on: ubuntu-18.04

--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -32,10 +32,5 @@ jobs:
     - name: Upload nuget packages (Portability)
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | head -c 7` -p:Portability=True
-        dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
-
-    - name: Upload nuget packages (native)
-      run: |
-        bash -c "dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date$(date +%Y%m%d-%H%M).git-$(git rev-parse --short=7 HEAD)-${{ matrix.RID }}"
-        bash -c "dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.Core.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json"
+        dotnet pack ./src/DotNetLightning.Core -p:Configuration=Release --version-suffix date`date +%Y%m%d-%H%M`-git-`echo $GITHUB_SHA | head -c 7` -p:BouncyCastle=True
+        dotnet nuget push ./src/DotNetLightning.Core/bin/Release/DotNetLightning.Kiss.1*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,21 +1,17 @@
-MIT License
+AGPL License
 
 Copyright (c) 2020 Joe Miyamoto <joemphilips@gmail.com>
+Copyright (c) 2020 Node Effect Ltd <andres@nodeffect.com>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -4,17 +4,12 @@ The main entry point is `DotNetLightning.Core`.
 
 ## Installation
 
-The package is compiled and published with two variants
+The package is compiled and published in nuget:
 
-* [`DotNetLightning`](https://www.nuget.org/packages/DotNetLightning/)
-  * This does not use native bindings for cryptographic operations.
-  * This is the one you want to use if you run your code everywhere, but possibly slower than below.
-* [`DotNetLightning.Core`](https://www.nuget.org/packages/DotNetLightning.Core/)
-  * This uses a pre-compiled `libsodium` for cryptographic operations.
-  * It only supports `windows`, `mac` and `linux` environments.
-  * This is what you want if you need performance and the environments above are the only ones you are planning to support.
-  
-run `dotnet add package` with the one you want.
+* [`DotNetLightning.Kiss`](https://www.nuget.org/packages/DotNetLightning.Kiss/)
+
+It does not use native bindings for cryptographic operations.
+
 Currently it is in alpha, so you probably want to install a latest version by specifying it with `--version`.
 The version is prefixed with git commit hash and date. Please take a look at the nuget page.
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -860,6 +860,48 @@ and Channel = {
         return channel, revokeAndACKMsg
     }
 
+    member self.ApplyRevokeAndACK (msg: RevokeAndACKMsg)
+                                      : Result<Channel, ChannelError> = result {
+        let! remoteNextCommitInfo =
+            self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyRevokeAndACK"
+        let cm = self.Commitments
+        match remoteNextCommitInfo with
+        | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> cm.RemoteCommit.RemotePerCommitmentPoint) ->
+            let errorMsg = sprintf "Invalid revoke_and_ack %A; must be %A" msg.PerCommitmentSecret cm.RemoteCommit.RemotePerCommitmentPoint
+            return! Error <| invalidRevokeAndACK msg errorMsg
+        | RemoteNextCommitInfo.Revoked _ ->
+            let errorMsg = sprintf "Unexpected revocation"
+            return! Error <| invalidRevokeAndACK msg errorMsg
+        | RemoteNextCommitInfo.Waiting theirNextCommit ->
+            let remotePerCommitmentSecretsOpt =
+                cm.RemotePerCommitmentSecrets.InsertPerCommitmentSecret
+                    cm.RemoteCommit.Index
+                    msg.PerCommitmentSecret
+            match remotePerCommitmentSecretsOpt with
+            | Error err -> return! Error <| invalidRevokeAndACK msg err.Message
+            | Ok remotePerCommitmentSecrets ->
+                let commitments1 = {
+                    cm with
+                        LocalChanges = {
+                            cm.LocalChanges with
+                                Signed = [];
+                                ACKed = cm.LocalChanges.ACKed @ cm.LocalChanges.Signed
+                        }
+                        RemoteChanges = {
+                            cm.RemoteChanges with
+                                Signed = []
+                        }
+                        RemoteCommit = theirNextCommit
+                        RemotePerCommitmentSecrets = remotePerCommitmentSecrets
+                }
+                return {
+                    self with
+                        Commitments = commitments1
+                        RemoteNextCommitInfo =
+                            Some <| RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
+                }
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -913,42 +955,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | ApplyRevokeAndACK msg ->
-            result {
-                let! remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "ApplyRevokeAndACK"
-                let cm = cs.Commitments
-                match remoteNextCommitInfo with
-                | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> cm.RemoteCommit.RemotePerCommitmentPoint) ->
-                    let errorMsg = sprintf "Invalid revoke_and_ack %A; must be %A" msg.PerCommitmentSecret cm.RemoteCommit.RemotePerCommitmentPoint
-                    return! Error <| invalidRevokeAndACK msg errorMsg
-                | RemoteNextCommitInfo.Revoked _ ->
-                    let errorMsg = sprintf "Unexpected revocation"
-                    return! Error <| invalidRevokeAndACK msg errorMsg
-                | RemoteNextCommitInfo.Waiting theirNextCommit ->
-                    let remotePerCommitmentSecretsOpt =
-                        cm.RemotePerCommitmentSecrets.InsertPerCommitmentSecret
-                            cm.RemoteCommit.Index
-                            msg.PerCommitmentSecret
-                    match remotePerCommitmentSecretsOpt with
-                    | Error err -> return! Error <| invalidRevokeAndACK msg err.Message
-                    | Ok remotePerCommitmentSecrets ->
-                        let commitments1 = {
-                            cm with
-                                LocalChanges = {
-                                    cm.LocalChanges with
-                                        Signed = [];
-                                        ACKed = cm.LocalChanges.ACKed @ cm.LocalChanges.Signed
-                                }
-                                RemoteChanges = {
-                                    cm.RemoteChanges with
-                                        Signed = []
-                                }
-                                RemoteCommit = theirNextCommit
-                                RemotePerCommitmentSecrets = remotePerCommitmentSecrets
-                        }
-                        return [ WeAcceptedRevokeAndACK(commitments1, msg.NextPerCommitmentPoint) ]
-            }
         | ChannelCommand.Close localShutdownScriptPubKey ->
             result {
                 if cs.NegotiatingState.LocalRequestedShutdown.IsSome then
@@ -1164,15 +1170,6 @@ module Channel =
 
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
-        // ----- normal operation --------
-        | WeAcceptedRevokeAndACK(newCommitments, remoteNextPerCommitmentPoint) ->
-            {
-                c with
-                    Commitments = newCommitments
-                    RemoteNextCommitInfo =
-                        Some <| RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint
-            }
-
         // -----  closing ------
         | AcceptedOperationShutdown(_msg, shutdownScriptPubKey) ->
             {

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -816,6 +816,33 @@ and Channel = {
         }
     }
 
+    member self.SignCommitment(): Result<Channel * Option<CommitmentSignedMsg>, ChannelError> = result {
+        let cm = self.Commitments
+        let! remoteNextCommitInfo =
+            self.RemoteNextCommitInfoIfFundingLockedNormal "SignCommit"
+        match remoteNextCommitInfo with
+        | _ when (cm.LocalHasChanges() |> not) ->
+            // Ignore SignCommitment Command (nothing to sign)
+            return self, None
+        | RemoteNextCommitInfo.Revoked _ ->
+            let! commitmentSignedMsg, newCommitments, newRemoteCommit =
+                Commitments.sendCommit
+                    self.ChannelPrivKeys
+                    cm
+                    self.StaticChannelConfig
+                    remoteNextCommitInfo
+            let channel = {
+                self with
+                    Commitments = newCommitments
+                    RemoteNextCommitInfo =
+                        Some <| RemoteNextCommitInfo.Waiting newRemoteCommit
+            }
+            return channel, Some commitmentSignedMsg
+        | RemoteNextCommitInfo.Waiting _ ->
+            // Already in the process of signing
+            return self, None
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -869,26 +896,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | SignCommitment ->
-            let cm = cs.Commitments
-            result {
-                let! remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "SignCommit"
-                match remoteNextCommitInfo with
-                | _ when (cm.LocalHasChanges() |> not) ->
-                    // Ignore SignCommitment Command (nothing to sign)
-                    return []
-                | RemoteNextCommitInfo.Revoked _ ->
-                    return!
-                        Commitments.sendCommit
-                            cs.ChannelPrivKeys
-                            cm
-                            cs.StaticChannelConfig
-                            remoteNextCommitInfo
-                | RemoteNextCommitInfo.Waiting _ ->
-                    // Already in the process of signing
-                    return []
-            }
         | ApplyCommitmentSigned msg ->
             result {
                 let! _remoteNextCommitInfo =
@@ -1152,13 +1159,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // ----- normal operation --------
-        | WeAcceptedOperationSign(_msg, newCommitments, waitingForRevocation) ->
-            {
-                c with
-                    Commitments = newCommitments
-                    RemoteNextCommitInfo =
-                        Some <| RemoteNextCommitInfo.Waiting waitingForRevocation
-            }
         | WeAcceptedCommitmentSigned(_msg, newCommitments) ->
             { c with Commitments = newCommitments }
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -461,7 +461,13 @@ module Channel =
 
         let handleMutualClose (closingTx: FinalizedTx, d: NegotiatingData) =
             let nextData =
-                ClosingData.Create (d.ChannelId, d.Commitments, None, DateTime.Now, (d.ClosingTxProposed |> List.collect id |> List.map (fun tx -> tx.UnsignedTx)), closingTx)
+                ClosingData.Create
+                    d.ChannelId
+                    d.Commitments
+                    None
+                    DateTime.Now
+                    (d.ClosingTxProposed |> List.collect id |> List.map (fun tx -> tx.UnsignedTx))
+                    closingTx
             [ MutualClosePerformed (closingTx, nextData) ]
             |> Ok
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -35,6 +35,7 @@ type ChannelWaitingForFundingSigned = {
             Transactions.checkTxFinalized signedLocalCommitTx CommitTx.WhichInput sigPairs |> expectTransactionError
         let commitments = {
             ProposedLocalChanges = List.empty
+            ProposedRemoteChanges = List.empty
             LocalChanges = LocalChanges.Zero
             RemoteChanges = RemoteChanges.Zero
             LocalNextHTLCId = HTLCId.Zero
@@ -126,6 +127,7 @@ and ChannelWaitingForFundingCreated = {
                 self.FundingSatoshis
         let commitments = {
             ProposedLocalChanges = List.empty
+            ProposedRemoteChanges = List.empty
             LocalChanges = LocalChanges.Zero
             RemoteChanges = RemoteChanges.Zero
             LocalNextHTLCId = HTLCId.Zero
@@ -617,7 +619,7 @@ and Channel = {
         let commitments1 = self.Commitments.AddRemoteProposal(msg)
         let! reduced =
             self.SavedChannelState.LocalCommit.Spec.Reduce
-                (commitments1.LocalChanges.ACKed, commitments1.RemoteChanges.Proposed)
+                (commitments1.LocalChanges.ACKed, commitments1.ProposedRemoteChanges)
             |> expectTransactionError
         do!
             Validation.checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec
@@ -696,7 +698,7 @@ and Channel = {
         let! reduced =
             self.SavedChannelState.LocalCommit.Spec.Reduce (
                 commitments1.LocalChanges.ACKed,
-                commitments1.RemoteChanges.Proposed
+                commitments1.ProposedRemoteChanges
             ) |> expectTransactionError
         do!
             Validation.checkTheirUpdateAddHTLCIsAcceptableWithCurrentSpec

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -674,7 +674,7 @@ module Channel =
 
                 let remoteCommit1 =
                     match state.RemoteNextCommitInfo with
-                    | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
+                    | RemoteNextCommitInfo.Waiting nextRemoteCommit -> nextRemoteCommit
                     | RemoteNextCommitInfo.Revoked _info -> commitments1.RemoteCommit
                 let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
                 do! Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 payment
@@ -718,7 +718,7 @@ module Channel =
                 // we need to base the next current commitment on the last sig we sent, even if we didn't yet receive their revocation
                 let remoteCommit1 =
                     match state.RemoteNextCommitInfo with
-                    | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
+                    | RemoteNextCommitInfo.Waiting nextRemoteCommit -> nextRemoteCommit
                     | RemoteNextCommitInfo.Revoked _info -> commitments1.RemoteCommit
                 let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
                 do! Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec reduced commitments1 add
@@ -793,7 +793,7 @@ module Channel =
             | RemoteNextCommitInfo.Revoked _ ->
                 let errorMsg = sprintf "Unexpected revocation"
                 invalidRevokeAndACK msg errorMsg
-            | RemoteNextCommitInfo.Waiting({ NextRemoteCommit = theirNextCommit }) ->
+            | RemoteNextCommitInfo.Waiting theirNextCommit ->
                 let remotePerCommitmentSecretsOpt =
                     cm.RemotePerCommitmentSecrets.InsertPerCommitmentSecret
                         cm.RemoteCommit.Index

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -883,7 +883,8 @@ module Channel =
 
         | WeAcceptedOperationUpdateFee(_msg, newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
-        | WeAcceptedUpdateFee(_msg), ChannelState.Normal _d -> c
+        | WeAcceptedUpdateFee(_msg, newCommitments), ChannelState.Normal normalData ->
+            { c with State = ChannelState.Normal({ normalData with Commitments = newCommitments }) }
 
         | WeAcceptedOperationSign(_msg, newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -1174,9 +1174,7 @@ and Channel = {
         let remoteCommit =
             match remoteNextCommitInfo with
             | Some (RemoteNextCommitInfo.Waiting nextRemoteCommit) -> nextRemoteCommit
-            | Some (RemoteNextCommitInfo.Revoked _info) -> savedChannelState.RemoteCommit
-            // TODO: This could return a proper error, or report the full balance
-            | None -> failwith "funding is not locked"
+            | _ -> savedChannelState.RemoteCommit
         let reducedRes =
             remoteCommit.Spec.Reduce(
                 savedChannelState.RemoteChanges.ACKed,

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -29,7 +29,7 @@ type ChannelWaitingForFundingSigned = {
     LocalSpec: CommitmentSpec
     LocalCommitTx: CommitTx
     RemoteCommit: RemoteCommit
-    ChannelFlags: uint8
+    ChannelFlags: ChannelFlags
     LastSent: FundingCreatedMsg
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     RemoteShutdownScriptPubKey: Option<ShutdownScriptPubKey>
@@ -114,7 +114,7 @@ and ChannelWaitingForFundingCreated = {
     PushMSat: LNMoney
     InitialFeeRatePerKw: FeeRatePerKw
     RemoteFirstPerCommitmentPoint: PerCommitmentPoint
-    ChannelFlags: uint8
+    ChannelFlags: ChannelFlags
 } with
     member self.ApplyFundingCreated (msg: FundingCreatedMsg)
                                         : Result<FundingSignedMsg * Channel, ChannelError> = result {
@@ -223,7 +223,7 @@ and ChannelWaitingForFundingTx = {
     InitFeeRatePerKw: FeeRatePerKw
     LocalParams: LocalParams
     RemoteInit: InitMsg
-    ChannelFlags: uint8
+    ChannelFlags: ChannelFlags
 } with
     member self.CreateFundingTx (fundingTx: FinalizedTx)
                                 (outIndex: TxOutIndex)
@@ -301,7 +301,7 @@ and ChannelWaitingForAcceptChannel = {
     InitFeeRatePerKw: FeeRatePerKw
     LocalParams: LocalParams
     RemoteInit: InitMsg
-    ChannelFlags: uint8
+    ChannelFlags: ChannelFlags
 } with
     member self.ApplyAcceptChannel (msg: AcceptChannelMsg)
                                        : Result<IDestination * Money * ChannelWaitingForFundingTx, ChannelError> = result {
@@ -369,7 +369,7 @@ and Channel = {
                                   initFeeRatePerKw: FeeRatePerKw,
                                   localParams: LocalParams,
                                   remoteInit: InitMsg,
-                                  channelFlags: uint8,
+                                  channelFlags: ChannelFlags,
                                   channelPrivKeys: ChannelPrivKeys
                                  ): Result<OpenChannelMsg * ChannelWaitingForAcceptChannel, ChannelError> =
             let openChannelMsgToSend: OpenChannelMsg = {

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -24,6 +24,7 @@ type ChannelWaitingForFundingSigned = {
     ChannelId: ChannelId
     LocalParams: LocalParams
     RemoteParams: RemoteParams
+    RemoteChannelPubKeys: ChannelPubKeys
     FundingTx: FinalizedTx
     LocalSpec: CommitmentSpec
     LocalCommitTx: CommitTx
@@ -35,9 +36,8 @@ type ChannelWaitingForFundingSigned = {
 } with
     member self.ApplyFundingSigned (msg: FundingSignedMsg)
                                        : Result<FinalizedTx * Channel, ChannelError> = result {
-        let remoteChannelKeys = self.RemoteParams.ChannelPubKeys
         let! finalizedLocalCommitTx =
-            let theirFundingPk = remoteChannelKeys.FundingPubKey.RawPubKey()
+            let theirFundingPk = self.RemoteChannelPubKeys.FundingPubKey.RawPubKey()
             let _, signedLocalCommitTx =
                 self.ChannelPrivKeys.SignWithFundingPrivKey self.LocalCommitTx.Value
             let remoteSigPairOfLocalTx = (theirFundingPk,  TransactionSignature(msg.Signature.Value, SigHash.All))
@@ -47,14 +47,15 @@ type ChannelWaitingForFundingSigned = {
             IsFunder = true
             LocalParams = self.LocalParams
             RemoteParams = self.RemoteParams
+            RemoteChannelPubKeys = self.RemoteChannelPubKeys
             ChannelFlags = self.ChannelFlags
             FundingScriptCoin =
                 let amount =
                     let index = int self.LastSent.FundingOutputIndex.Value
                     self.FundingTx.Value.Outputs.[index].Value
                 ChannelHelpers.getFundingScriptCoin
-                    self.LocalParams.ChannelPubKeys.FundingPubKey
-                    remoteChannelKeys.FundingPubKey
+                    (self.ChannelPrivKeys.FundingPrivKey.FundingPubKey())
+                    self.RemoteChannelPubKeys.FundingPubKey
                     self.LastSent.FundingTxId
                     self.LastSent.FundingOutputIndex
                     amount
@@ -114,6 +115,7 @@ and ChannelWaitingForFundingCreated = {
     TemporaryFailure: ChannelId
     LocalParams: LocalParams
     RemoteParams: RemoteParams
+    RemoteChannelPubKeys: ChannelPubKeys
     FundingSatoshis: Money
     PushMSat: LNMoney
     InitialFeeRatePerKw: FeeRatePerKw
@@ -122,13 +124,14 @@ and ChannelWaitingForFundingCreated = {
 } with
     member self.ApplyFundingCreated (msg: FundingCreatedMsg)
                                         : Result<FundingSignedMsg * Channel, ChannelError> = result {
-        let remoteChannelKeys = self.RemoteParams.ChannelPubKeys
         let! (localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
             let firstPerCommitmentPoint =
                 self.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint
                     CommitmentNumber.FirstCommitment
             ChannelHelpers.makeFirstCommitTxs
                 false
+                (self.ChannelPrivKeys.ToChannelPubKeys())
+                self.RemoteChannelPubKeys
                 self.LocalParams
                 self.RemoteParams
                 self.FundingSatoshis
@@ -143,7 +146,7 @@ and ChannelWaitingForFundingCreated = {
         let _s, signedLocalCommitTx =
             self.ChannelPrivKeys.SignWithFundingPrivKey localCommitTx.Value
         let remoteTxSig = TransactionSignature(msg.Signature.Value, SigHash.All)
-        let theirSigPair = (remoteChannelKeys.FundingPubKey.RawPubKey(), remoteTxSig)
+        let theirSigPair = (self.RemoteChannelPubKeys.FundingPubKey.RawPubKey(), remoteTxSig)
         let sigPairs = seq [ theirSigPair ]
         let! finalizedCommitTx =
             Transactions.checkTxFinalized (signedLocalCommitTx) (localCommitTx.WhichInput) sigPairs
@@ -154,11 +157,12 @@ and ChannelWaitingForFundingCreated = {
             IsFunder = false
             LocalParams = self.LocalParams
             RemoteParams = self.RemoteParams
+            RemoteChannelPubKeys = self.RemoteChannelPubKeys
             ChannelFlags = self.ChannelFlags
             FundingScriptCoin =
                 ChannelHelpers.getFundingScriptCoin
-                    self.LocalParams.ChannelPubKeys.FundingPubKey
-                    remoteChannelKeys.FundingPubKey
+                    (self.ChannelPrivKeys.FundingPrivKey.FundingPubKey())
+                    self.RemoteChannelPubKeys.FundingPubKey
                     msg.FundingTxId
                     msg.FundingOutputIndex
                     self.FundingSatoshis
@@ -225,6 +229,7 @@ and ChannelWaitingForFundingTx = {
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     LastReceived: AcceptChannelMsg
     TemporaryChannelId: ChannelId
+    RemoteChannelPubKeys: ChannelPubKeys
     FundingSatoshis: Money
     PushMSat: LNMoney
     InitFeeRatePerKw: FeeRatePerKw
@@ -244,6 +249,8 @@ and ChannelWaitingForFundingTx = {
         let! (_localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
             ChannelHelpers.makeFirstCommitTxs
                 true
+                (self.ChannelPrivKeys.ToChannelPubKeys())
+                self.RemoteChannelPubKeys
                 localParams
                 remoteParams
                 self.FundingSatoshis
@@ -275,6 +282,7 @@ and ChannelWaitingForFundingTx = {
             ChannelId = channelId
             LocalParams = localParams
             RemoteParams = remoteParams
+            RemoteChannelPubKeys = self.RemoteChannelPubKeys
             FundingTx = fundingTx
             LocalSpec = commitmentSpec
             LocalCommitTx = localCommitTx
@@ -317,6 +325,13 @@ and ChannelWaitingForAcceptChannel = {
             Scripts.funding
                 (self.ChannelPrivKeys.ToChannelPubKeys().FundingPubKey)
                 msg.FundingPubKey
+        let remoteChannelPubKeys = {
+            FundingPubKey = msg.FundingPubKey
+            RevocationBasepoint = msg.RevocationBasepoint
+            PaymentBasepoint = msg.PaymentBasepoint
+            DelayedPaymentBasepoint = msg.DelayedPaymentBasepoint
+            HtlcBasepoint = msg.HTLCBasepoint
+        }
         let destination = redeem.WitHash :> IDestination
         let amount = self.FundingSatoshis
         let channelWaitingForFundingTx = {
@@ -329,6 +344,7 @@ and ChannelWaitingForAcceptChannel = {
             LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
             LastReceived = msg
             TemporaryChannelId = self.TemporaryChannelId
+            RemoteChannelPubKeys = remoteChannelPubKeys
             FundingSatoshis = self.FundingSatoshis
             PushMSat = self.PushMSat
             InitFeeRatePerKw = self.InitFeeRatePerKw
@@ -451,6 +467,13 @@ and Channel = {
                     FirstPerCommitmentPoint = firstPerCommitmentPoint
                     ShutdownScriptPubKey = shutdownScriptPubKey
                 }
+                let remoteChannelPubKeys = {
+                    FundingPubKey = openChannelMsg.FundingPubKey
+                    RevocationBasepoint = openChannelMsg.RevocationBasepoint
+                    PaymentBasepoint = openChannelMsg.PaymentBasepoint
+                    DelayedPaymentBasepoint = openChannelMsg.DelayedPaymentBasepoint
+                    HtlcBasepoint = openChannelMsg.HTLCBasepoint
+                }
                 let remoteParams = RemoteParams.FromOpenChannel remoteInit openChannelMsg
                 let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
                 let nodeSecret = nodeMasterPrivKey.NodeSecret()
@@ -467,6 +490,7 @@ and Channel = {
                     TemporaryFailure = openChannelMsg.TemporaryChannelId
                     LocalParams = localParams
                     RemoteParams = remoteParams
+                    RemoteChannelPubKeys = remoteChannelPubKeys
                     FundingSatoshis = openChannelMsg.FundingSatoshis
                     PushMSat = openChannelMsg.PushMSat
                     InitialFeeRatePerKw = openChannelMsg.FeeRatePerKw
@@ -897,12 +921,14 @@ module Channel =
                         // we have to send first closing_signed msg iif we are the funder
                         if (cm.IsFunder) then
                             let! (closingTx, closingSignedMsg) =
-                                Closing.makeFirstClosingTx (cs.ChannelPrivKeys,
-                                                            cm,
-                                                            localShutdown.ScriptPubKey,
-                                                            msg.ScriptPubKey,
-                                                            cs.FeeEstimator,
-                                                            cs.Network)
+                                Closing.makeFirstClosingTx (
+                                    cs.ChannelPrivKeys,
+                                    cm,
+                                    localShutdown.ScriptPubKey,
+                                    msg.ScriptPubKey,
+                                    cs.FeeEstimator,
+                                    cs.Network
+                                )
                             let nextState = {
                                 LocalShutdown = localShutdown
                                 RemoteShutdown = msg
@@ -971,7 +997,7 @@ module Channel =
         | Negotiating state, ApplyClosingSigned msg ->
             result {
                 let cm = cs.Commitments
-                let remoteChannelKeys = cm.RemoteParams.ChannelPubKeys
+                let remoteChannelKeys = cm.RemoteChannelPubKeys
                 let lastCommitFeeSatoshi =
                     cm.FundingScriptCoin.TxOut.Value - (cm.LocalCommit.PublishableTxs.CommitTx.Value.TotalOut)
                 do! checkRemoteProposedHigherFeeThanBefore lastCommitFeeSatoshi msg.FeeSatoshis

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -1005,99 +1005,9 @@ module Channel =
                             }
                             return [ AcceptedShutdownWhenNoPendingHTLCs(None, nextState) ]
                     else
-                        let nextState = {
-                            LocalShutdown = localShutdown
-                            RemoteShutdown = msg
-                            RemoteNextCommitInfo = state.RemoteNextCommitInfo
-                        }
-                        return [ AcceptedShutdownWhenWeHavePendingHTLCs(nextState) ]
+                        return [ AcceptedShutdownWhenWeHavePendingHTLCs(localShutdown, msg) ]
             }
         // ----------- closing ---------
-        | Shutdown state, FulfillHTLC op ->
-            result {
-                let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLocked state.RemoteNextCommitInfo "FulfillHTLC"
-                let! t = Commitments.sendFulfill op cs.Commitments remoteNextCommitInfo
-                return [ WeAcceptedOperationFulfillHTLC t ]
-            }
-        | Shutdown state, ApplyUpdateFulfillHTLC msg ->
-            result {
-                let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLocked
-                        state.RemoteNextCommitInfo
-                        "ApplyUpdateFulfillHTLC"
-                return! Commitments.receiveFulfill msg cs.Commitments remoteNextCommitInfo
-            }
-        | Shutdown state, FailHTLC op ->
-            result {
-                let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLocked state.RemoteNextCommitInfo "FailHTLC"
-                return! Commitments.sendFail cs.NodeSecret op cs.Commitments remoteNextCommitInfo
-            }
-        | Shutdown state, FailMalformedHTLC op ->
-            result {
-                let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLocked
-                        state.RemoteNextCommitInfo
-                        "FailMalformedHTLC"
-                return! Commitments.sendFailMalformed op cs.Commitments remoteNextCommitInfo
-            }
-        | Shutdown state, ApplyUpdateFailMalformedHTLC msg ->
-            result {
-                let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLocked
-                        state.RemoteNextCommitInfo
-                        "ApplyUpdateFailMalformedHTLC"
-                return!
-                    Commitments.receiveFailMalformed msg cs.Commitments remoteNextCommitInfo
-            }
-        | Shutdown state, UpdateFee op ->
-            result {
-                let! _remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLocked state.RemoteNextCommitInfo "UpdateFee"
-                return! cs.Commitments |> Commitments.sendFee op
-            }
-        | Shutdown state, ApplyUpdateFee msg ->
-            result {
-                let! _remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLocked
-                        state.RemoteNextCommitInfo
-                        "ApplyUpdateFee"
-                let localFeerate =
-                    cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
-                return! cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
-            }
-        | Shutdown state, SignCommitment ->
-            let cm = cs.Commitments
-            result {
-                let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLocked state.RemoteNextCommitInfo "SignCommit"
-                match remoteNextCommitInfo with
-                | _ when (not <| cm.LocalHasChanges()) ->
-                    // nothing to sign
-                    return []
-                | RemoteNextCommitInfo.Revoked _ ->
-                    return!
-                        Commitments.sendCommit
-                            cs.ChannelPrivKeys
-                            cs.Network
-                            cm
-                            remoteNextCommitInfo
-                | RemoteNextCommitInfo.Waiting _waitForRevocation ->
-                    // Already in the process of signing.
-                    return []
-            }
-        | Shutdown state, ApplyCommitmentSigned msg ->
-            result {
-                let! _remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLocked
-                        state.RemoteNextCommitInfo
-                        "ApplyCommitmentSigned"
-                return! Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network cs.Commitments
-            }
-        | Shutdown _state, ApplyRevokeAndACK _msg ->
-            failwith "not implemented"
-
         | Negotiating state, ApplyClosingSigned msg ->
             result {
                 let cm = cs.Commitments
@@ -1301,8 +1211,15 @@ module Channel =
             }
         | AcceptedShutdownWhenNoPendingHTLCs(_maybeMsg, nextState), ChannelState.Normal _d ->
             { c with State = Negotiating nextState }
-        | AcceptedShutdownWhenWeHavePendingHTLCs(nextState), ChannelState.Normal _d ->
-            { c with State = Shutdown nextState }
+        | AcceptedShutdownWhenWeHavePendingHTLCs(localShutdown, remoteShutdown), ChannelState.Normal normalData ->
+            {
+                c with
+                    State = ChannelState.Normal {
+                        normalData with
+                            LocalShutdown = Some localShutdown
+                            RemoteShutdown = Some remoteShutdown
+                    }
+            }
         | MutualClosePerformed (_txToPublish, nextState), ChannelState.Negotiating _d ->
             { c with State = Closing nextState }
         | WeProposedNewClosingSigned(_msg, nextState), ChannelState.Negotiating _d ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -630,7 +630,6 @@ module Channel =
                 }
                 let nextState = {
                     ShortChannelId = shortChannelId
-                    TheirMessage = None
                     HaveWeSentFundingLocked = false
                 }
                 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -798,6 +798,24 @@ and Channel = {
         return channel, updateFeeMsg
     }
 
+    member self.ApplyUpdateFee (msg: UpdateFeeMsg)
+                                   : Result<Channel, ChannelError> = result {
+        let! _remoteNextCommitInfo =
+            self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyUpdateFee"
+        let localFeerate = self.ChannelOptions.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
+        let! newCommitments =
+            Commitments.receiveFee
+                self.ChannelOptions
+                localFeerate
+                msg
+                self.StaticChannelConfig
+                self.Commitments
+        return {
+            self with
+                Commitments = newCommitments
+        }
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -851,19 +869,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | ApplyUpdateFee msg ->
-            result {
-                let! _remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "ApplyUpdateFee"
-                let localFeerate = cs.ChannelOptions.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
-                return!
-                    Commitments.receiveFee
-                        cs.ChannelOptions
-                        localFeerate
-                        msg
-                        cs.StaticChannelConfig
-                        cs.Commitments
-            }
         | SignCommitment ->
             let cm = cs.Commitments
             result {
@@ -1147,9 +1152,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // ----- normal operation --------
-        | WeAcceptedUpdateFee(_msg, newCommitments) ->
-            { c with Commitments = newCommitments }
-
         | WeAcceptedOperationSign(_msg, newCommitments, waitingForRevocation) ->
             {
                 c with

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -974,10 +974,10 @@ module Channel =
                                 RemoteNextCommitInfo = state.RemoteNextCommitInfo
                                 LocalShutdown = localShutdownScriptPubKey
                                 RemoteShutdown = msg.ScriptPubKey
-                                ClosingTxProposed = [[{
+                                ClosingTxProposed = [ Some {
                                     ClosingTxProposed.UnsignedTx = closingTx
                                     LocalClosingSigned = closingSignedMsg
-                                }]]
+                                }]
                                 MaybeBestUnpublishedTx = None
                             }
                             return [
@@ -991,7 +991,7 @@ module Channel =
                                 RemoteNextCommitInfo = state.RemoteNextCommitInfo
                                 LocalShutdown = localShutdownScriptPubKey
                                 RemoteShutdown = msg.ScriptPubKey
-                                ClosingTxProposed = [ [] ]
+                                ClosingTxProposed = [ None ]
                                 MaybeBestUnpublishedTx = None
                             }
                             return [ AcceptedShutdownWhenNoPendingHTLCs(None, nextState) ]
@@ -1042,11 +1042,11 @@ module Channel =
                 let maybeLocalFee =
                     state.ClosingTxProposed
                     |> List.tryHead
-                    |> Option.bind (List.tryHead)
+                    |> Option.bind id
                     |> Option.map (fun v -> v.LocalClosingSigned.FeeSatoshis)
                 let areWeInDeal = Some(msg.FeeSatoshis) = maybeLocalFee
                 let hasTooManyNegotiationDone =
-                    (state.ClosingTxProposed |> List.collect (id) |> List.length) >= cs.ChannelOptions.MaxClosingNegotiationIterations
+                    (state.ClosingTxProposed |> List.choose (id) |> List.length) >= cs.ChannelOptions.MaxClosingNegotiationIterations
                 if (areWeInDeal || hasTooManyNegotiationDone) then
                     return!
                         Closing.handleMutualClose
@@ -1054,7 +1054,7 @@ module Channel =
                             { state with MaybeBestUnpublishedTx = Some(finalizedTx) }
                             state.RemoteNextCommitInfo
                 else
-                    let lastLocalClosingFee = state.ClosingTxProposed |> List.tryHead |> Option.bind (List.tryHead) |> Option.map (fun txp -> txp.LocalClosingSigned.FeeSatoshis)
+                    let lastLocalClosingFee = state.ClosingTxProposed |> List.tryHead |> Option.bind id |> Option.map (fun txp -> txp.LocalClosingSigned.FeeSatoshis)
                     let! localF = 
                         match lastLocalClosingFee with
                         | Some v -> Ok v
@@ -1077,8 +1077,10 @@ module Channel =
                     else if (nextClosingFee = msg.FeeSatoshis) then
                         // we have reached on agreement!
                         let closingTxProposed1 =
-                            let newProposed = [ { ClosingTxProposed.UnsignedTx = closingTx
-                                                  LocalClosingSigned = closingSignedMsg } ]
+                            let newProposed = Some {
+                                ClosingTxProposed.UnsignedTx = closingTx
+                                LocalClosingSigned = closingSignedMsg
+                            }
                             newProposed :: state.ClosingTxProposed
                         let negoData = { state with ClosingTxProposed = closingTxProposed1
                                                     MaybeBestUnpublishedTx = Some(finalizedTx) }
@@ -1099,8 +1101,10 @@ module Channel =
                             )
                             |> expectTransactionError
                         let closingTxProposed1 =
-                            let newProposed = [ { ClosingTxProposed.UnsignedTx = closingTx
-                                                  LocalClosingSigned = closingSignedMsg } ]
+                            let newProposed = Some {
+                                ClosingTxProposed.UnsignedTx = closingTx
+                                LocalClosingSigned = closingSignedMsg
+                            }
                             newProposed :: state.ClosingTxProposed
                         let nextState = { state with ClosingTxProposed = closingTxProposed1; MaybeBestUnpublishedTx = Some(finalizedTx) }
                         return [ WeProposedNewClosingSigned(closingSignedMsg, nextState) ]

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -172,7 +172,6 @@ and ChannelWaitingForFundingCreated = {
             RemoteCommit = {
                 Index = CommitmentNumber.FirstCommitment
                 Spec = remoteSpec
-                TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
                 RemotePerCommitmentPoint = self.RemoteFirstPerCommitmentPoint
             }
             LocalChanges = LocalChanges.Zero
@@ -278,7 +277,6 @@ and ChannelWaitingForFundingTx = {
             RemoteCommit = {
                 RemoteCommit.Index = CommitmentNumber.FirstCommitment
                 Spec = remoteSpec
-                TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
                 RemotePerCommitmentPoint = self.LastReceived.FirstPerCommitmentPoint
             }
             ChannelFlags = self.ChannelFlags

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -1153,14 +1153,3 @@ and Channel = {
                 return channel, NewClosingSigned closingSignedMsg
     }
 
-module Channel =
-
-    let executeCommand (_cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
-        match command with
-        | _cmd ->
-            failwith "not implemented"
-
-    let applyEvent c (e: ChannelEvent): Channel =
-        match e with
-        // ----- else -----
-        | _otherEvent -> c

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -78,8 +78,8 @@ type ChannelWaitingForFundingSigned = {
         }
         let nextState = ChannelState.Normal {
             ShortChannelId = None
-            LocalShutdown = None
-            RemoteShutdown = None
+            LocalShutdownState = ShutdownState.ForNewChannel self.LocalShutdownScriptPubKey
+            RemoteShutdownState = ShutdownState.ForNewChannel self.RemoteShutdownScriptPubKey
             RemoteNextCommitInfo = None
         }
         let channel = {
@@ -91,8 +91,6 @@ type ChannelWaitingForFundingSigned = {
             State = nextState
             Network = self.Network
             FundingTxMinimumDepth = self.FundingTxMinimumDepth
-            LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
-            RemoteShutdownScriptPubKey = self.RemoteShutdownScriptPubKey
             Commitments = commitments
         }
         return self.FundingTx, channel
@@ -191,8 +189,8 @@ and ChannelWaitingForFundingCreated = {
         }
         let nextState = ChannelState.Normal {
             ShortChannelId = None
-            LocalShutdown = None
-            RemoteShutdown = None
+            LocalShutdownState = ShutdownState.ForNewChannel self.LocalShutdownScriptPubKey
+            RemoteShutdownState = ShutdownState.ForNewChannel self.RemoteShutdownScriptPubKey
             RemoteNextCommitInfo = None
         }
         let channel = {
@@ -203,8 +201,6 @@ and ChannelWaitingForFundingCreated = {
             NodeSecret = self.NodeSecret
             Network = self.Network
             State = nextState
-            LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
-            RemoteShutdownScriptPubKey = self.RemoteShutdownScriptPubKey
             FundingTxMinimumDepth = self.FundingTxMinimumDepth
             Commitments = commitments
         }
@@ -355,8 +351,6 @@ and Channel = {
     NodeSecret: NodeSecret
     State: ChannelState
     Network: Network
-    LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
-    RemoteShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     FundingTxMinimumDepth: BlockHeightOffset32
     Commitments: Commitments
  }
@@ -698,7 +692,7 @@ module Channel =
                     onceConfirmedFundingTxHasBecomeUnconfirmed(height, depth)
 
         // ---------- normal operation ---------
-        | ChannelState.Normal state, MonoHopUnidirectionalPayment op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
+        | ChannelState.Normal state, MonoHopUnidirectionalPayment op when state.HasEnteredShutdown() ->
             sprintf "Could not send mono-hop unidirectional payment %A since shutdown is already in progress." op
             |> apiMisuse
         | ChannelState.Normal state, MonoHopUnidirectionalPayment op ->
@@ -726,7 +720,7 @@ module Channel =
                 do! Validation.checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 msg
                 return [ WeAcceptedMonoHopUnidirectionalPayment commitments1 ]
             }
-        | ChannelState.Normal state, AddHTLC op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
+        | ChannelState.Normal state, AddHTLC op when state.HasEnteredShutdown() ->
             sprintf "Could not add new HTLC %A since shutdown is already in progress." op
             |> apiMisuse
         | ChannelState.Normal state, AddHTLC op ->
@@ -900,34 +894,32 @@ module Channel =
 
         | ChannelState.Normal state, ChannelCommand.Close localShutdownScriptPubKey ->
             result {
-                match cs.LocalShutdownScriptPubKey with
-                | Some commitedShutdownScriptPubKey ->
-                    if commitedShutdownScriptPubKey <> localShutdownScriptPubKey then
-                        do! cannotCloseChannel "Shutdown script does not match the shutdown script we orginally gave the peer"
-                | None -> ()
-                if (state.LocalShutdown.IsSome) then
-                    do! cannotCloseChannel "shutdown is already in progress"
+                match state.LocalShutdownState with
+                | Some shutdownState when shutdownState.HasRequestedShutdown ->
+                    do! Error <| cannotCloseChannel "shutdown is already in progress"
+                | _ -> ()
+                let! nextLocalShutdownState =
+                    Validation.checkShutdownScriptPubKeyAcceptable
+                        state.LocalShutdownState
+                        localShutdownScriptPubKey
                 if (cs.Commitments.LocalHasUnsignedOutgoingHTLCs()) then
-                    do! cannotCloseChannel "Cannot close with unsigned outgoing htlcs"
+                    do! Error <| cannotCloseChannel "Cannot close with unsigned outgoing htlcs"
                 let shutdownMsg: ShutdownMsg = {
                     ChannelId = cs.Commitments.ChannelId()
                     ScriptPubKey = localShutdownScriptPubKey
                 }
-                return [ AcceptedOperationShutdown shutdownMsg ]
+                return [ AcceptedOperationShutdown(shutdownMsg, nextLocalShutdownState) ]
             }
         | ChannelState.Normal state, RemoteShutdown(msg, localShutdownScriptPubKey) ->
             result {
-                match cs.LocalShutdownScriptPubKey with
-                | Some commitedLocalShutdownScriptPubKey ->
-                    if commitedLocalShutdownScriptPubKey <> localShutdownScriptPubKey then
-                        do! cannotCloseChannel "Shutdown script does not match the shutdown script we orginally gave the peer"
-                | None -> ()
-                match cs.RemoteShutdownScriptPubKey with
-                | Some commitedRemoteShutdownScriptPubKey ->
-                    if commitedRemoteShutdownScriptPubKey <> msg.ScriptPubKey then
-                        do! cannotCloseChannel "Shutdown script does not match the shutdown script the peer originally gave us"
-                | None -> ()
-                    
+                let! localShutdownState =
+                    Validation.checkShutdownScriptPubKeyAcceptable
+                        state.LocalShutdownState
+                        localShutdownScriptPubKey
+                let! remoteShutdownState =
+                    Validation.checkShutdownScriptPubKeyAcceptable
+                        state.RemoteShutdownState
+                        msg.ScriptPubKey
                 let cm = cs.Commitments
                 // They have pending unsigned htlcs => they violated the spec, close the channel
                 // they don't have pending unsigned htlcs
@@ -948,26 +940,23 @@ module Channel =
                     return! receivedShutdownWhenRemoteHasUnsignedOutgoingHTLCs msg
                 // Do we have Unsigned Outgoing HTLCs?
                 else if (cm.LocalHasUnsignedOutgoingHTLCs()) then
-                    if (state.LocalShutdown.IsSome) then
-                        return failwith "can't have pending unsigned outgoing htlcs after having sent Shutdown. this should never happen"
-                    else
-                        let remoteNextCommitInfo =
-                            match state.RemoteNextCommitInfo with
-                            | None -> failwith "can't have unsigned outgoing htlcs if we haven't recieved funding_locked. this should never happen"
-                            | Some remoteNextCommitInfo -> remoteNextCommitInfo
-                        // Are we in the middle of a signature?
-                        match remoteNextCommitInfo with
-                        // yes.
-                        | RemoteNextCommitInfo.Waiting _waitingForRevocation ->
-                            return [
-                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs msg.ScriptPubKey
-                            ]
-                        // No. let's sign right away.
-                        | RemoteNextCommitInfo.Revoked _ ->
-                            return [
-                                ChannelStateRequestedSignCommitment;
-                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs msg.ScriptPubKey
-                            ]
+                    let remoteNextCommitInfo =
+                        match state.RemoteNextCommitInfo with
+                        | None -> failwith "can't have unsigned outgoing htlcs if we haven't recieved funding_locked. this should never happen"
+                        | Some remoteNextCommitInfo -> remoteNextCommitInfo
+                    // Are we in the middle of a signature?
+                    match remoteNextCommitInfo with
+                    // yes.
+                    | RemoteNextCommitInfo.Waiting _waitingForRevocation ->
+                        return [
+                            AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdownState
+                        ]
+                    // No. let's sign right away.
+                    | RemoteNextCommitInfo.Revoked _ ->
+                        return [
+                            ChannelStateRequestedSignCommitment;
+                            AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdownState
+                        ]
                 else
                     let hasNoPendingHTLCs =
                         match state.RemoteNextCommitInfo with
@@ -1015,10 +1004,15 @@ module Channel =
                             ChannelId = cs.Commitments.ChannelId()
                             ScriptPubKey = localShutdownScriptPubKey
                         }
+                        let nextState = {
+                            state with
+                                LocalShutdownState = Some localShutdownState
+                                RemoteShutdownState = Some remoteShutdownState
+                        }
                         return [
                             AcceptedShutdownWhenWeHavePendingHTLCs(
                                 localShutdownMsg,
-                                msg.ScriptPubKey
+                                nextState
                             )
                         ]
             }
@@ -1214,32 +1208,28 @@ module Channel =
             }
 
         // -----  closing ------
-        | AcceptedOperationShutdown msg, ChannelState.Normal normalData ->
+        | AcceptedOperationShutdown(_msg, nextLocalShutdownState), ChannelState.Normal normalData ->
             {
                 c with
                     State = ChannelState.Normal {
                         normalData with
-                            LocalShutdown = Some msg.ScriptPubKey
+                            LocalShutdownState = Some nextLocalShutdownState
                     }
             }
-        | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdownScriptPubKey, ChannelState.Normal normalData ->
+        | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs nextRemoteShutdownState, ChannelState.Normal normalData ->
             { 
                 c with
                     State = ChannelState.Normal {
                         normalData with
-                            RemoteShutdown = Some remoteShutdownScriptPubKey
+                            RemoteShutdownState = Some nextRemoteShutdownState
                     }
             }
         | AcceptedShutdownWhenNoPendingHTLCs(_maybeMsg, nextState), ChannelState.Normal _d ->
             { c with State = Negotiating nextState }
-        | AcceptedShutdownWhenWeHavePendingHTLCs(localShutdown, remoteShutdownScriptPubKey), ChannelState.Normal normalData ->
+        | AcceptedShutdownWhenWeHavePendingHTLCs(_localShutdown, nextState), ChannelState.Normal _normalData ->
             {
                 c with
-                    State = ChannelState.Normal {
-                        normalData with
-                            LocalShutdown = Some localShutdown.ScriptPubKey
-                            RemoteShutdown = Some remoteShutdownScriptPubKey
-                    }
+                    State = ChannelState.Normal nextState
             }
         | MutualClosePerformed (_txToPublish, nextState), ChannelState.Negotiating _d ->
             { c with State = Closing nextState }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -446,6 +446,32 @@ module Channel =
                 [] |> Ok
 
         // ---------- normal operation ---------
+        | ChannelState.Normal state, MonoHopUnidirectionalPayment op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
+            sprintf "Could not send mono-hop unidirectional payment %A since shutdown is already in progress." op
+            |> apiMisuse
+        | ChannelState.Normal state, MonoHopUnidirectionalPayment op ->
+            result {
+                let payment: MonoHopUnidirectionalPaymentMsg = {
+                    ChannelId = state.Commitments.ChannelId
+                    Amount = op.Amount
+                }
+                let commitments1 = state.Commitments.AddLocalProposal(payment)
+
+                let remoteCommit1 =
+                    match commitments1.RemoteNextCommitInfo with
+                    | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
+                    | RemoteNextCommitInfo.Revoked _info -> commitments1.RemoteCommit
+                let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
+                do! Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 payment
+                return [ WeAcceptedOperationMonoHopUnidirectionalPayment(payment, commitments1) ]
+            }
+        | ChannelState.Normal state, ApplyMonoHopUnidirectionalPayment msg ->
+            result {
+                let commitments1 = state.Commitments.AddRemoteProposal(msg)
+                let! reduced = commitments1.LocalCommit.Spec.Reduce (commitments1.LocalChanges.ACKed, commitments1.RemoteChanges.Proposed) |> expectTransactionError
+                do! Validation.checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 msg
+                return [ WeAcceptedMonoHopUnidirectionalPayment commitments1 ]
+            }
         | ChannelState.Normal state, AddHTLC op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
             sprintf "Could not add new HTLC %A since shutdown is already in progress." op
             |> apiMisuse
@@ -551,8 +577,8 @@ module Channel =
                                                  RemoteCommit = theirNextCommit
                                                  RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
                                                  RemotePerCommitmentSecrets = remotePerCommitmentSecrets }
-                    let _result = Ok [ WeAcceptedRevokeAndACK commitments1 ]
-                    failwith "needs update"
+                    Console.WriteLine("WARNING: revocation is not implemented yet")
+                    Ok [ WeAcceptedRevokeAndACK(commitments1) ]
 
         | ChannelState.Normal state, ChannelCommand.Close cmd ->
             let localSPK = cmd.ScriptPubKey |> Option.defaultValue (state.Commitments.LocalParams.DefaultFinalScriptPubKey)
@@ -832,8 +858,12 @@ module Channel =
             { c with State = ChannelState.Normal data }
 
         // ----- normal operation --------
+        | WeAcceptedOperationMonoHopUnidirectionalPayment(_, newCommitments), ChannelState.Normal normalData ->
+            { c with State = ChannelState.Normal({ normalData with Commitments = newCommitments }) }
         | WeAcceptedOperationAddHTLC(_, newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
+        | WeAcceptedMonoHopUnidirectionalPayment(newCommitments), ChannelState.Normal normalData ->
+            { c with State = ChannelState.Normal({ normalData with Commitments = newCommitments }) }
         | WeAcceptedUpdateAddHTLC(newCommitments), ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with Commitments = newCommitments }) }
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -34,6 +34,7 @@ type ChannelWaitingForFundingSigned = {
             let sigPairs = seq [ remoteSigPairOfLocalTx; ]
             Transactions.checkTxFinalized signedLocalCommitTx CommitTx.WhichInput sigPairs |> expectTransactionError
         let commitments = {
+            ProposedLocalChanges = List.empty
             LocalChanges = LocalChanges.Zero
             RemoteChanges = RemoteChanges.Zero
             LocalNextHTLCId = HTLCId.Zero
@@ -124,6 +125,7 @@ and ChannelWaitingForFundingCreated = {
                 msg.FundingOutputIndex
                 self.FundingSatoshis
         let commitments = {
+            ProposedLocalChanges = List.empty
             LocalChanges = LocalChanges.Zero
             RemoteChanges = RemoteChanges.Zero
             LocalNextHTLCId = HTLCId.Zero
@@ -597,7 +599,7 @@ and Channel = {
                 match remoteNextCommitInfo with
                 | Waiting nextRemoteCommit -> nextRemoteCommit
                 | Revoked _info -> self.SavedChannelState.RemoteCommit
-            let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
+            let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.ProposedLocalChanges) |> expectTransactionError
             do!
                 Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec
                     reduced
@@ -665,7 +667,7 @@ and Channel = {
                 match remoteNextCommitInfo with
                 | Waiting nextRemoteCommit -> nextRemoteCommit
                 | Revoked _info -> self.SavedChannelState.RemoteCommit
-            let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
+            let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.ProposedLocalChanges) |> expectTransactionError
             do!
                 Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec
                     reduced

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -118,12 +118,14 @@ and ChannelWaitingForFundingCreated = {
     InitialFeeRatePerKw: FeeRatePerKw
     RemoteFirstPerCommitmentPoint: PerCommitmentPoint
     ChannelFlags: uint8
-    LastSent: AcceptChannelMsg
 } with
     member self.ApplyFundingCreated (msg: FundingCreatedMsg)
                                         : Result<FundingSignedMsg * Channel, ChannelError> = result {
         let remoteChannelKeys = self.RemoteParams.ChannelPubKeys
         let! (localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
+            let firstPerCommitmentPoint =
+                self.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint
+                    CommitmentNumber.FirstCommitment
             ChannelHelpers.makeFirstCommitTxs
                 self.LocalParams
                 self.RemoteParams
@@ -132,7 +134,7 @@ and ChannelWaitingForFundingCreated = {
                 self.InitialFeeRatePerKw
                 msg.FundingOutputIndex
                 msg.FundingTxId
-                self.LastSent.FirstPerCommitmentPoint
+                firstPerCommitmentPoint
                 self.RemoteFirstPerCommitmentPoint
                 self.Network
         assert (localCommitTx.Value.IsReadyToSign())
@@ -218,7 +220,6 @@ and ChannelWaitingForFundingTx = {
     NodeSecret: NodeSecret
     Network: Network
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
-    LastSent: OpenChannelMsg
     LastReceived: AcceptChannelMsg
     TemporaryChannelId: ChannelId
     FundingSatoshis: Money
@@ -234,16 +235,15 @@ and ChannelWaitingForFundingTx = {
                                     : Result<FundingCreatedMsg * ChannelWaitingForFundingSigned, ChannelError> = result {
         let remoteParams = RemoteParams.FromAcceptChannel self.RemoteNodeId (self.RemoteInit) self.LastReceived
         let localParams = self.LocalParams
-        assert (self.LastSent.FundingPubKey = localParams.ChannelPubKeys.FundingPubKey)
         let commitmentSpec = CommitmentSpec.Create (self.FundingSatoshis.ToLNMoney() - self.PushMSat) self.PushMSat self.FundingTxFeeRatePerKw
         let commitmentSeed = self.ChannelPrivKeys.CommitmentSeed
         let fundingTxId = fundingTx.Value.GetTxId()
         let! (_localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
             ChannelHelpers.makeFirstCommitTxs localParams
                                        remoteParams
-                                       self.LastSent.FundingSatoshis
-                                       self.LastSent.PushMSat
-                                       self.LastSent.FeeRatePerKw
+                                       self.FundingSatoshis
+                                       self.PushMSat
+                                       self.InitFeeRatePerKw
                                        outIndex
                                        fundingTxId
                                        (commitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment)
@@ -296,7 +296,6 @@ and ChannelWaitingForAcceptChannel = {
     NodeSecret: NodeSecret
     Network: Network
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
-    LastSent: OpenChannelMsg
     TemporaryChannelId: ChannelId
     FundingSatoshis: Money
     PushMSat: LNMoney
@@ -308,7 +307,7 @@ and ChannelWaitingForAcceptChannel = {
 } with
     member self.ApplyAcceptChannel (msg: AcceptChannelMsg)
                                        : Result<IDestination * Money * ChannelWaitingForFundingTx, ChannelError> = result {
-        do! Validation.checkAcceptChannelMsgAcceptable self.ChannelHandshakeLimits self.FundingSatoshis self.LastSent msg
+        do! Validation.checkAcceptChannelMsgAcceptable self.ChannelHandshakeLimits self.FundingSatoshis self.LocalParams.ChannelReserveSatoshis self.LocalParams.DustLimitSatoshis msg
         let redeem =
             Scripts.funding
                 (self.ChannelPrivKeys.ToChannelPubKeys().FundingPubKey)
@@ -323,7 +322,6 @@ and ChannelWaitingForAcceptChannel = {
             NodeSecret = self.NodeSecret
             Network = self.Network
             LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
-            LastSent = self.LastSent
             LastReceived = msg
             TemporaryChannelId = self.TemporaryChannelId
             FundingSatoshis = self.FundingSatoshis
@@ -401,7 +399,6 @@ and Channel = {
                     RemoteNodeId = remoteNodeId
                     NodeSecret = nodeSecret
                     Network = network
-                    LastSent = openChannelMsgToSend
                     LocalShutdownScriptPubKey = shutdownScriptPubKey
                     TemporaryChannelId = temporaryChannelId
                     FundingSatoshis = fundingSatoshis
@@ -431,9 +428,7 @@ and Channel = {
                                  ): Result<AcceptChannelMsg * ChannelWaitingForFundingCreated, ChannelError> =
             result {
                 do! Validation.checkOpenChannelMsgAcceptable feeEstimator channelHandshakeLimits channelOptions openChannelMsg
-                let localParams = localParams
-                let channelKeys = channelPrivKeys
-                let localCommitmentPubKey = channelKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
+                let firstPerCommitmentPoint = channelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
                 let acceptChannelMsg: AcceptChannelMsg = {
                     TemporaryChannelId = openChannelMsg.TemporaryChannelId
                     DustLimitSatoshis = localParams.DustLimitSatoshis
@@ -443,12 +438,12 @@ and Channel = {
                     MinimumDepth = minimumDepth
                     ToSelfDelay = localParams.ToSelfDelay
                     MaxAcceptedHTLCs = localParams.MaxAcceptedHTLCs
-                    FundingPubKey = channelKeys.FundingPrivKey.FundingPubKey()
-                    RevocationBasepoint = channelKeys.RevocationBasepointSecret.RevocationBasepoint()
-                    PaymentBasepoint = channelKeys.PaymentBasepointSecret.PaymentBasepoint()
-                    DelayedPaymentBasepoint = channelKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
-                    HTLCBasepoint = channelKeys.HtlcBasepointSecret.HtlcBasepoint()
-                    FirstPerCommitmentPoint = localCommitmentPubKey
+                    FundingPubKey = channelPrivKeys.FundingPrivKey.FundingPubKey()
+                    RevocationBasepoint = channelPrivKeys.RevocationBasepointSecret.RevocationBasepoint()
+                    PaymentBasepoint = channelPrivKeys.PaymentBasepointSecret.PaymentBasepoint()
+                    DelayedPaymentBasepoint = channelPrivKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
+                    HTLCBasepoint = channelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
+                    FirstPerCommitmentPoint = firstPerCommitmentPoint
                     ShutdownScriptPubKey = shutdownScriptPubKey
                 }
                 let remoteParams = RemoteParams.FromOpenChannel remoteNodeId remoteInit openChannelMsg
@@ -471,7 +466,6 @@ and Channel = {
                     PushMSat = openChannelMsg.PushMSat
                     InitialFeeRatePerKw = openChannelMsg.FeeRatePerKw
                     RemoteFirstPerCommitmentPoint = openChannelMsg.FirstPerCommitmentPoint
-                    LastSent = acceptChannelMsg
                 }
                 return (acceptChannelMsg, channelWaitingForFundingCreated)
             }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -785,6 +785,19 @@ and Channel = {
         }
     }
 
+    member self.UpdateFee (op: OperationUpdateFee)
+                              : Result<Channel * UpdateFeeMsg, ChannelError> = result {
+        let! _remoteNextCommitInfo =
+            self.RemoteNextCommitInfoIfFundingLockedNormal "UpdateFee"
+        let! updateFeeMsg, newCommitments =
+            Commitments.sendFee op self.StaticChannelConfig self.Commitments
+        let channel = {
+            self with
+                Commitments = newCommitments
+        }
+        return channel, updateFeeMsg
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -838,12 +851,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | UpdateFee op ->
-            result {
-                let! _remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "UpdateFee"
-                return! Commitments.sendFee op cs.StaticChannelConfig cs.Commitments
-            }
         | ApplyUpdateFee msg ->
             result {
                 let! _remoteNextCommitInfo =
@@ -1140,8 +1147,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // ----- normal operation --------
-        | WeAcceptedOperationUpdateFee(_msg, newCommitments) ->
-            { c with Commitments = newCommitments }
         | WeAcceptedUpdateFee(_msg, newCommitments) ->
             { c with Commitments = newCommitments }
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -14,51 +14,28 @@ open ResultUtils
 open ResultUtils.Portability
 
 type ChannelWaitingForFundingSigned = {
+    StaticChannelConfig: StaticChannelConfig
     ChannelOptions: ChannelOptions
     ChannelPrivKeys: ChannelPrivKeys
     FeeEstimator: IFeeEstimator
-    RemoteNodeId: NodeId
     NodeSecret: NodeSecret
-    Network: Network
-    FundingTxMinimumDepth: BlockHeightOffset32
     ChannelId: ChannelId
-    LocalParams: LocalParams
-    RemoteParams: RemoteParams
-    RemoteChannelPubKeys: ChannelPubKeys
     FundingTx: FinalizedTx
     LocalSpec: CommitmentSpec
     LocalCommitTx: CommitTx
     RemoteCommit: RemoteCommit
-    ChannelFlags: ChannelFlags
     LastSent: FundingCreatedMsg
-    LocalStaticShutdownScriptPubKey: Option<ShutdownScriptPubKey>
-    RemoteStaticShutdownScriptPubKey: Option<ShutdownScriptPubKey>
 } with
     member self.ApplyFundingSigned (msg: FundingSignedMsg)
                                        : Result<FinalizedTx * Channel, ChannelError> = result {
         let! finalizedLocalCommitTx =
-            let theirFundingPk = self.RemoteChannelPubKeys.FundingPubKey.RawPubKey()
+            let theirFundingPk = self.StaticChannelConfig.RemoteChannelPubKeys.FundingPubKey.RawPubKey()
             let _, signedLocalCommitTx =
                 self.ChannelPrivKeys.SignWithFundingPrivKey self.LocalCommitTx.Value
             let remoteSigPairOfLocalTx = (theirFundingPk,  TransactionSignature(msg.Signature.Value, SigHash.All))
             let sigPairs = seq [ remoteSigPairOfLocalTx; ]
             Transactions.checkTxFinalized signedLocalCommitTx self.LocalCommitTx.WhichInput sigPairs |> expectTransactionError
         let commitments = {
-            IsFunder = true
-            LocalParams = self.LocalParams
-            RemoteParams = self.RemoteParams
-            RemoteChannelPubKeys = self.RemoteChannelPubKeys
-            ChannelFlags = self.ChannelFlags
-            FundingScriptCoin =
-                let amount =
-                    let index = int self.LastSent.FundingOutputIndex.Value
-                    self.FundingTx.Value.Outputs.[index].Value
-                ChannelHelpers.getFundingScriptCoin
-                    (self.ChannelPrivKeys.FundingPrivKey.FundingPubKey())
-                    self.RemoteChannelPubKeys.FundingPubKey
-                    self.LastSent.FundingTxId
-                    self.LastSent.FundingOutputIndex
-                    amount
             LocalCommit = {
                 Index = CommitmentNumber.FirstCommitment
                 Spec = self.LocalSpec
@@ -77,33 +54,31 @@ type ChannelWaitingForFundingSigned = {
             RemotePerCommitmentSecrets = PerCommitmentSecretStore()
         }
         let channel = {
+            StaticChannelConfig = self.StaticChannelConfig
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
             FeeEstimator = self.FeeEstimator
-            RemoteNodeId = self.RemoteNodeId
             NodeSecret = self.NodeSecret
             ShortChannelId = None
             RemoteNextCommitInfo = None
-            LocalStaticShutdownScriptPubKey = self.LocalStaticShutdownScriptPubKey
-            RemoteStaticShutdownScriptPubKey = self.RemoteStaticShutdownScriptPubKey
             NegotiatingState = NegotiatingState.New()
-            Network = self.Network
-            FundingTxMinimumDepth = self.FundingTxMinimumDepth
             Commitments = commitments
         }
         return self.FundingTx, channel
     }
 
 and ChannelWaitingForFundingCreated = {
-    ChannelOptions: ChannelOptions
-    ChannelPrivKeys: ChannelPrivKeys
-    FeeEstimator: IFeeEstimator
+    AnnounceChannel: bool
     RemoteNodeId: NodeId
-    NodeSecret: NodeSecret
     Network: Network
     FundingTxMinimumDepth: BlockHeightOffset32
     LocalStaticShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     RemoteStaticShutdownScriptPubKey: Option<ShutdownScriptPubKey>
+    IsFunder: bool
+    ChannelOptions: ChannelOptions
+    ChannelPrivKeys: ChannelPrivKeys
+    FeeEstimator: IFeeEstimator
+    NodeSecret: NodeSecret
     TemporaryFailure: ChannelId
     LocalParams: LocalParams
     RemoteParams: RemoteParams
@@ -112,7 +87,6 @@ and ChannelWaitingForFundingCreated = {
     PushMSat: LNMoney
     InitialFeeRatePerKw: FeeRatePerKw
     RemoteFirstPerCommitmentPoint: PerCommitmentPoint
-    ChannelFlags: ChannelFlags
 } with
     member self.ApplyFundingCreated (msg: FundingCreatedMsg)
                                         : Result<FundingSignedMsg * Channel, ChannelError> = result {
@@ -145,19 +119,14 @@ and ChannelWaitingForFundingCreated = {
             |> expectTransactionError
         let localSigOfRemoteCommit, _ =
             self.ChannelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
+        let fundingScriptCoin =
+            ChannelHelpers.getFundingScriptCoin
+                (self.ChannelPrivKeys.FundingPrivKey.FundingPubKey())
+                self.RemoteChannelPubKeys.FundingPubKey
+                msg.FundingTxId
+                msg.FundingOutputIndex
+                self.FundingSatoshis
         let commitments = {
-            IsFunder = false
-            LocalParams = self.LocalParams
-            RemoteParams = self.RemoteParams
-            RemoteChannelPubKeys = self.RemoteChannelPubKeys
-            ChannelFlags = self.ChannelFlags
-            FundingScriptCoin =
-                ChannelHelpers.getFundingScriptCoin
-                    (self.ChannelPrivKeys.FundingPrivKey.FundingPubKey())
-                    self.RemoteChannelPubKeys.FundingPubKey
-                    msg.FundingTxId
-                    msg.FundingOutputIndex
-                    self.FundingSatoshis
             LocalCommit = {
                 Index = CommitmentNumber.FirstCommitment
                 Spec = localSpec
@@ -179,30 +148,40 @@ and ChannelWaitingForFundingCreated = {
             OriginChannels = Map.empty
             RemotePerCommitmentSecrets = PerCommitmentSecretStore()
         }
-        let channelId = commitments.ChannelId()
+        let staticChannelConfig = {
+            AnnounceChannel = self.AnnounceChannel
+            RemoteNodeId = self.RemoteNodeId
+            Network = self.Network
+            FundingTxMinimumDepth = self.FundingTxMinimumDepth
+            LocalStaticShutdownScriptPubKey = self.LocalStaticShutdownScriptPubKey
+            RemoteStaticShutdownScriptPubKey = self.RemoteStaticShutdownScriptPubKey
+            IsFunder = self.IsFunder
+            FundingScriptCoin = fundingScriptCoin
+            LocalParams = self.LocalParams
+            RemoteParams = self.RemoteParams
+            RemoteChannelPubKeys = self.RemoteChannelPubKeys
+        }
+        let channelId = staticChannelConfig.ChannelId()
         let msgToSend: FundingSignedMsg = {
             ChannelId = channelId
             Signature = !>localSigOfRemoteCommit.Signature
         }
         let channel = {
+            StaticChannelConfig = staticChannelConfig
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
             FeeEstimator = self.FeeEstimator
-            RemoteNodeId = self.RemoteNodeId
             NodeSecret = self.NodeSecret
-            Network = self.Network
             RemoteNextCommitInfo = None
             ShortChannelId = None
-            LocalStaticShutdownScriptPubKey = self.LocalStaticShutdownScriptPubKey
-            RemoteStaticShutdownScriptPubKey = self.RemoteStaticShutdownScriptPubKey
             NegotiatingState = NegotiatingState.New()
-            FundingTxMinimumDepth = self.FundingTxMinimumDepth
             Commitments = commitments
         }
         return msgToSend, channel
     }
 
 and ChannelWaitingForFundingTx = {
+    AnnounceChannel: bool
     ChannelOptions: ChannelOptions
     ChannelPrivKeys: ChannelPrivKeys
     FeeEstimator: IFeeEstimator
@@ -219,7 +198,6 @@ and ChannelWaitingForFundingTx = {
     InitFeeRatePerKw: FeeRatePerKw
     LocalParams: LocalParams
     RemoteInit: InitMsg
-    ChannelFlags: ChannelFlags
 } with
     member self.CreateFundingTx (fundingTx: FinalizedTx)
                                 (outIndex: TxOutIndex)
@@ -252,21 +230,33 @@ and ChannelWaitingForFundingTx = {
             FundingOutputIndex = outIndex
             Signature = !>localSigOfRemoteCommit.Signature
         }
+        let fundingScriptCoin =
+            ChannelHelpers.getFundingScriptCoin
+                (self.ChannelPrivKeys.FundingPrivKey.FundingPubKey())
+                self.RemoteChannelPubKeys.FundingPubKey
+                fundingTxId
+                outIndex
+                self.FundingSatoshis
         let channelId = OutPoint(fundingTxId.Value, uint32 outIndex.Value).ToChannelId()
         let channelWaitingForFundingSigned = {
+            StaticChannelConfig = {
+                AnnounceChannel = self.AnnounceChannel
+                RemoteNodeId = self.RemoteNodeId
+                Network = self.Network
+                FundingTxMinimumDepth = self.LastReceived.MinimumDepth
+                LocalStaticShutdownScriptPubKey = self.LocalStaticShutdownScriptPubKey
+                RemoteStaticShutdownScriptPubKey = self.RemoteStaticShutdownScriptPubKey
+                IsFunder = true
+                FundingScriptCoin = fundingScriptCoin
+                LocalParams = localParams
+                RemoteParams = remoteParams
+                RemoteChannelPubKeys = self.RemoteChannelPubKeys
+            }
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
             FeeEstimator = self.FeeEstimator
-            RemoteNodeId = self.RemoteNodeId
             NodeSecret = self.NodeSecret
-            Network = self.Network
-            FundingTxMinimumDepth = self.LastReceived.MinimumDepth
-            LocalStaticShutdownScriptPubKey = self.LocalStaticShutdownScriptPubKey
-            RemoteStaticShutdownScriptPubKey = self.RemoteStaticShutdownScriptPubKey
             ChannelId = channelId
-            LocalParams = localParams
-            RemoteParams = remoteParams
-            RemoteChannelPubKeys = self.RemoteChannelPubKeys
             FundingTx = fundingTx
             LocalSpec = commitmentSpec
             LocalCommitTx = localCommitTx
@@ -275,7 +265,6 @@ and ChannelWaitingForFundingTx = {
                 Spec = remoteSpec
                 RemotePerCommitmentPoint = self.LastReceived.FirstPerCommitmentPoint
             }
-            ChannelFlags = self.ChannelFlags
             LastSent = nextMsg
         }
         return nextMsg, channelWaitingForFundingSigned
@@ -283,6 +272,7 @@ and ChannelWaitingForFundingTx = {
 
 
 and ChannelWaitingForAcceptChannel = {
+    AnnounceChannel: bool
     ChannelOptions: ChannelOptions
     ChannelHandshakeLimits: ChannelHandshakeLimits
     ChannelPrivKeys: ChannelPrivKeys
@@ -297,7 +287,6 @@ and ChannelWaitingForAcceptChannel = {
     InitFeeRatePerKw: FeeRatePerKw
     LocalParams: LocalParams
     RemoteInit: InitMsg
-    ChannelFlags: ChannelFlags
 } with
     member self.ApplyAcceptChannel (msg: AcceptChannelMsg)
                                        : Result<IDestination * Money * ChannelWaitingForFundingTx, ChannelError> = result {
@@ -316,6 +305,7 @@ and ChannelWaitingForAcceptChannel = {
         let destination = redeem.WitHash :> IDestination
         let amount = self.FundingSatoshis
         let channelWaitingForFundingTx = {
+            AnnounceChannel = self.AnnounceChannel
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
             FeeEstimator = self.FeeEstimator
@@ -332,29 +322,25 @@ and ChannelWaitingForAcceptChannel = {
             InitFeeRatePerKw = self.InitFeeRatePerKw
             LocalParams = self.LocalParams
             RemoteInit = self.RemoteInit
-            ChannelFlags = self.ChannelFlags
         }
         return destination, amount, channelWaitingForFundingTx
     }
 
 and Channel = {
+    StaticChannelConfig: StaticChannelConfig
     ChannelOptions: ChannelOptions
     ChannelPrivKeys: ChannelPrivKeys
     FeeEstimator: IFeeEstimator
-    RemoteNodeId: NodeId
     NodeSecret: NodeSecret
     ShortChannelId: Option<ShortChannelId>
     RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
-    LocalStaticShutdownScriptPubKey: Option<ShutdownScriptPubKey>
-    RemoteStaticShutdownScriptPubKey: Option<ShutdownScriptPubKey>
     NegotiatingState: NegotiatingState
-    Network: Network
-    FundingTxMinimumDepth: BlockHeightOffset32
     Commitments: Commitments
  }
         with
         static member NewOutbound(channelHandshakeLimits: ChannelHandshakeLimits,
                                   channelOptions: ChannelOptions,
+                                  announceChannel: bool,
                                   nodeMasterPrivKey: NodeMasterPrivKey,
                                   channelIndex: int,
                                   feeEstimator: IFeeEstimator,
@@ -367,7 +353,6 @@ and Channel = {
                                   initFeeRatePerKw: FeeRatePerKw,
                                   localParams: LocalParams,
                                   remoteInit: InitMsg,
-                                  channelFlags: ChannelFlags,
                                   channelPrivKeys: ChannelPrivKeys
                                  ): Result<OpenChannelMsg * ChannelWaitingForAcceptChannel, ChannelError> =
             let openChannelMsgToSend: OpenChannelMsg = {
@@ -388,7 +373,9 @@ and Channel = {
                 DelayedPaymentBasepoint = channelPrivKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
                 HTLCBasepoint = channelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
                 FirstPerCommitmentPoint = channelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
-                ChannelFlags = channelFlags
+                ChannelFlags = {
+                    AnnounceChannel = announceChannel
+                }
                 ShutdownScriptPubKey = shutdownScriptPubKey
             }
             result {
@@ -396,6 +383,7 @@ and Channel = {
                 let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
                 let nodeSecret = nodeMasterPrivKey.NodeSecret()
                 let channelWaitingForAcceptChannel = {
+                    AnnounceChannel = announceChannel
                     ChannelHandshakeLimits = channelHandshakeLimits
                     ChannelOptions = channelOptions
                     ChannelPrivKeys = channelPrivKeys
@@ -410,13 +398,13 @@ and Channel = {
                     InitFeeRatePerKw = initFeeRatePerKw
                     LocalParams = localParams
                     RemoteInit = remoteInit
-                    ChannelFlags = channelFlags
                 }
                 return (openChannelMsgToSend, channelWaitingForAcceptChannel)
             }
 
         static member NewInbound (channelHandshakeLimits: ChannelHandshakeLimits,
                                   channelOptions: ChannelOptions,
+                                  announceChannel: bool,
                                   nodeMasterPrivKey: NodeMasterPrivKey,
                                   channelIndex: int,
                                   feeEstimator: IFeeEstimator,
@@ -430,7 +418,7 @@ and Channel = {
                                   channelPrivKeys: ChannelPrivKeys
                                  ): Result<AcceptChannelMsg * ChannelWaitingForFundingCreated, ChannelError> =
             result {
-                do! Validation.checkOpenChannelMsgAcceptable feeEstimator channelHandshakeLimits channelOptions openChannelMsg
+                do! Validation.checkOpenChannelMsgAcceptable feeEstimator channelHandshakeLimits channelOptions announceChannel openChannelMsg
                 let firstPerCommitmentPoint = channelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
                 let acceptChannelMsg: AcceptChannelMsg = {
                     TemporaryChannelId = openChannelMsg.TemporaryChannelId
@@ -460,16 +448,17 @@ and Channel = {
                 let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
                 let nodeSecret = nodeMasterPrivKey.NodeSecret()
                 let channelWaitingForFundingCreated = {
-                    ChannelOptions = channelOptions
-                    ChannelPrivKeys = channelPrivKeys
-                    FeeEstimator = feeEstimator
+                    AnnounceChannel = openChannelMsg.ChannelFlags.AnnounceChannel
                     RemoteNodeId = remoteNodeId
-                    NodeSecret = nodeSecret
                     Network = network
                     FundingTxMinimumDepth = minimumDepth
                     LocalStaticShutdownScriptPubKey = shutdownScriptPubKey
                     RemoteStaticShutdownScriptPubKey = openChannelMsg.ShutdownScriptPubKey
-                    ChannelFlags = openChannelMsg.ChannelFlags
+                    IsFunder = false
+                    ChannelOptions = channelOptions
+                    ChannelPrivKeys = channelPrivKeys
+                    FeeEstimator = feeEstimator
+                    NodeSecret = nodeSecret
                     TemporaryFailure = openChannelMsg.TemporaryChannelId
                     LocalParams = localParams
                     RemoteParams = remoteParams
@@ -496,19 +485,18 @@ module Channel =
         |> fun ecdsaSig -> TransactionSignature(ecdsaSig.Value, SigHash.All)
 
     module Closing =
-        let makeClosingTx (channelPrivKeys: ChannelPrivKeys,
-                           cm: Commitments,
-                           localSpk: ShutdownScriptPubKey,
-                           remoteSpk: ShutdownScriptPubKey,
-                           closingFee: Money,
-                           network: Network
-                          ) =
-            let dustLimitSatoshis = Money.Max(cm.LocalParams.DustLimitSatoshis, cm.RemoteParams.DustLimitSatoshis)
+        let makeClosingTx (channelPrivKeys: ChannelPrivKeys)
+                          (cm: Commitments)
+                          (localSpk: ShutdownScriptPubKey)
+                          (remoteSpk: ShutdownScriptPubKey)
+                          (closingFee: Money)
+                          (staticChannelConfig: StaticChannelConfig) =
+            let dustLimitSatoshis = Money.Max(staticChannelConfig.LocalParams.DustLimitSatoshis, staticChannelConfig.RemoteParams.DustLimitSatoshis)
             result {
-                let! closingTx = Transactions.makeClosingTx (cm.FundingScriptCoin) (localSpk) (remoteSpk) (cm.IsFunder) (dustLimitSatoshis) (closingFee) (cm.LocalCommit.Spec) network
+                let! closingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin (localSpk) (remoteSpk) staticChannelConfig.IsFunder (dustLimitSatoshis) (closingFee) (cm.LocalCommit.Spec) staticChannelConfig.Network
                 let localSignature, psbtUpdated = channelPrivKeys.SignWithFundingPrivKey closingTx.Value
                 let msg: ClosingSignedMsg = {
-                    ChannelId = cm.ChannelId()
+                    ChannelId = staticChannelConfig.ChannelId()
                     FeeSatoshis = closingFee
                     Signature = localSignature.Signature |> LNECDSASignature
                 }
@@ -519,9 +507,9 @@ module Channel =
                             (localSpk: ShutdownScriptPubKey)
                             (remoteSpk: ShutdownScriptPubKey)
                             (feeEst: IFeeEstimator)
-                            (network: Network) =
+                            (staticChannelConfig: StaticChannelConfig) =
             result {
-                let! dummyClosingTx = Transactions.makeClosingTx cm.FundingScriptCoin localSpk remoteSpk cm.IsFunder Money.Zero Money.Zero cm.LocalCommit.Spec network
+                let! dummyClosingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin localSpk remoteSpk staticChannelConfig.IsFunder Money.Zero Money.Zero cm.LocalCommit.Spec staticChannelConfig.Network
                 let tx = dummyClosingTx.Value.GetGlobalTransaction()
                 tx.Inputs.[0].WitScript <-
                     let witness = seq [ dummySig.ToBytes(); dummySig.ToBytes(); dummyClosingTx.Value.Inputs.[0].WitnessScript.ToBytes() ]
@@ -536,11 +524,12 @@ module Channel =
 
     let makeChannelReestablish (channelPrivKeys: ChannelPrivKeys)
                                (commitments: Commitments)
+                               (staticChannelConfig: StaticChannelConfig)
                                    : Result<ChannelEvent list, ChannelError> =
         let commitmentSeed = channelPrivKeys.CommitmentSeed
         let ourChannelReestablish =
             {
-                ChannelId = commitments.ChannelId()
+                ChannelId = staticChannelConfig.ChannelId()
                 NextCommitmentNumber =
                     (commitments.RemotePerCommitmentSecrets.NextCommitmentNumber().NextCommitment())
                 NextRevocationNumber =
@@ -581,7 +570,7 @@ module Channel =
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
         | CreateChannelReestablish ->
-            makeChannelReestablish cs.ChannelPrivKeys cs.Commitments
+            makeChannelReestablish cs.ChannelPrivKeys cs.Commitments cs.StaticChannelConfig
         | ApplyFundingLocked msg ->
             result {
                 do!
@@ -601,14 +590,14 @@ module Channel =
         | ApplyFundingConfirmedOnBC(height, txindex, depth) ->
             match cs.ShortChannelId with
             | None -> 
-                if cs.FundingTxMinimumDepth > depth then
+                if cs.StaticChannelConfig.FundingTxMinimumDepth > depth then
                     [] |> Ok
                 else
                     let nextPerCommitmentPoint =
                         cs.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint
                             (CommitmentNumber.FirstCommitment.NextCommitment())
                     let msgToSend: FundingLockedMsg = {
-                        ChannelId = cs.Commitments.ChannelId()
+                        ChannelId = cs.StaticChannelConfig.ChannelId()
                         NextPerCommitmentPoint = nextPerCommitmentPoint
                     }
 
@@ -620,7 +609,7 @@ module Channel =
                         ShortChannelId.BlockHeight = height;
                         BlockIndex = txindex
                         TxOutIndex =
-                            cs.Commitments.FundingScriptCoin.Outpoint.N
+                            cs.StaticChannelConfig.FundingScriptCoin.Outpoint.N
                             |> uint16
                             |> TxOutIndex
                     }
@@ -641,7 +630,7 @@ module Channel =
                             WeResumedDelayedFundingLocked remoteNextPerCommitmentPoint
                         ]
             | Some _shortChannelId ->
-                if (cs.FundingTxMinimumDepth <= depth) then
+                if (cs.StaticChannelConfig.FundingTxMinimumDepth <= depth) then
                     [] |> Ok
                 else
                     onceConfirmedFundingTxHasBecomeUnconfirmed(height, depth)
@@ -651,7 +640,7 @@ module Channel =
         | MonoHopUnidirectionalPayment op ->
             result {
                 let payment: MonoHopUnidirectionalPaymentMsg = {
-                    ChannelId = cs.Commitments.ChannelId()
+                    ChannelId = cs.StaticChannelConfig.ChannelId()
                     Amount = op.Amount
                 }
                 let commitments1 = cs.Commitments.AddLocalProposal(payment)
@@ -663,14 +652,22 @@ module Channel =
                     | Waiting nextRemoteCommit -> nextRemoteCommit
                     | Revoked _info -> commitments1.RemoteCommit
                 let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
-                do! Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 payment
+                do!
+                    Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec
+                        reduced
+                        cs.StaticChannelConfig
+                        payment
                 return [ WeAcceptedOperationMonoHopUnidirectionalPayment(payment, commitments1) ]
             }
         | ApplyMonoHopUnidirectionalPayment msg ->
             result {
                 let commitments1 = cs.Commitments.AddRemoteProposal(msg)
                 let! reduced = commitments1.LocalCommit.Spec.Reduce (commitments1.LocalChanges.ACKed, commitments1.RemoteChanges.Proposed) |> expectTransactionError
-                do! Validation.checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 msg
+                do!
+                    Validation.checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec
+                        reduced
+                        cs.StaticChannelConfig
+                        msg
                 return [ WeAcceptedMonoHopUnidirectionalPayment commitments1 ]
             }
         | AddHTLC op when cs.NegotiatingState.HasEnteredShutdown() ->
@@ -678,9 +675,9 @@ module Channel =
             |> apiMisuse
         | AddHTLC op ->
             result {
-                do! Validation.checkOperationAddHTLC cs.Commitments op
+                do! Validation.checkOperationAddHTLC cs.StaticChannelConfig.RemoteParams op
                 let add: UpdateAddHTLCMsg = {
-                    ChannelId = cs.Commitments.ChannelId()
+                    ChannelId = cs.StaticChannelConfig.ChannelId()
                     HTLCId = cs.Commitments.LocalNextHTLCId
                     Amount = op.Amount
                     PaymentHash = op.PaymentHash
@@ -709,12 +706,21 @@ module Channel =
                     | Waiting nextRemoteCommit -> nextRemoteCommit
                     | Revoked _info -> commitments1.RemoteCommit
                 let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
-                do! Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec reduced commitments1 add
+                do!
+                    Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec
+                        reduced
+                        cs.StaticChannelConfig
+                        add
                 return [ WeAcceptedOperationAddHTLC(add, commitments1) ]
             }
         | ApplyUpdateAddHTLC (msg, height) ->
             result {
-                do! Validation.checkTheirUpdateAddHTLCIsAcceptable cs.Commitments msg height
+                do!
+                    Validation.checkTheirUpdateAddHTLCIsAcceptable
+                        cs.Commitments
+                        cs.StaticChannelConfig.LocalParams
+                        msg
+                        height
                 let commitments1 = {
                     cs.Commitments.AddRemoteProposal(msg) with
                         RemoteNextHTLCId = cs.Commitments.LocalNextHTLCId + 1UL
@@ -724,14 +730,23 @@ module Channel =
                         commitments1.LocalChanges.ACKed,
                         commitments1.RemoteChanges.Proposed
                     ) |> expectTransactionError
-                do! Validation.checkTheirUpdateAddHTLCIsAcceptableWithCurrentSpec reduced commitments1 msg
+                do!
+                    Validation.checkTheirUpdateAddHTLCIsAcceptableWithCurrentSpec
+                        reduced
+                        cs.StaticChannelConfig
+                        msg
                 return [ WeAcceptedUpdateAddHTLC commitments1 ]
             }
         | FulfillHTLC cmd ->
             result {
                 let! remoteNextCommitInfo =
                     remoteNextCommitInfoIfFundingLockedNormal cs.ShortChannelId cs.RemoteNextCommitInfo "FulfillHTLC"
-                let! t = Commitments.sendFulfill cmd cs.Commitments remoteNextCommitInfo
+                let! t =
+                    Commitments.sendFulfill
+                        cmd
+                        cs.Commitments
+                        cs.StaticChannelConfig
+                        remoteNextCommitInfo
                 return [ WeAcceptedOperationFulfillHTLC t ]
             }
         | ChannelCommand.ApplyUpdateFulfillHTLC msg ->
@@ -744,13 +759,24 @@ module Channel =
             result {
                 let! remoteNextCommitInfo =
                     remoteNextCommitInfoIfFundingLockedNormal cs.ShortChannelId cs.RemoteNextCommitInfo "FailHTLC"
-                return! Commitments.sendFail cs.NodeSecret op cs.Commitments remoteNextCommitInfo
+                return!
+                    Commitments.sendFail
+                        cs.NodeSecret
+                        op
+                        cs.Commitments
+                        cs.StaticChannelConfig
+                        remoteNextCommitInfo
             }
         | FailMalformedHTLC op ->
             result {
                 let! remoteNextCommitInfo =
                     remoteNextCommitInfoIfFundingLockedNormal cs.ShortChannelId cs.RemoteNextCommitInfo "FailMalformedHTLC"
-                return! Commitments.sendFailMalformed op cs.Commitments remoteNextCommitInfo
+                return!
+                    Commitments.sendFailMalformed
+                        op
+                        cs.Commitments
+                        cs.StaticChannelConfig
+                        remoteNextCommitInfo
             }
         | ApplyUpdateFailHTLC msg ->
             result {
@@ -768,14 +794,20 @@ module Channel =
             result {
                 let! _remoteNextCommitInfo =
                     remoteNextCommitInfoIfFundingLockedNormal cs.ShortChannelId cs.RemoteNextCommitInfo "UpdateFee"
-                return! cs.Commitments |> Commitments.sendFee op
+                return! Commitments.sendFee op cs.StaticChannelConfig cs.Commitments
             }
         | ApplyUpdateFee msg ->
             result {
                 let! _remoteNextCommitInfo =
                     remoteNextCommitInfoIfFundingLockedNormal cs.ShortChannelId cs.RemoteNextCommitInfo "ApplyUpdateFee"
                 let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
-                return! cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
+                return!
+                    Commitments.receiveFee
+                        cs.ChannelOptions
+                        localFeerate
+                        msg
+                        cs.StaticChannelConfig
+                        cs.Commitments
             }
         | SignCommitment ->
             let cm = cs.Commitments
@@ -787,7 +819,12 @@ module Channel =
                     // Ignore SignCommitment Command (nothing to sign)
                     return []
                 | RemoteNextCommitInfo.Revoked _ ->
-                    return! Commitments.sendCommit cs.ChannelPrivKeys cs.Network cm remoteNextCommitInfo
+                    return!
+                        Commitments.sendCommit
+                            cs.ChannelPrivKeys
+                            cm
+                            cs.StaticChannelConfig
+                            remoteNextCommitInfo
                 | RemoteNextCommitInfo.Waiting _ ->
                     // Already in the process of signing
                     return []
@@ -796,7 +833,12 @@ module Channel =
             result {
                 let! _remoteNextCommitInfo =
                     remoteNextCommitInfoIfFundingLockedNormal cs.ShortChannelId cs.RemoteNextCommitInfo "ApplyCommitmentSigned"
-                return! cs.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
+                return!
+                    Commitments.receiveCommit
+                        cs.ChannelPrivKeys
+                        msg
+                        cs.StaticChannelConfig
+                        cs.Commitments
             }
         | ApplyRevokeAndACK msg ->
             result {
@@ -840,12 +882,12 @@ module Channel =
                     do! Error <| cannotCloseChannel "shutdown is already in progress"
                 do!
                     Validation.checkShutdownScriptPubKeyAcceptable
-                        cs.LocalStaticShutdownScriptPubKey
+                        cs.StaticChannelConfig.LocalStaticShutdownScriptPubKey
                         localShutdownScriptPubKey
                 if (cs.Commitments.LocalHasUnsignedOutgoingHTLCs()) then
                     do! Error <| cannotCloseChannel "Cannot close with unsigned outgoing htlcs"
                 let shutdownMsg: ShutdownMsg = {
-                    ChannelId = cs.Commitments.ChannelId()
+                    ChannelId = cs.StaticChannelConfig.ChannelId()
                     ScriptPubKey = localShutdownScriptPubKey
                 }
                 return [ AcceptedOperationShutdown(shutdownMsg, localShutdownScriptPubKey) ]
@@ -855,11 +897,11 @@ module Channel =
                 let remoteShutdownScriptPubKey = msg.ScriptPubKey
                 do!
                     Validation.checkShutdownScriptPubKeyAcceptable
-                        cs.LocalStaticShutdownScriptPubKey
+                        cs.StaticChannelConfig.LocalStaticShutdownScriptPubKey
                         localShutdownScriptPubKey
                 do!
                     Validation.checkShutdownScriptPubKeyAcceptable
-                        cs.RemoteStaticShutdownScriptPubKey
+                        cs.StaticChannelConfig.RemoteStaticShutdownScriptPubKey
                         remoteShutdownScriptPubKey
                 let cm = cs.Commitments
                 // They have pending unsigned htlcs => they violated the spec, close the channel
@@ -905,24 +947,24 @@ module Channel =
                         | Some remoteNextCommitInfo -> cm.HasNoPendingHTLCs remoteNextCommitInfo
                     if hasNoPendingHTLCs then
                         // we have to send first closing_signed msg iif we are the funder
-                        if (cm.IsFunder) then
+                        if cs.StaticChannelConfig.IsFunder then
                             let! closingFee =
                                 Closing.firstClosingFee
                                     cm
                                     localShutdownScriptPubKey
                                     remoteShutdownScriptPubKey
                                     cs.FeeEstimator
-                                    cs.Network
+                                    cs.StaticChannelConfig
                                 |> expectTransactionError
                             let! (_closingTx, closingSignedMsg) =
-                                Closing.makeClosingTx (
-                                    cs.ChannelPrivKeys,
-                                    cm,
-                                    localShutdownScriptPubKey,
-                                    remoteShutdownScriptPubKey,
-                                    closingFee,
-                                    cs.Network
-                                ) |> expectTransactionError
+                                Closing.makeClosingTx
+                                    cs.ChannelPrivKeys
+                                    cm
+                                    localShutdownScriptPubKey
+                                    remoteShutdownScriptPubKey
+                                    closingFee
+                                    cs.StaticChannelConfig
+                                |> expectTransactionError
                             let nextState = {
                                 LocalRequestedShutdown = Some localShutdownScriptPubKey
                                 RemoteRequestedShutdown = Some remoteShutdownScriptPubKey
@@ -945,7 +987,7 @@ module Channel =
                             return [ AcceptedShutdownWhenNoPendingHTLCs(None, nextState) ]
                     else
                         let localShutdownMsg: ShutdownMsg = {
-                            ChannelId = cs.Commitments.ChannelId()
+                            ChannelId = cs.StaticChannelConfig.ChannelId()
                             ScriptPubKey = localShutdownScriptPubKey
                         }
                         return [
@@ -970,9 +1012,9 @@ module Channel =
                     | (None, None) ->
                         Error ReceivedClosingSignedBeforeSendingOrReceivingShutdown
                 let cm = cs.Commitments
-                let remoteChannelKeys = cm.RemoteChannelPubKeys
+                let remoteChannelKeys = cs.StaticChannelConfig.RemoteChannelPubKeys
                 let lastCommitFeeSatoshi =
-                    cm.FundingScriptCoin.TxOut.Value - (cm.LocalCommit.PublishableTxs.CommitTx.Value.TotalOut)
+                    cs.StaticChannelConfig.FundingScriptCoin.TxOut.Value - (cm.LocalCommit.PublishableTxs.CommitTx.Value.TotalOut)
                 do! checkRemoteProposedHigherFeeThanBaseFee lastCommitFeeSatoshi msg.FeeSatoshis
                 do!
                     checkRemoteProposedFeeWithinNegotiatedRange
@@ -981,14 +1023,13 @@ module Channel =
                         msg.FeeSatoshis
 
                 let! closingTx, _closingSignedMsg =
-                    Closing.makeClosingTx (
-                        cs.ChannelPrivKeys,
-                        cm,
-                        localShutdownScriptPubKey,
-                        remoteShutdownScriptPubKey,
-                        msg.FeeSatoshis,
-                        cs.Network
-                    )
+                    Closing.makeClosingTx
+                        cs.ChannelPrivKeys
+                        cm
+                        localShutdownScriptPubKey
+                        remoteShutdownScriptPubKey
+                        msg.FeeSatoshis
+                        cs.StaticChannelConfig
                     |> expectTransactionError
                 let! finalizedTx =
                     Transactions.checkTxFinalized
@@ -1018,7 +1059,7 @@ module Channel =
                                 localShutdownScriptPubKey
                                 remoteShutdownScriptPubKey
                                 cs.FeeEstimator
-                                cs.Network
+                                cs.StaticChannelConfig
                             |> expectTransactionError
                     let nextClosingFee =
                         Closing.nextClosingFee (localF, msg.FeeSatoshis)
@@ -1029,14 +1070,13 @@ module Channel =
                         return [ MutualClosePerformed finalizedTx ]
                     else
                         let! _closingTx, closingSignedMsg =
-                            Closing.makeClosingTx (
-                                cs.ChannelPrivKeys,
-                                cm,
-                                localShutdownScriptPubKey,
-                                remoteShutdownScriptPubKey,
-                                nextClosingFee,
-                                cs.Network
-                            )
+                            Closing.makeClosingTx
+                                cs.ChannelPrivKeys
+                                cm
+                                localShutdownScriptPubKey
+                                remoteShutdownScriptPubKey
+                                nextClosingFee
+                                cs.StaticChannelConfig
                             |> expectTransactionError
                         let nextState = {
                             cs.NegotiatingState with

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -630,53 +630,49 @@ module Channel =
                 }
                 let nextState = {
                     ShortChannelId = shortChannelId
-                    HaveWeSentFundingLocked = false
                 }
                 
                 match (state.Deferred) with
                 | None ->
-                    [ FundingConfirmed nextState; WeSentFundingLocked msgToSend ] |> Ok
+                    [ FundingConfirmed (msgToSend, nextState) ] |> Ok
                 | Some msg ->
-                    [ FundingConfirmed nextState; WeSentFundingLocked msgToSend; WeResumedDelayedFundingLocked msg ] |> Ok
+                    [ FundingConfirmed (msgToSend, nextState); WeResumedDelayedFundingLocked msg ] |> Ok
         | WaitForFundingLocked _state, ApplyFundingConfirmedOnBC(height, _txindex, depth) ->
             if (cs.FundingTxMinimumDepth <= depth) then
                 [] |> Ok
             else
                 onceConfirmedFundingTxHasBecomeUnconfirmed(height, depth)
         | WaitForFundingLocked state, ApplyFundingLocked msg ->
-            if (state.HaveWeSentFundingLocked) then
-                let initialChannelUpdate =
-                    let feeRate = cs.Commitments.LocalCommit.Spec.FeeRatePerKw
-                    let feeBase =
-                        ChannelHelpers.getOurFeeBaseMSat
-                            cs.FeeEstimator
-                            feeRate
-                            cs.Commitments.IsFunder
-                    ChannelHelpers.makeChannelUpdate (cs.Network.Consensus.HashGenesisBlock,
-                                               cs.NodeSecret,
-                                               cs.RemoteNodeId,
-                                               state.ShortChannelId,
-                                               cs.Commitments.LocalParams.ToSelfDelay,
-                                               cs.Commitments.RemoteParams.HTLCMinimumMSat,
-                                               feeBase,
-                                               cs.ChannelOptions.FeeProportionalMillionths,
-                                               true,
-                                               None)
-                let nextCommitments = {
-                    cs.Commitments with
-                        RemoteNextCommitInfo =
-                            RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint)
-                }
-                let nextState = {
-                    ShortChannelId = state.ShortChannelId
-                    ChannelAnnouncement = None
-                    ChannelUpdate = initialChannelUpdate
-                    LocalShutdown = None
-                    RemoteShutdown = None
-                }
-                [ BothFundingLocked(nextState, nextCommitments) ] |> Ok
-            else
-                [] |> Ok
+            let initialChannelUpdate =
+                let feeRate = cs.Commitments.LocalCommit.Spec.FeeRatePerKw
+                let feeBase =
+                    ChannelHelpers.getOurFeeBaseMSat
+                        cs.FeeEstimator
+                        feeRate
+                        cs.Commitments.IsFunder
+                ChannelHelpers.makeChannelUpdate (cs.Network.Consensus.HashGenesisBlock,
+                                           cs.NodeSecret,
+                                           cs.RemoteNodeId,
+                                           state.ShortChannelId,
+                                           cs.Commitments.LocalParams.ToSelfDelay,
+                                           cs.Commitments.RemoteParams.HTLCMinimumMSat,
+                                           feeBase,
+                                           cs.ChannelOptions.FeeProportionalMillionths,
+                                           true,
+                                           None)
+            let nextCommitments = {
+                cs.Commitments with
+                    RemoteNextCommitInfo =
+                        RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint)
+            }
+            let nextState = {
+                ShortChannelId = state.ShortChannelId
+                ChannelAnnouncement = None
+                ChannelUpdate = initialChannelUpdate
+                LocalShutdown = None
+                RemoteShutdown = None
+            }
+            [ BothFundingLocked(nextState, nextCommitments) ] |> Ok
 
         // ---------- normal operation ---------
         | ChannelState.Normal state, MonoHopUnidirectionalPayment op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
@@ -1086,7 +1082,7 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e, c.State with
         // --------- init both ------
-        | FundingConfirmed data, WaitForFundingConfirmed _ ->
+        | FundingConfirmed (_ourFundingLockedMsg, data), WaitForFundingConfirmed _ ->
             { c with State = WaitForFundingLocked data }
         | TheySentFundingLocked msg, WaitForFundingConfirmed s ->
             { c with State = WaitForFundingConfirmed({ s with Deferred = Some(msg) }) }
@@ -1115,9 +1111,6 @@ module Channel =
                 RemoteShutdown = None
             }
             { c with State = ChannelState.Normal nextState }
-        | WeSentFundingLocked _msg, WaitForFundingLocked prevState ->
-            { c with State = WaitForFundingLocked { prevState with HaveWeSentFundingLocked = true } }
-
         // ----- normal operation --------
         | WeAcceptedOperationMonoHopUnidirectionalPayment(_, newCommitments), ChannelState.Normal _normalData ->
             { c with Commitments = newCommitments }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -501,6 +501,50 @@ and Channel = {
             return self
     }
 
+    member self.ApplyFundingConfirmedOnBC (height: BlockHeight)
+                                          (txindex: TxIndexInBlock)
+                                          (depth: BlockHeightOffset32)
+                                              : Result<Channel * Option<FundingLockedMsg>, ChannelError> = result {
+        match self.ShortChannelId with
+        | None ->
+            if self.StaticChannelConfig.FundingTxMinimumDepth > depth then
+                // TODO: this should probably be an error (?)
+                return self, None
+            else
+                let nextPerCommitmentPoint =
+                    self.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint
+                        (CommitmentNumber.FirstCommitment.NextCommitment())
+                let msgToSend: FundingLockedMsg = {
+                    ChannelId = self.StaticChannelConfig.ChannelId()
+                    NextPerCommitmentPoint = nextPerCommitmentPoint
+                }
+
+                // This is temporary channel id that we will use in our
+                // channel_update message, the goal is to be able to use our
+                // channel as soon as it reaches NORMAL state, and before it is
+                // announced on the network (this id might be updated when the
+                // funding tx gets deeply buried, if there was a reorg in the
+                // meantime) this is not specified in BOLT.
+                let shortChannelId = {
+                    ShortChannelId.BlockHeight = height;
+                    BlockIndex = txindex
+                    TxOutIndex =
+                        self.StaticChannelConfig.FundingScriptCoin.Outpoint.N
+                        |> uint16
+                        |> TxOutIndex
+                }
+                let channel = {
+                    self with
+                        ShortChannelId = Some shortChannelId
+                }
+                return channel, Some msgToSend
+        | Some _shortChannelId ->
+            if (self.StaticChannelConfig.FundingTxMinimumDepth <= depth) then
+                return self, None
+            else
+                return! Error <| OnceConfirmedFundingTxHasBecomeUnconfirmed(height, depth)
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -578,53 +622,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | ApplyFundingConfirmedOnBC(height, txindex, depth) ->
-            match cs.ShortChannelId with
-            | None -> 
-                if cs.StaticChannelConfig.FundingTxMinimumDepth > depth then
-                    [] |> Ok
-                else
-                    let nextPerCommitmentPoint =
-                        cs.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint
-                            (CommitmentNumber.FirstCommitment.NextCommitment())
-                    let msgToSend: FundingLockedMsg = {
-                        ChannelId = cs.StaticChannelConfig.ChannelId()
-                        NextPerCommitmentPoint = nextPerCommitmentPoint
-                    }
-
-                    // This is temporary channel id that we will use in our channel_update message, the goal is to be able to use our channel
-                    // as soon as it reaches NORMAL state, and before it is announced on the network
-                    // (this id might be updated when the funding tx gets deeply buried, if there was a reorg in the meantime)
-                    // this is not specified in BOLT.
-                    let shortChannelId = {
-                        ShortChannelId.BlockHeight = height;
-                        BlockIndex = txindex
-                        TxOutIndex =
-                            cs.StaticChannelConfig.FundingScriptCoin.Outpoint.N
-                            |> uint16
-                            |> TxOutIndex
-                    }
-                    match cs.RemoteNextCommitInfo with
-                    | None ->
-                        [ FundingConfirmed (msgToSend, shortChannelId) ] |> Ok
-                    | Some remoteNextCommitInfo ->
-                        let remoteNextPerCommitmentPoint =
-                            match remoteNextCommitInfo with
-                            | Revoked remoteNextPerCommitmentPoint -> remoteNextPerCommitmentPoint
-                            // Note:
-                            // We should never actually reach this line because we
-                            // never send a commit before the funding is
-                            // confirmed.
-                            | Waiting remoteCommit -> remoteCommit.RemotePerCommitmentPoint
-                        Ok [
-                            FundingConfirmed (msgToSend, shortChannelId)
-                            WeResumedDelayedFundingLocked remoteNextPerCommitmentPoint
-                        ]
-            | Some _shortChannelId ->
-                if (cs.StaticChannelConfig.FundingTxMinimumDepth <= depth) then
-                    [] |> Ok
-                else
-                    onceConfirmedFundingTxHasBecomeUnconfirmed(height, depth)
         | MonoHopUnidirectionalPayment op when cs.NegotiatingState.HasEnteredShutdown() ->
             sprintf "Could not send mono-hop unidirectional payment %A since shutdown is already in progress." op
             |> apiMisuse
@@ -1082,12 +1079,6 @@ module Channel =
 
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
-        // --------- init both ------
-        | FundingConfirmed (_ourFundingLockedMsg, shortChannelId) ->
-            {
-                c with
-                    ShortChannelId = Some shortChannelId
-            }
         // ----- normal operation --------
         | WeAcceptedOperationMonoHopUnidirectionalPayment(_, newCommitments) ->
             { c with Commitments = newCommitments }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -536,18 +536,6 @@ module Channel =
             ((localClosingFee.Satoshi + remoteClosingFee.Satoshi) / 4L) * 2L
             |> Money.Satoshis
 
-        let claimCurrentLocalCommitTxOutputs (channelPrivKeys: ChannelPrivKeys,
-                                              commitments: Commitments,
-                                              commitTx: CommitTx
-                                             ) =
-            result {
-                let commitmentSeed = channelPrivKeys.CommitmentSeed
-                do! check (commitments.LocalCommit.PublishableTxs.CommitTx.Value.GetTxId()) (=) (commitTx.Value.GetTxId()) "txid mismatch. provided txid (%A) does not match current local commit tx (%A)"
-                let _localPerCommitmentPoint =
-                    commitmentSeed.DerivePerCommitmentPoint commitments.LocalCommit.Index
-                failwith "TODO"
-            }
-
     let makeChannelReestablish (channelPrivKeys: ChannelPrivKeys)
                                (commitments: Commitments)
                                    : Result<ChannelEvent list, ChannelError> =

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -34,16 +34,6 @@ type ChannelWaitingForFundingSigned = {
             let sigPairs = seq [ remoteSigPairOfLocalTx; ]
             Transactions.checkTxFinalized signedLocalCommitTx CommitTx.WhichInput sigPairs |> expectTransactionError
         let commitments = {
-            LocalCommit = {
-                Index = CommitmentNumber.FirstCommitment
-                Spec = self.LocalSpec
-                PublishableTxs = {
-                    PublishableTxs.CommitTx = finalizedLocalCommitTx
-                    HTLCTxs = []
-                }
-                PendingHTLCSuccessTxs = []
-            }
-            RemoteCommit = self.RemoteCommit
             LocalChanges = LocalChanges.Zero
             RemoteChanges = RemoteChanges.Zero
             LocalNextHTLCId = HTLCId.Zero
@@ -55,6 +45,16 @@ type ChannelWaitingForFundingSigned = {
                 StaticChannelConfig = self.StaticChannelConfig
                 RemotePerCommitmentSecrets = PerCommitmentSecretStore()
                 ShortChannelId = None
+                LocalCommit = {
+                    Index = CommitmentNumber.FirstCommitment
+                    Spec = self.LocalSpec
+                    PublishableTxs = {
+                        PublishableTxs.CommitTx = finalizedLocalCommitTx
+                        HTLCTxs = []
+                    }
+                    PendingHTLCSuccessTxs = []
+                }
+                RemoteCommit = self.RemoteCommit
             }
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
@@ -124,20 +124,6 @@ and ChannelWaitingForFundingCreated = {
                 msg.FundingOutputIndex
                 self.FundingSatoshis
         let commitments = {
-            LocalCommit = {
-                Index = CommitmentNumber.FirstCommitment
-                Spec = localSpec
-                PublishableTxs = {
-                    PublishableTxs.CommitTx = finalizedCommitTx
-                    HTLCTxs = []
-                }
-                PendingHTLCSuccessTxs = []
-            }
-            RemoteCommit = {
-                Index = CommitmentNumber.FirstCommitment
-                Spec = remoteSpec
-                RemotePerCommitmentPoint = self.RemoteFirstPerCommitmentPoint
-            }
             LocalChanges = LocalChanges.Zero
             RemoteChanges = RemoteChanges.Zero
             LocalNextHTLCId = HTLCId.Zero
@@ -167,6 +153,20 @@ and ChannelWaitingForFundingCreated = {
                 StaticChannelConfig = staticChannelConfig
                 RemotePerCommitmentSecrets = PerCommitmentSecretStore()
                 ShortChannelId = None
+                LocalCommit = {
+                    Index = CommitmentNumber.FirstCommitment
+                    Spec = localSpec
+                    PublishableTxs = {
+                        PublishableTxs.CommitTx = finalizedCommitTx
+                        HTLCTxs = []
+                    }
+                    PendingHTLCSuccessTxs = []
+                }
+                RemoteCommit = {
+                    Index = CommitmentNumber.FirstCommitment
+                    Spec = remoteSpec
+                    RemotePerCommitmentPoint = self.RemoteFirstPerCommitmentPoint
+                }
             }
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
@@ -500,7 +500,7 @@ and Channel = {
                 YourLastPerCommitmentSecret =
                     self.SavedChannelState.RemotePerCommitmentSecrets.MostRecentPerCommitmentSecret()
                 MyCurrentPerCommitmentPoint =
-                    commitmentSeed.DerivePerCommitmentPoint self.Commitments.RemoteCommit.Index
+                    commitmentSeed.DerivePerCommitmentPoint self.SavedChannelState.RemoteCommit.Index
             }
         }
         ourChannelReestablish
@@ -596,7 +596,7 @@ and Channel = {
             let remoteCommit1 =
                 match remoteNextCommitInfo with
                 | Waiting nextRemoteCommit -> nextRemoteCommit
-                | Revoked _info -> commitments1.RemoteCommit
+                | Revoked _info -> self.SavedChannelState.RemoteCommit
             let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
             do!
                 Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec
@@ -614,7 +614,7 @@ and Channel = {
                                                       : Result<Channel, ChannelError> = result {
         let commitments1 = self.Commitments.AddRemoteProposal(msg)
         let! reduced =
-            commitments1.LocalCommit.Spec.Reduce
+            self.SavedChannelState.LocalCommit.Spec.Reduce
                 (commitments1.LocalChanges.ACKed, commitments1.RemoteChanges.Proposed)
             |> expectTransactionError
         do!
@@ -664,7 +664,7 @@ and Channel = {
             let remoteCommit1 =
                 match remoteNextCommitInfo with
                 | Waiting nextRemoteCommit -> nextRemoteCommit
-                | Revoked _info -> commitments1.RemoteCommit
+                | Revoked _info -> self.SavedChannelState.RemoteCommit
             let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
             do!
                 Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec
@@ -692,7 +692,7 @@ and Channel = {
                 RemoteNextHTLCId = self.Commitments.LocalNextHTLCId + 1UL
         }
         let! reduced =
-            commitments1.LocalCommit.Spec.Reduce (
+            self.SavedChannelState.LocalCommit.Spec.Reduce (
                 commitments1.LocalChanges.ACKed,
                 commitments1.RemoteChanges.Proposed
             ) |> expectTransactionError
@@ -715,7 +715,7 @@ and Channel = {
             Commitments.sendFulfill
                 cmd
                 self.Commitments
-                self.SavedChannelState.StaticChannelConfig
+                self.SavedChannelState
                 remoteNextCommitInfo
 
         let channel = {
@@ -729,7 +729,12 @@ and Channel = {
                                            : Result<Channel, ChannelError> = result {
         let! remoteNextCommitInfo =
             self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyUpdateFulfullHTLC"
-        let! newCommitments = Commitments.receiveFulfill msg self.Commitments remoteNextCommitInfo
+        let! newCommitments =
+            Commitments.receiveFulfill
+                msg
+                self.Commitments
+                self.SavedChannelState
+                remoteNextCommitInfo
         return {
             self with
                 Commitments = newCommitments
@@ -745,7 +750,7 @@ and Channel = {
                 self.NodeSecret
                 op
                 self.Commitments
-                self.SavedChannelState.StaticChannelConfig
+                self.SavedChannelState
                 remoteNextCommitInfo
         let channel = {
             self with
@@ -762,7 +767,7 @@ and Channel = {
             Commitments.sendFailMalformed
                 op
                 self.Commitments
-                self.SavedChannelState.StaticChannelConfig
+                self.SavedChannelState
                 remoteNextCommitInfo
         let channel = {
             self with
@@ -775,7 +780,12 @@ and Channel = {
                                         : Result<Channel, ChannelError> = result {
         let! remoteNextCommitInfo =
             self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyUpdateFailHTLC"
-        let! newCommitments = Commitments.receiveFail msg self.Commitments remoteNextCommitInfo
+        let! newCommitments =
+            Commitments.receiveFail
+                msg
+                self.Commitments
+                self.SavedChannelState
+                remoteNextCommitInfo
         return {
             self with
                 Commitments = newCommitments
@@ -787,7 +797,11 @@ and Channel = {
         let! remoteNextCommitInfo =
             self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyUpdateFailMalformedHTLC"
         let! newCommitments =
-            Commitments.receiveFailMalformed msg self.Commitments remoteNextCommitInfo
+            Commitments.receiveFailMalformed
+                msg
+                self.Commitments
+                self.SavedChannelState
+                remoteNextCommitInfo
         return {
             self with
                 Commitments = newCommitments
@@ -799,7 +813,7 @@ and Channel = {
         let! _remoteNextCommitInfo =
             self.RemoteNextCommitInfoIfFundingLockedNormal "UpdateFee"
         let! updateFeeMsg, newCommitments =
-            Commitments.sendFee op self.SavedChannelState.StaticChannelConfig self.Commitments
+            Commitments.sendFee op self.SavedChannelState self.Commitments
         let channel = {
             self with
                 Commitments = newCommitments
@@ -817,7 +831,7 @@ and Channel = {
                 self.ChannelOptions
                 localFeerate
                 msg
-                self.SavedChannelState.StaticChannelConfig
+                self.SavedChannelState
                 self.Commitments
         return {
             self with
@@ -838,7 +852,7 @@ and Channel = {
                 Commitments.sendCommit
                     self.ChannelPrivKeys
                     cm
-                    self.SavedChannelState.StaticChannelConfig
+                    self.SavedChannelState
                     remoteNextCommitInfo
             let channel = {
                 self with
@@ -856,14 +870,15 @@ and Channel = {
                                           : Result<Channel * RevokeAndACKMsg, ChannelError> = result {
         let! _remoteNextCommitInfo =
             self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyCommitmentSigned"
-        let! revokeAndACKMsg, newCommitments =
+        let! revokeAndACKMsg, newSavedChannelState, newCommitments =
             Commitments.receiveCommit
                 self.ChannelPrivKeys
                 msg
-                self.SavedChannelState.StaticChannelConfig
                 self.Commitments
+                self.SavedChannelState
         let channel = {
             self with
+                SavedChannelState = newSavedChannelState
                 Commitments = newCommitments
         }
         return channel, revokeAndACKMsg
@@ -875,8 +890,8 @@ and Channel = {
             self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyRevokeAndACK"
         let cm = self.Commitments
         match remoteNextCommitInfo with
-        | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> cm.RemoteCommit.RemotePerCommitmentPoint) ->
-            let errorMsg = sprintf "Invalid revoke_and_ack %A; must be %A" msg.PerCommitmentSecret cm.RemoteCommit.RemotePerCommitmentPoint
+        | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> self.SavedChannelState.RemoteCommit.RemotePerCommitmentPoint) ->
+            let errorMsg = sprintf "Invalid revoke_and_ack %A; must be %A" msg.PerCommitmentSecret self.SavedChannelState.RemoteCommit.RemotePerCommitmentPoint
             return! Error <| invalidRevokeAndACK msg errorMsg
         | RemoteNextCommitInfo.Revoked _ ->
             let errorMsg = sprintf "Unexpected revocation"
@@ -884,7 +899,7 @@ and Channel = {
         | RemoteNextCommitInfo.Waiting theirNextCommit ->
             let remotePerCommitmentSecretsOpt =
                 self.SavedChannelState.RemotePerCommitmentSecrets.InsertPerCommitmentSecret
-                    cm.RemoteCommit.Index
+                    self.SavedChannelState.RemoteCommit.Index
                     msg.PerCommitmentSecret
             match remotePerCommitmentSecretsOpt with
             | Error err -> return! Error <| invalidRevokeAndACK msg err.Message
@@ -900,11 +915,11 @@ and Channel = {
                             cm.RemoteChanges with
                                 Signed = []
                         }
-                        RemoteCommit = theirNextCommit
                 }
                 let savedChannelState = {
                     self.SavedChannelState with
                         RemotePerCommitmentSecrets = remotePerCommitmentSecrets
+                        RemoteCommit = theirNextCommit
                 }
                 return {
                     self with
@@ -953,10 +968,9 @@ and Channel = {
                                        (remoteSpk: ShutdownScriptPubKey)
                                        (closingFee: Money) = result {
         let channelPrivKeys = self.ChannelPrivKeys
-        let cm = self.Commitments
         let staticChannelConfig = self.SavedChannelState.StaticChannelConfig
         let dustLimitSatoshis = Money.Max(staticChannelConfig.LocalParams.DustLimitSatoshis, staticChannelConfig.RemoteParams.DustLimitSatoshis)
-        let! closingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin (localSpk) (remoteSpk) staticChannelConfig.IsFunder (dustLimitSatoshis) (closingFee) (cm.LocalCommit.Spec) staticChannelConfig.Network
+        let! closingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin (localSpk) (remoteSpk) staticChannelConfig.IsFunder (dustLimitSatoshis) (closingFee) (self.SavedChannelState.LocalCommit.Spec) staticChannelConfig.Network
         let localSignature, psbtUpdated = channelPrivKeys.SignWithFundingPrivKey closingTx.Value
         let msg: ClosingSignedMsg = {
             ChannelId = staticChannelConfig.ChannelId()
@@ -968,15 +982,14 @@ and Channel = {
 
     member internal self.FirstClosingFee (localSpk: ShutdownScriptPubKey)
                                          (remoteSpk: ShutdownScriptPubKey) = result {
-        let cm = self.Commitments
         let feeEst = self.ChannelOptions.FeeEstimator
         let staticChannelConfig = self.SavedChannelState.StaticChannelConfig
-        let! dummyClosingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin localSpk remoteSpk staticChannelConfig.IsFunder Money.Zero Money.Zero cm.LocalCommit.Spec staticChannelConfig.Network
+        let! dummyClosingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin localSpk remoteSpk staticChannelConfig.IsFunder Money.Zero Money.Zero self.SavedChannelState.LocalCommit.Spec staticChannelConfig.Network
         let tx = dummyClosingTx.Value.GetGlobalTransaction()
         tx.Inputs.[0].WitScript <-
             let witness = seq [ Channel.DummySig.ToBytes(); Channel.DummySig.ToBytes(); dummyClosingTx.Value.Inputs.[0].WitnessScript.ToBytes() ]
             WitScript(witness)
-        let feeRatePerKw = FeeRatePerKw.Max (feeEst.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority), cm.LocalCommit.Spec.FeeRatePerKw)
+        let feeRatePerKw = FeeRatePerKw.Max (feeEst.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority), self.SavedChannelState.LocalCommit.Spec.FeeRatePerKw)
         return feeRatePerKw.CalculateFeeFromVirtualSize(tx)
     }
 
@@ -1028,7 +1041,8 @@ and Channel = {
             let hasNoPendingHTLCs =
                 match self.RemoteNextCommitInfo with
                 | None -> true
-                | Some remoteNextCommitInfo -> cm.HasNoPendingHTLCs remoteNextCommitInfo
+                | Some remoteNextCommitInfo ->
+                    self.SavedChannelState.HasNoPendingHTLCs remoteNextCommitInfo
             if hasNoPendingHTLCs then
                 // we have to send first closing_signed msg iif we are the funder
                 if self.SavedChannelState.StaticChannelConfig.IsFunder then
@@ -1095,10 +1109,9 @@ and Channel = {
                 Error ReceivedClosingSignedBeforeSendingShutdown
             | (None, None) ->
                 Error ReceivedClosingSignedBeforeSendingOrReceivingShutdown
-        let cm = self.Commitments
         let remoteChannelKeys = self.SavedChannelState.StaticChannelConfig.RemoteChannelPubKeys
         let lastCommitFeeSatoshi =
-            self.SavedChannelState.StaticChannelConfig.FundingScriptCoin.TxOut.Value - (cm.LocalCommit.PublishableTxs.CommitTx.Value.TotalOut)
+            self.SavedChannelState.StaticChannelConfig.FundingScriptCoin.TxOut.Value - (self.SavedChannelState.LocalCommit.PublishableTxs.CommitTx.Value.TotalOut)
         do! checkRemoteProposedHigherFeeThanBaseFee lastCommitFeeSatoshi msg.FeeSatoshis
         do!
             checkRemoteProposedFeeWithinNegotiatedRange

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -14,7 +14,7 @@ open ResultUtils
 open ResultUtils.Portability
 
 type ChannelWaitingForFundingSigned = {
-    Config: ChannelConfig
+    ChannelOptions: ChannelOptions
     ChannelPrivKeys: ChannelPrivKeys
     FeeEstimator: IFeeEstimator
     RemoteNodeId: NodeId
@@ -67,7 +67,7 @@ type ChannelWaitingForFundingSigned = {
                           InitialFeeRatePerKw = state.InitialFeeRatePerKw
                           ChannelId = msg.ChannelId }
         let channel = {
-            Config = self.Config
+            ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
             FeeEstimator = self.FeeEstimator
             RemoteNodeId = self.RemoteNodeId
@@ -80,7 +80,7 @@ type ChannelWaitingForFundingSigned = {
     }
 
 and ChannelWaitingForFundingCreated = {
-    Config: ChannelConfig
+    ChannelOptions: ChannelOptions
     ChannelPrivKeys: ChannelPrivKeys
     FeeEstimator: IFeeEstimator
     RemoteNodeId: NodeId
@@ -151,7 +151,7 @@ and ChannelWaitingForFundingCreated = {
                           InitialFeeRatePerKw = state.InitialFeeRatePerKw
                           ChannelId = channelId }
         let channel = {
-            Config = self.Config
+            ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
             FeeEstimator = self.FeeEstimator
             RemoteNodeId = self.RemoteNodeId
@@ -164,7 +164,7 @@ and ChannelWaitingForFundingCreated = {
     }
 
 and ChannelWaitingForFundingTx = {
-    Config: ChannelConfig
+    ChannelOptions: ChannelOptions
     ChannelPrivKeys: ChannelPrivKeys
     FeeEstimator: IFeeEstimator
     RemoteNodeId: NodeId
@@ -220,7 +220,7 @@ and ChannelWaitingForFundingTx = {
             InitialFeeRatePerKw = state.InputInitFunder.InitFeeRatePerKw
         }
         let channelWaitingForFundingSigned = {
-            Config = self.Config
+            ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
             FeeEstimator = self.FeeEstimator
             RemoteNodeId = self.RemoteNodeId
@@ -234,7 +234,8 @@ and ChannelWaitingForFundingTx = {
 
 
 and ChannelWaitingForAcceptChannel = {
-    Config: ChannelConfig
+    ChannelOptions: ChannelOptions
+    ChannelHandshakeLimits: ChannelHandshakeLimits
     ChannelPrivKeys: ChannelPrivKeys
     FeeEstimator: IFeeEstimator
     RemoteNodeId: NodeId
@@ -245,7 +246,7 @@ and ChannelWaitingForAcceptChannel = {
     member self.ApplyAcceptChannel (msg: AcceptChannelMsg)
                                        : Result<IDestination * Money * ChannelWaitingForFundingTx, ChannelError> = result {
         let state = self.WaitForAcceptChannelData
-        do! Validation.checkAcceptChannelMsgAcceptable (self.Config) state msg
+        do! Validation.checkAcceptChannelMsgAcceptable self.ChannelHandshakeLimits state msg
         let redeem =
             Scripts.funding
                 (state.InputInitFunder.ChannelPrivKeys.ToChannelPubKeys().FundingPubKey)
@@ -258,7 +259,7 @@ and ChannelWaitingForAcceptChannel = {
             LastReceived = msg
         }
         let channelWaitingForFundingTx = {
-            Config = self.Config
+            ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
             FeeEstimator = self.FeeEstimator
             RemoteNodeId = self.RemoteNodeId
@@ -270,7 +271,7 @@ and ChannelWaitingForAcceptChannel = {
     }
 
 and Channel = {
-    Config: ChannelConfig
+    ChannelOptions: ChannelOptions
     ChannelPrivKeys: ChannelPrivKeys
     FeeEstimator: IFeeEstimator
     RemoteNodeId: NodeId
@@ -280,7 +281,8 @@ and Channel = {
     FundingTxMinimumDepth: BlockHeightOffset32
  }
         with
-        static member NewOutbound(config: ChannelConfig,
+        static member NewOutbound(channelHandshakeLimits: ChannelHandshakeLimits,
+                                  channelOptions: ChannelOptions,
                                   nodeMasterPrivKey: NodeMasterPrivKey,
                                   channelIndex: int,
                                   feeEstimator: IFeeEstimator,
@@ -307,10 +309,10 @@ and Channel = {
                 HTLCBasepoint = inputInitFunder.ChannelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
                 FirstPerCommitmentPoint = inputInitFunder.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
                 ChannelFlags = inputInitFunder.ChannelFlags
-                ShutdownScriptPubKey = config.ChannelOptions.ShutdownScriptPubKey
+                ShutdownScriptPubKey = channelOptions.ShutdownScriptPubKey
             }
             result {
-                do! Validation.checkOurOpenChannelMsgAcceptable config openChannelMsgToSend
+                do! Validation.checkOurOpenChannelMsgAcceptable openChannelMsgToSend
                 let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
                 let nodeSecret = nodeMasterPrivKey.NodeSecret()
                 let waitForAcceptChannelData = {
@@ -318,7 +320,8 @@ and Channel = {
                     LastSent = openChannelMsgToSend
                 }
                 let channelWaitingForAcceptChannel = {
-                    Config = config
+                    ChannelHandshakeLimits = channelHandshakeLimits
+                    ChannelOptions = channelOptions
                     ChannelPrivKeys = channelPrivKeys
                     FeeEstimator = feeEstimator
                     RemoteNodeId = remoteNodeId
@@ -329,7 +332,8 @@ and Channel = {
                 return (openChannelMsgToSend, channelWaitingForAcceptChannel)
             }
 
-        static member NewInbound (config: ChannelConfig,
+        static member NewInbound (channelHandshakeLimits: ChannelHandshakeLimits,
+                                  channelOptions: ChannelOptions,
                                   nodeMasterPrivKey: NodeMasterPrivKey,
                                   channelIndex: int,
                                   feeEstimator: IFeeEstimator,
@@ -340,7 +344,7 @@ and Channel = {
                                   openChannelMsg: OpenChannelMsg
                                  ): Result<AcceptChannelMsg * ChannelWaitingForFundingCreated, ChannelError> =
             result {
-                do! Validation.checkOpenChannelMsgAcceptable feeEstimator config openChannelMsg
+                do! Validation.checkOpenChannelMsgAcceptable feeEstimator channelHandshakeLimits channelOptions openChannelMsg
                 let localParams = inputInitFundee.LocalParams
                 let channelKeys = inputInitFundee.ChannelPrivKeys
                 let localCommitmentPubKey = channelKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
@@ -359,14 +363,14 @@ and Channel = {
                     DelayedPaymentBasepoint = channelKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
                     HTLCBasepoint = channelKeys.HtlcBasepointSecret.HtlcBasepoint()
                     FirstPerCommitmentPoint = localCommitmentPubKey
-                    ShutdownScriptPubKey = config.ChannelOptions.ShutdownScriptPubKey
+                    ShutdownScriptPubKey = channelOptions.ShutdownScriptPubKey
                 }
                 let remoteParams = RemoteParams.FromOpenChannel remoteNodeId inputInitFundee.RemoteInit openChannelMsg
                 let waitForFundingCreatedData = Data.WaitForFundingCreatedData.Create localParams remoteParams openChannelMsg acceptChannelMsg
                 let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
                 let nodeSecret = nodeMasterPrivKey.NodeSecret()
                 let channelWaitingForFundingCreated = {
-                    Config = config
+                    ChannelOptions = channelOptions
                     ChannelPrivKeys = channelPrivKeys
                     FeeEstimator = feeEstimator
                     RemoteNodeId = remoteNodeId
@@ -533,7 +537,7 @@ module Channel =
                                                state.Commitments.LocalParams.ToSelfDelay,
                                                state.Commitments.RemoteParams.HTLCMinimumMSat,
                                                feeBase,
-                                               cs.Config.ChannelOptions.FeeProportionalMillionths,
+                                               cs.ChannelOptions.FeeProportionalMillionths,
                                                true,
                                                None)
                 let nextState = { NormalData.Buried = true
@@ -639,7 +643,7 @@ module Channel =
             state.Commitments |> Commitments.sendFee op
         | ChannelState.Normal state, ApplyUpdateFee msg ->
             let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
-            state.Commitments |> Commitments.receiveFee cs.Config localFeerate msg
+            state.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
 
         | ChannelState.Normal state, SignCommitment ->
             let cm = state.Commitments
@@ -789,7 +793,7 @@ module Channel =
             state.Commitments |> Commitments.sendFee op
         | Shutdown state, ApplyUpdateFee msg ->
             let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
-            state.Commitments |> Commitments.receiveFee cs.Config localFeerate msg
+            state.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
         | Shutdown state, SignCommitment ->
             let cm = state.Commitments
             match cm.RemoteNextCommitInfo with
@@ -839,7 +843,7 @@ module Channel =
                     |> Option.map (fun v -> v.LocalClosingSigned.FeeSatoshis)
                 let areWeInDeal = Some(msg.FeeSatoshis) = maybeLocalFee
                 let hasTooManyNegotiationDone =
-                    (state.ClosingTxProposed |> List.collect (id) |> List.length) >= cs.Config.PeerChannelConfigLimits.MaxClosingNegotiationIterations
+                    (state.ClosingTxProposed |> List.collect (id) |> List.length) >= cs.ChannelOptions.MaxClosingNegotiationIterations
                 if (areWeInDeal || hasTooManyNegotiationDone) then
                     return! Closing.handleMutualClose (finalizedTx, { state with MaybeBestUnpublishedTx = Some(finalizedTx) })
                 else
@@ -920,7 +924,7 @@ module Channel =
                                                            s.Commitments.LocalParams.ToSelfDelay,
                                                            s.Commitments.RemoteParams.HTLCMinimumMSat,
                                                            feeBase,
-                                                           c.Config.ChannelOptions.FeeProportionalMillionths,
+                                                           c.ChannelOptions.FeeProportionalMillionths,
                                                            true,
                                                            None)
             let nextState = { NormalData.Buried = false;

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -75,8 +75,11 @@ type ChannelWaitingForFundingSigned = {
             OriginChannels = Map.empty
             RemotePerCommitmentSecrets = PerCommitmentSecretStore()
         }
-        let nextState = WaitForFundingConfirmed {
-            RemoteNextPerCommitmentPointOpt = None
+        let nextState = ChannelState.Normal {
+            ShortChannelId = None
+            LocalShutdown = None
+            RemoteShutdown = None
+            RemoteNextCommitInfo = None
         }
         let channel = {
             ChannelOptions = self.ChannelOptions
@@ -183,8 +186,11 @@ and ChannelWaitingForFundingCreated = {
             ChannelId = channelId
             Signature = !>localSigOfRemoteCommit.Signature
         }
-        let nextState = WaitForFundingConfirmed {
-            RemoteNextPerCommitmentPointOpt = None
+        let nextState = ChannelState.Normal {
+            ShortChannelId = None
+            LocalShutdown = None
+            RemoteShutdown = None
+            RemoteNextCommitInfo = None
         }
         let channel = {
             ChannelOptions = self.ChannelOptions
@@ -541,14 +547,14 @@ module Channel =
 
         let handleMutualClose (closingTx: FinalizedTx)
                               (d: NegotiatingData)
-                              (remoteNextCommitInfo: RemoteNextCommitInfo) =
+                              (remoteNextCommitInfoOpt: Option<RemoteNextCommitInfo>) =
             let nextData =
                 ClosingData.Create
                     None
                     DateTime.Now
                     (d.ClosingTxProposed |> List.collect id |> List.map (fun tx -> tx.UnsignedTx))
                     closingTx
-                    remoteNextCommitInfo
+                    remoteNextCommitInfoOpt
             [ MutualClosePerformed (closingTx, nextData) ]
             |> Ok
 
@@ -584,62 +590,103 @@ module Channel =
             }
         [ WeSentChannelReestablish ourChannelReestablish ] |> Ok
 
+    let remoteNextCommitInfoIfFundingLocked (remoteNextCommitInfoOpt: Option<RemoteNextCommitInfo>)
+                                            (operation: string)
+                                                : Result<RemoteNextCommitInfo, ChannelError> =
+        match remoteNextCommitInfoOpt with
+        | None ->
+            sprintf
+                "cannot perform operation %s because peer has not sent funding_locked"
+                operation
+            |> apiMisuse
+        | Some remoteNextCommitInfo -> Ok remoteNextCommitInfo
+
+    let remoteNextCommitInfoIfFundingLockedNormal (normalData: NormalData)
+                                                  (operation: string)
+                                                      : Result<RemoteNextCommitInfo, ChannelError> =
+        match normalData.ShortChannelId with
+        | None ->
+            sprintf
+                "cannot perform operation %s because funding is not confirmed"
+                operation
+            |> apiMisuse
+        | Some _ ->
+            remoteNextCommitInfoIfFundingLocked normalData.RemoteNextCommitInfo operation
+
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match cs.State, command with
 
         // --------------- open channel procedure: case we are funder -------------
-        | WaitForFundingConfirmed _state, CreateChannelReestablish ->
-            makeChannelReestablish cs.ChannelPrivKeys cs.Commitments
         | ChannelState.Normal _state, CreateChannelReestablish ->
             makeChannelReestablish cs.ChannelPrivKeys cs.Commitments
-        | WaitForFundingConfirmed _state, ApplyFundingLocked msg ->
-            [ TheySentFundingLocked msg ] |> Ok
-        | WaitForFundingConfirmed state, ApplyFundingConfirmedOnBC(height, txindex, depth) ->
-            if cs.FundingTxMinimumDepth > depth then
-                [] |> Ok
-            else
-                let nextPerCommitmentPoint =
-                    cs.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint
-                        (CommitmentNumber.FirstCommitment.NextCommitment())
-                let msgToSend: FundingLockedMsg = {
-                    ChannelId = cs.Commitments.ChannelId()
-                    NextPerCommitmentPoint = nextPerCommitmentPoint
-                }
-
-                // This is temporary channel id that we will use in our channel_update message, the goal is to be able to use our channel
-                // as soon as it reaches NORMAL state, and before it is announced on the network
-                // (this id might be updated when the funding tx gets deeply buried, if there was a reorg in the meantime)
-                // this is not specified in BOLT.
-                let shortChannelId = {
-                    ShortChannelId.BlockHeight = height;
-                    BlockIndex = txindex
-                    TxOutIndex =
-                        cs.Commitments.FundingScriptCoin.Outpoint.N
-                        |> uint16
-                        |> TxOutIndex
-                }
-                let nextState = {
-                    ShortChannelId = shortChannelId
-                }
-                
-                match (state.RemoteNextPerCommitmentPointOpt) with
+        | ChannelState.Normal state, ApplyFundingLocked msg ->
+            result {
+                do!
+                    match state.RemoteNextCommitInfo with
+                    | None -> Ok ()
+                    | Some remoteNextCommitInfo ->
+                        if remoteNextCommitInfo.PerCommitmentPoint() <> msg.NextPerCommitmentPoint then
+                            Error <| InvalidFundingLocked { NetworkMsg = msg }
+                        else
+                            Ok ()
+                match state.ShortChannelId with
                 | None ->
-                    [ FundingConfirmed (msgToSend, nextState) ] |> Ok
-                | Some remoteNextPerCommitmentPoint ->
-                    [ FundingConfirmed (msgToSend, nextState); WeResumedDelayedFundingLocked remoteNextPerCommitmentPoint ] |> Ok
-        | WaitForFundingLocked _state, ApplyFundingConfirmedOnBC(height, _txindex, depth) ->
-            if (cs.FundingTxMinimumDepth <= depth) then
-                [] |> Ok
-            else
-                onceConfirmedFundingTxHasBecomeUnconfirmed(height, depth)
-        | WaitForFundingLocked state, ApplyFundingLocked msg ->
-            let nextState = {
-                ShortChannelId = state.ShortChannelId
-                LocalShutdown = None
-                RemoteShutdown = None
-                RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint)
+                    return [ TheySentFundingLocked msg ]
+                | Some _shortChannelId ->
+                    let nextState = {
+                        state with
+                            RemoteNextCommitInfo =
+                                Some <| RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
+                    }
+                    return [ BothFundingLocked(nextState) ]
             }
-            [ BothFundingLocked(nextState) ] |> Ok
+        | ChannelState.Normal state, ApplyFundingConfirmedOnBC(height, txindex, depth) ->
+            match state.ShortChannelId with
+            | None -> 
+                if cs.FundingTxMinimumDepth > depth then
+                    [] |> Ok
+                else
+                    let nextPerCommitmentPoint =
+                        cs.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint
+                            (CommitmentNumber.FirstCommitment.NextCommitment())
+                    let msgToSend: FundingLockedMsg = {
+                        ChannelId = cs.Commitments.ChannelId()
+                        NextPerCommitmentPoint = nextPerCommitmentPoint
+                    }
+
+                    // This is temporary channel id that we will use in our channel_update message, the goal is to be able to use our channel
+                    // as soon as it reaches NORMAL state, and before it is announced on the network
+                    // (this id might be updated when the funding tx gets deeply buried, if there was a reorg in the meantime)
+                    // this is not specified in BOLT.
+                    let shortChannelId = {
+                        ShortChannelId.BlockHeight = height;
+                        BlockIndex = txindex
+                        TxOutIndex =
+                            cs.Commitments.FundingScriptCoin.Outpoint.N
+                            |> uint16
+                            |> TxOutIndex
+                    }
+                    match state.RemoteNextCommitInfo with
+                    | None ->
+                        [ FundingConfirmed (msgToSend, shortChannelId) ] |> Ok
+                    | Some remoteNextCommitInfo ->
+                        let remoteNextPerCommitmentPoint =
+                            match remoteNextCommitInfo with
+                            | Revoked remoteNextPerCommitmentPoint -> remoteNextPerCommitmentPoint
+                            // Note:
+                            // We should never actually reach this line because we
+                            // never send a commit before the funding is
+                            // confirmed.
+                            | Waiting remoteCommit -> remoteCommit.RemotePerCommitmentPoint
+                        Ok [
+                            FundingConfirmed (msgToSend, shortChannelId)
+                            WeResumedDelayedFundingLocked remoteNextPerCommitmentPoint
+                        ]
+            | Some _shortChannelId ->
+                if (cs.FundingTxMinimumDepth <= depth) then
+                    [] |> Ok
+                else
+                    onceConfirmedFundingTxHasBecomeUnconfirmed(height, depth)
 
         // ---------- normal operation ---------
         | ChannelState.Normal state, MonoHopUnidirectionalPayment op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
@@ -653,10 +700,12 @@ module Channel =
                 }
                 let commitments1 = cs.Commitments.AddLocalProposal(payment)
 
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "MonoHopUniDirectionalPayment"
                 let remoteCommit1 =
-                    match state.RemoteNextCommitInfo with
-                    | RemoteNextCommitInfo.Waiting nextRemoteCommit -> nextRemoteCommit
-                    | RemoteNextCommitInfo.Revoked _info -> commitments1.RemoteCommit
+                    match remoteNextCommitInfo with
+                    | Waiting nextRemoteCommit -> nextRemoteCommit
+                    | Revoked _info -> commitments1.RemoteCommit
                 let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
                 do! Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec reduced commitments1 payment
                 return [ WeAcceptedOperationMonoHopUnidirectionalPayment(payment, commitments1) ]
@@ -696,11 +745,13 @@ module Channel =
                                 |> Map.add add.HTLCId origin
                     }
 
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "AddHTLC"
                 // we need to base the next current commitment on the last sig we sent, even if we didn't yet receive their revocation
                 let remoteCommit1 =
-                    match state.RemoteNextCommitInfo with
-                    | RemoteNextCommitInfo.Waiting nextRemoteCommit -> nextRemoteCommit
-                    | RemoteNextCommitInfo.Revoked _info -> commitments1.RemoteCommit
+                    match remoteNextCommitInfo with
+                    | Waiting nextRemoteCommit -> nextRemoteCommit
+                    | Revoked _info -> commitments1.RemoteCommit
                 let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
                 do! Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec reduced commitments1 add
                 return [ WeAcceptedOperationAddHTLC(add, commitments1) ]
@@ -723,80 +774,120 @@ module Channel =
 
         | ChannelState.Normal state, FulfillHTLC cmd ->
             result {
-                let! t = Commitments.sendFulfill cmd cs.Commitments state.RemoteNextCommitInfo
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "FulfillHTLC"
+                let! t = Commitments.sendFulfill cmd cs.Commitments remoteNextCommitInfo
                 return [ WeAcceptedOperationFulfillHTLC t ]
             }
 
         | ChannelState.Normal state, ChannelCommand.ApplyUpdateFulfillHTLC msg ->
-            Commitments.receiveFulfill msg cs.Commitments state.RemoteNextCommitInfo
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyUpdateFulfullHTLC"
+                return! Commitments.receiveFulfill msg cs.Commitments remoteNextCommitInfo
+            }
 
         | ChannelState.Normal state, FailHTLC op ->
-            Commitments.sendFail cs.NodeSecret op cs.Commitments state.RemoteNextCommitInfo
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "FailHTLC"
+                return! Commitments.sendFail cs.NodeSecret op cs.Commitments remoteNextCommitInfo
+            }
 
         | ChannelState.Normal state, FailMalformedHTLC op ->
-            Commitments.sendFailMalformed op cs.Commitments state.RemoteNextCommitInfo
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "FailMalformedHTLC"
+                return! Commitments.sendFailMalformed op cs.Commitments remoteNextCommitInfo
+            }
 
         | ChannelState.Normal state, ApplyUpdateFailHTLC msg ->
-            Commitments.receiveFail msg cs.Commitments state.RemoteNextCommitInfo
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyUpdateFailHTLC"
+                return! Commitments.receiveFail msg cs.Commitments remoteNextCommitInfo
+            }
 
         | ChannelState.Normal state, ApplyUpdateFailMalformedHTLC msg ->
-            Commitments.receiveFailMalformed msg cs.Commitments state.RemoteNextCommitInfo
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyUpdateFailMalformedHTLC"
+                return! Commitments.receiveFailMalformed msg cs.Commitments remoteNextCommitInfo
+            }
 
-        | ChannelState.Normal _state, UpdateFee op ->
-            cs.Commitments |> Commitments.sendFee op
-        | ChannelState.Normal _state, ApplyUpdateFee msg ->
-            let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
-            cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
+        | ChannelState.Normal state, UpdateFee op ->
+            result {
+                let! _remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "UpdateFee"
+                return! cs.Commitments |> Commitments.sendFee op
+            }
+        | ChannelState.Normal state, ApplyUpdateFee msg ->
+            result {
+                let! _remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyUpdateFee"
+                let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
+                return! cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
+            }
 
         | ChannelState.Normal state, SignCommitment ->
             let cm = cs.Commitments
             result {
-                match state.RemoteNextCommitInfo with
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "SignCommit"
+                match remoteNextCommitInfo with
                 | _ when (cm.LocalHasChanges() |> not) ->
                     // Ignore SignCommitment Command (nothing to sign)
                     return []
                 | RemoteNextCommitInfo.Revoked _ ->
-                    return! Commitments.sendCommit cs.ChannelPrivKeys cs.Network cm state.RemoteNextCommitInfo
+                    return! Commitments.sendCommit cs.ChannelPrivKeys cs.Network cm remoteNextCommitInfo
                 | RemoteNextCommitInfo.Waiting _ ->
                     // Already in the process of signing
                     return []
             }
 
-        | ChannelState.Normal _state, ApplyCommitmentSigned msg ->
-            cs.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
+        | ChannelState.Normal state, ApplyCommitmentSigned msg ->
+            result {
+                let! _remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyCommitmentSigned"
+                return! cs.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
+            }
 
         | ChannelState.Normal state, ApplyRevokeAndACK msg ->
-            let cm = cs.Commitments
-            match state.RemoteNextCommitInfo with
-            | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> cm.RemoteCommit.RemotePerCommitmentPoint) ->
-                let errorMsg = sprintf "Invalid revoke_and_ack %A; must be %A" msg.PerCommitmentSecret cm.RemoteCommit.RemotePerCommitmentPoint
-                invalidRevokeAndACK msg errorMsg
-            | RemoteNextCommitInfo.Revoked _ ->
-                let errorMsg = sprintf "Unexpected revocation"
-                invalidRevokeAndACK msg errorMsg
-            | RemoteNextCommitInfo.Waiting theirNextCommit ->
-                let remotePerCommitmentSecretsOpt =
-                    cm.RemotePerCommitmentSecrets.InsertPerCommitmentSecret
-                        cm.RemoteCommit.Index
-                        msg.PerCommitmentSecret
-                match remotePerCommitmentSecretsOpt with
-                | Error err -> invalidRevokeAndACK msg err.Message
-                | Ok remotePerCommitmentSecrets ->
-                    let commitments1 = {
-                        cm with
-                            LocalChanges = {
-                                cm.LocalChanges with
-                                    Signed = [];
-                                    ACKed = cm.LocalChanges.ACKed @ cm.LocalChanges.Signed
-                            }
-                            RemoteChanges = {
-                                cm.RemoteChanges with
-                                    Signed = []
-                            }
-                            RemoteCommit = theirNextCommit
-                            RemotePerCommitmentSecrets = remotePerCommitmentSecrets
-                    }
-                    Ok [ WeAcceptedRevokeAndACK(commitments1, msg.NextPerCommitmentPoint) ]
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyRevokeAndACK"
+                let cm = cs.Commitments
+                match remoteNextCommitInfo with
+                | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> cm.RemoteCommit.RemotePerCommitmentPoint) ->
+                    let errorMsg = sprintf "Invalid revoke_and_ack %A; must be %A" msg.PerCommitmentSecret cm.RemoteCommit.RemotePerCommitmentPoint
+                    return! Error <| invalidRevokeAndACK msg errorMsg
+                | RemoteNextCommitInfo.Revoked _ ->
+                    let errorMsg = sprintf "Unexpected revocation"
+                    return! Error <| invalidRevokeAndACK msg errorMsg
+                | RemoteNextCommitInfo.Waiting theirNextCommit ->
+                    let remotePerCommitmentSecretsOpt =
+                        cm.RemotePerCommitmentSecrets.InsertPerCommitmentSecret
+                            cm.RemoteCommit.Index
+                            msg.PerCommitmentSecret
+                    match remotePerCommitmentSecretsOpt with
+                    | Error err -> return! Error <| invalidRevokeAndACK msg err.Message
+                    | Ok remotePerCommitmentSecrets ->
+                        let commitments1 = {
+                            cm with
+                                LocalChanges = {
+                                    cm.LocalChanges with
+                                        Signed = [];
+                                        ACKed = cm.LocalChanges.ACKed @ cm.LocalChanges.Signed
+                                }
+                                RemoteChanges = {
+                                    cm.RemoteChanges with
+                                        Signed = []
+                                }
+                                RemoteCommit = theirNextCommit
+                                RemotePerCommitmentSecrets = remotePerCommitmentSecrets
+                        }
+                        return [ WeAcceptedRevokeAndACK(commitments1, msg.NextPerCommitmentPoint) ]
+            }
 
         | ChannelState.Normal state, ChannelCommand.Close localShutdownScriptPubKey ->
             result {
@@ -845,8 +936,12 @@ module Channel =
                     if (state.LocalShutdown.IsSome) then
                         return failwith "can't have pending unsigned outgoing htlcs after having sent Shutdown. this should never happen"
                     else
+                        let remoteNextCommitInfo =
+                            match state.RemoteNextCommitInfo with
+                            | None -> failwith "can't have unsigned outgoing htlcs if we haven't recieved funding_locked. this should never happen"
+                            | Some remoteNextCommitInfo -> remoteNextCommitInfo
                         // Are we in the middle of a signature?
-                        match state.RemoteNextCommitInfo with
+                        match remoteNextCommitInfo with
                         // yes.
                         | RemoteNextCommitInfo.Waiting _waitingForRevocation ->
                             return [
@@ -868,7 +963,11 @@ module Channel =
                                 ScriptPubKey = localShutdownScriptPubKey
                             }
                             (localShutdown, [ localShutdown ])
-                    if (cm.HasNoPendingHTLCs state.RemoteNextCommitInfo) then
+                    let hasNoPendingHTLCs =
+                        match state.RemoteNextCommitInfo with
+                        | None -> true
+                        | Some remoteNextCommitInfo -> cm.HasNoPendingHTLCs remoteNextCommitInfo
+                    if hasNoPendingHTLCs then
                         // we have to send first closing_signed msg iif we are the funder
                         if (cm.IsFunder) then
                             let! (closingTx, closingSignedMsg) =
@@ -916,35 +1015,86 @@ module Channel =
         // ----------- closing ---------
         | Shutdown state, FulfillHTLC op ->
             result {
-                let! t = Commitments.sendFulfill op cs.Commitments state.RemoteNextCommitInfo
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked state.RemoteNextCommitInfo "FulfillHTLC"
+                let! t = Commitments.sendFulfill op cs.Commitments remoteNextCommitInfo
                 return [ WeAcceptedOperationFulfillHTLC t ]
             }
         | Shutdown state, ApplyUpdateFulfillHTLC msg ->
-            Commitments.receiveFulfill msg cs.Commitments state.RemoteNextCommitInfo
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked
+                        state.RemoteNextCommitInfo
+                        "ApplyUpdateFulfillHTLC"
+                return! Commitments.receiveFulfill msg cs.Commitments remoteNextCommitInfo
+            }
         | Shutdown state, FailHTLC op ->
-            Commitments.sendFail cs.NodeSecret op cs.Commitments state.RemoteNextCommitInfo
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked state.RemoteNextCommitInfo "FailHTLC"
+                return! Commitments.sendFail cs.NodeSecret op cs.Commitments remoteNextCommitInfo
+            }
         | Shutdown state, FailMalformedHTLC op ->
-            Commitments.sendFailMalformed op cs.Commitments state.RemoteNextCommitInfo
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked
+                        state.RemoteNextCommitInfo
+                        "FailMalformedHTLC"
+                return! Commitments.sendFailMalformed op cs.Commitments remoteNextCommitInfo
+            }
         | Shutdown state, ApplyUpdateFailMalformedHTLC msg ->
-            Commitments.receiveFailMalformed msg cs.Commitments state.RemoteNextCommitInfo
-        | Shutdown _state, UpdateFee op ->
-            cs.Commitments |> Commitments.sendFee op
-        | Shutdown _state, ApplyUpdateFee msg ->
-            let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
-            cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked
+                        state.RemoteNextCommitInfo
+                        "ApplyUpdateFailMalformedHTLC"
+                return!
+                    Commitments.receiveFailMalformed msg cs.Commitments remoteNextCommitInfo
+            }
+        | Shutdown state, UpdateFee op ->
+            result {
+                let! _remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked state.RemoteNextCommitInfo "UpdateFee"
+                return! cs.Commitments |> Commitments.sendFee op
+            }
+        | Shutdown state, ApplyUpdateFee msg ->
+            result {
+                let! _remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked
+                        state.RemoteNextCommitInfo
+                        "ApplyUpdateFee"
+                let localFeerate =
+                    cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
+                return! cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
+            }
         | Shutdown state, SignCommitment ->
             let cm = cs.Commitments
-            match state.RemoteNextCommitInfo with
-            | _ when (not <| cm.LocalHasChanges()) ->
-                // nothing to sign
-                [] |> Ok
-            | RemoteNextCommitInfo.Revoked _ ->
-                Commitments.sendCommit cs.ChannelPrivKeys cs.Network cm state.RemoteNextCommitInfo
-            | RemoteNextCommitInfo.Waiting _waitForRevocation ->
-                // Already in the process of signing.
-                [] |> Ok
-        | Shutdown _state, ApplyCommitmentSigned msg ->
-            cs.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
+            result {
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked state.RemoteNextCommitInfo "SignCommit"
+                match remoteNextCommitInfo with
+                | _ when (not <| cm.LocalHasChanges()) ->
+                    // nothing to sign
+                    return []
+                | RemoteNextCommitInfo.Revoked _ ->
+                    return!
+                        Commitments.sendCommit
+                            cs.ChannelPrivKeys
+                            cs.Network
+                            cm
+                            remoteNextCommitInfo
+                | RemoteNextCommitInfo.Waiting _waitForRevocation ->
+                    // Already in the process of signing.
+                    return []
+            }
+        | Shutdown state, ApplyCommitmentSigned msg ->
+            result {
+                let! _remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked
+                        state.RemoteNextCommitInfo
+                        "ApplyCommitmentSigned"
+                return! Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network cs.Commitments
+            }
         | Shutdown _state, ApplyRevokeAndACK _msg ->
             failwith "not implemented"
 
@@ -1019,9 +1169,9 @@ module Channel =
                                                     MaybeBestUnpublishedTx = Some(finalizedTx) }
                         return!
                             Closing.handleMutualClose
-                            finalizedTx
-                            negoData
-                            state.RemoteNextCommitInfo
+                                finalizedTx
+                                negoData
+                                state.RemoteNextCommitInfo
                     else
                         let! closingTx, closingSignedMsg =
                             Closing.makeClosingTx (
@@ -1044,8 +1194,12 @@ module Channel =
             // got valid payment preimage, recalculating txs to redeem the corresponding htlc on-chain
             result {
                 let cm = cs.Commitments
+                let! remoteNextCommitInfo =
+                    remoteNextCommitInfoIfFundingLocked
+                        state.RemoteNextCommitInfo
+                        "FulfillHTC"
                 let! (_msgToSend, newCommitments) =
-                    Commitments.sendFulfill op cm state.RemoteNextCommitInfo
+                    Commitments.sendFulfill op cm remoteNextCommitInfo
                 let _localCommitPublished =
                     state.LocalCommitPublished
                     |> Option.map (fun localCommitPublished ->
@@ -1063,24 +1217,23 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e, c.State with
         // --------- init both ------
-        | FundingConfirmed (_ourFundingLockedMsg, data), WaitForFundingConfirmed _ ->
-            { c with State = WaitForFundingLocked data }
-        | TheySentFundingLocked msg, WaitForFundingConfirmed s ->
+        | FundingConfirmed (_ourFundingLockedMsg, shortChannelId), ChannelState.Normal normalData ->
             {
                 c with
-                    State = WaitForFundingConfirmed {
-                        s with
-                            RemoteNextPerCommitmentPointOpt = Some(msg.NextPerCommitmentPoint)
+                    State = ChannelState.Normal {
+                        normalData with
+                            ShortChannelId = Some shortChannelId
                     }
             }
-        | TheySentFundingLocked msg, WaitForFundingLocked s ->
-            let nextState = {
-                RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
-                ShortChannelId = s.ShortChannelId
-                LocalShutdown = None
-                RemoteShutdown = None
+        | TheySentFundingLocked msg, ChannelState.Normal normalData ->
+            {
+                c with
+                    State = ChannelState.Normal {
+                        normalData with
+                            RemoteNextCommitInfo =
+                                Some <| RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
+                    }
             }
-            { c with State = ChannelState.Normal nextState }
         // ----- normal operation --------
         | WeAcceptedOperationMonoHopUnidirectionalPayment(_, newCommitments), ChannelState.Normal _normalData ->
             { c with Commitments = newCommitments }
@@ -1117,7 +1270,8 @@ module Channel =
                     Commitments = newCommitments
                     State = ChannelState.Normal {
                         normalData with
-                            RemoteNextCommitInfo = RemoteNextCommitInfo.Waiting waitingForRevocation
+                            RemoteNextCommitInfo =
+                                Some <| RemoteNextCommitInfo.Waiting waitingForRevocation
                     }
             }
         | WeAcceptedCommitmentSigned(_msg, newCommitments), ChannelState.Normal _normalData ->
@@ -1130,7 +1284,7 @@ module Channel =
                     State = ChannelState.Normal {
                         normalData with
                             RemoteNextCommitInfo =
-                                RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint
+                                Some <| RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint
                     }
             }
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -872,20 +872,9 @@ module Channel =
                         // Are we in the middle of a signature?
                         match cm.RemoteNextCommitInfo with
                         // yes.
-                        | RemoteNextCommitInfo.Waiting waitingForRevocation ->
-                            let nextCommitments = {
-                                cs.Commitments with
-                                    RemoteNextCommitInfo =
-                                        RemoteNextCommitInfo.Waiting {
-                                            waitingForRevocation with
-                                                ReSignASAP = true
-                                        }
-                            }
+                        | RemoteNextCommitInfo.Waiting _waitingForRevocation ->
                             return [
-                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(
-                                    msg,
-                                    nextCommitments
-                                )
+                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(msg, cm)
                             ]
                         // No. let's sign right away.
                         | RemoteNextCommitInfo.Revoked _ ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -461,6 +461,23 @@ and Channel = {
             return (acceptChannelMsg, channelWaitingForFundingCreated)
         }
 
+    member self.CreateChannelReestablish (): ChannelReestablishMsg =
+        let commitmentSeed = self.ChannelPrivKeys.CommitmentSeed
+        let ourChannelReestablish = {
+            ChannelId = self.StaticChannelConfig.ChannelId()
+            NextCommitmentNumber =
+                (self.Commitments.RemotePerCommitmentSecrets.NextCommitmentNumber().NextCommitment())
+            NextRevocationNumber =
+                self.Commitments.RemotePerCommitmentSecrets.NextCommitmentNumber()
+            DataLossProtect = OptionalField.Some <| {
+                YourLastPerCommitmentSecret =
+                    self.Commitments.RemotePerCommitmentSecrets.MostRecentPerCommitmentSecret()
+                MyCurrentPerCommitmentPoint =
+                    commitmentSeed.DerivePerCommitmentPoint self.Commitments.RemoteCommit.Index
+            }
+        }
+        ourChannelReestablish
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -512,27 +529,6 @@ module Channel =
             ((localClosingFee.Satoshi + remoteClosingFee.Satoshi) / 4L) * 2L
             |> Money.Satoshis
 
-    let makeChannelReestablish (channelPrivKeys: ChannelPrivKeys)
-                               (commitments: Commitments)
-                               (staticChannelConfig: StaticChannelConfig)
-                                   : Result<ChannelEvent list, ChannelError> =
-        let commitmentSeed = channelPrivKeys.CommitmentSeed
-        let ourChannelReestablish =
-            {
-                ChannelId = staticChannelConfig.ChannelId()
-                NextCommitmentNumber =
-                    (commitments.RemotePerCommitmentSecrets.NextCommitmentNumber().NextCommitment())
-                NextRevocationNumber =
-                    commitments.RemotePerCommitmentSecrets.NextCommitmentNumber()
-                DataLossProtect = OptionalField.Some <| {
-                    YourLastPerCommitmentSecret =
-                        commitments.RemotePerCommitmentSecrets.MostRecentPerCommitmentSecret()
-                    MyCurrentPerCommitmentPoint =
-                        commitmentSeed.DerivePerCommitmentPoint commitments.RemoteCommit.Index
-                }
-            }
-        [ WeSentChannelReestablish ourChannelReestablish ] |> Ok
-
     let remoteNextCommitInfoIfFundingLocked (remoteNextCommitInfoOpt: Option<RemoteNextCommitInfo>)
                                             (operation: string)
                                                 : Result<RemoteNextCommitInfo, ChannelError> =
@@ -559,8 +555,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | CreateChannelReestablish ->
-            makeChannelReestablish cs.ChannelPrivKeys cs.Commitments cs.StaticChannelConfig
         | ApplyFundingLocked msg ->
             result {
                 do!

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -669,6 +669,35 @@ and Channel = {
             return channel, add
     }
 
+    member self.ApplyUpdateAddHTLC (msg: UpdateAddHTLCMsg)
+                                   (height: BlockHeight)
+                                       : Result<Channel, ChannelError> = result {
+        do!
+            Validation.checkTheirUpdateAddHTLCIsAcceptable
+                self.Commitments
+                self.StaticChannelConfig.LocalParams
+                msg
+                height
+        let commitments1 = {
+            self.Commitments.AddRemoteProposal(msg) with
+                RemoteNextHTLCId = self.Commitments.LocalNextHTLCId + 1UL
+        }
+        let! reduced =
+            commitments1.LocalCommit.Spec.Reduce (
+                commitments1.LocalChanges.ACKed,
+                commitments1.RemoteChanges.Proposed
+            ) |> expectTransactionError
+        do!
+            Validation.checkTheirUpdateAddHTLCIsAcceptableWithCurrentSpec
+                reduced
+                self.StaticChannelConfig
+                msg
+        return {
+            self with
+                Commitments = commitments1
+        }
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -722,30 +751,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | ApplyUpdateAddHTLC (msg, height) ->
-            result {
-                do!
-                    Validation.checkTheirUpdateAddHTLCIsAcceptable
-                        cs.Commitments
-                        cs.StaticChannelConfig.LocalParams
-                        msg
-                        height
-                let commitments1 = {
-                    cs.Commitments.AddRemoteProposal(msg) with
-                        RemoteNextHTLCId = cs.Commitments.LocalNextHTLCId + 1UL
-                }
-                let! reduced =
-                    commitments1.LocalCommit.Spec.Reduce (
-                        commitments1.LocalChanges.ACKed,
-                        commitments1.RemoteChanges.Proposed
-                    ) |> expectTransactionError
-                do!
-                    Validation.checkTheirUpdateAddHTLCIsAcceptableWithCurrentSpec
-                        reduced
-                        cs.StaticChannelConfig
-                        msg
-                return [ WeAcceptedUpdateAddHTLC commitments1 ]
-            }
         | FulfillHTLC cmd ->
             result {
                 let! remoteNextCommitInfo =
@@ -1101,9 +1106,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // ----- normal operation --------
-        | WeAcceptedUpdateAddHTLC(newCommitments) ->
-            { c with Commitments = newCommitments }
-
         | WeAcceptedOperationFulfillHTLC(_, newCommitments) ->
             { c with Commitments = newCommitments }
         | WeAcceptedFulfillHTLC(_msg, _origin, _htlc, newCommitments) ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -669,7 +669,6 @@ module Channel =
                             RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint)
                 }
                 let nextState = {
-                    NormalData.Buried = true
                     ShortChannelId = state.ShortChannelId
                     ChannelAnnouncement = None
                     ChannelUpdate = initialChannelUpdate
@@ -1110,7 +1109,6 @@ module Channel =
                                                            true,
                                                            None)
             let nextState = {
-                NormalData.Buried = false;
                 ShortChannelId = s.ShortChannelId
                 ChannelAnnouncement = None
                 ChannelUpdate = channelUpdate

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -978,7 +978,6 @@ module Channel =
                                     ClosingTxProposed.UnsignedTx = closingTx
                                     LocalClosingSigned = closingSignedMsg
                                 }]
-                                MaybeBestUnpublishedTx = None
                             }
                             return [
                                 AcceptedShutdownWhenNoPendingHTLCs(
@@ -992,7 +991,6 @@ module Channel =
                                 LocalShutdown = localShutdownScriptPubKey
                                 RemoteShutdown = msg.ScriptPubKey
                                 ClosingTxProposed = []
-                                MaybeBestUnpublishedTx = None
                             }
                             return [ AcceptedShutdownWhenNoPendingHTLCs(None, nextState) ]
                     else
@@ -1050,7 +1048,7 @@ module Channel =
                     return!
                         Closing.handleMutualClose
                             finalizedTx
-                            { state with MaybeBestUnpublishedTx = Some(finalizedTx) }
+                            state
                             state.RemoteNextCommitInfo
                 else
                     let lastLocalClosingFee = state.ClosingTxProposed |> List.tryHead |> Option.map (fun txp -> txp.LocalClosingSigned.FeeSatoshis)
@@ -1071,7 +1069,7 @@ module Channel =
                         return!
                             Closing.handleMutualClose
                                 finalizedTx
-                                { state with MaybeBestUnpublishedTx = Some(finalizedTx) }
+                                state
                                 state.RemoteNextCommitInfo
                     else if (nextClosingFee = msg.FeeSatoshis) then
                         // we have reached on agreement!
@@ -1081,8 +1079,7 @@ module Channel =
                                 LocalClosingSigned = closingSignedMsg
                             }
                             newProposed :: state.ClosingTxProposed
-                        let negoData = { state with ClosingTxProposed = closingTxProposed1
-                                                    MaybeBestUnpublishedTx = Some(finalizedTx) }
+                        let negoData = { state with ClosingTxProposed = closingTxProposed1 }
                         return!
                             Closing.handleMutualClose
                                 finalizedTx
@@ -1105,7 +1102,7 @@ module Channel =
                                 LocalClosingSigned = closingSignedMsg
                             }
                             newProposed :: state.ClosingTxProposed
-                        let nextState = { state with ClosingTxProposed = closingTxProposed1; MaybeBestUnpublishedTx = Some(finalizedTx) }
+                        let nextState = { state with ClosingTxProposed = closingTxProposed1 }
                         return [ WeProposedNewClosingSigned(closingSignedMsg, nextState) ]
             }
         | Closing state, FulfillHTLC op ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -619,6 +619,56 @@ and Channel = {
         }
     }
 
+    member self.AddHTLC (op: OperationAddHTLC)
+                            : Result<Channel * UpdateAddHTLCMsg, ChannelError> = result {
+        if self.NegotiatingState.HasEnteredShutdown() then
+            return!
+                sprintf "Could not add new HTLC %A since shutdown is already in progress." op
+                |> apiMisuse
+        else
+            do! Validation.checkOperationAddHTLC self.StaticChannelConfig.RemoteParams op
+            let add: UpdateAddHTLCMsg = {
+                ChannelId = self.StaticChannelConfig.ChannelId()
+                HTLCId = self.Commitments.LocalNextHTLCId
+                Amount = op.Amount
+                PaymentHash = op.PaymentHash
+                CLTVExpiry = op.Expiry
+                OnionRoutingPacket = op.Onion
+            }
+            let commitments1 =
+                let commitments = {
+                    self.Commitments.AddLocalProposal(add) with
+                        LocalNextHTLCId = self.Commitments.LocalNextHTLCId + 1UL
+                }
+                match op.Origin with
+                | None -> commitments
+                | Some origin -> {
+                    commitments with
+                        OriginChannels =
+                            self.Commitments.OriginChannels
+                            |> Map.add add.HTLCId origin
+                }
+
+            let! remoteNextCommitInfo =
+                self.RemoteNextCommitInfoIfFundingLockedNormal "AddHTLC"
+            // we need to base the next current commitment on the last sig we sent, even if we didn't yet receive their revocation
+            let remoteCommit1 =
+                match remoteNextCommitInfo with
+                | Waiting nextRemoteCommit -> nextRemoteCommit
+                | Revoked _info -> commitments1.RemoteCommit
+            let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
+            do!
+                Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec
+                    reduced
+                    self.StaticChannelConfig
+                    add
+            let channel = {
+                self with
+                    Commitments = commitments1
+            }
+            return channel, add
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -672,49 +722,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | AddHTLC op when cs.NegotiatingState.HasEnteredShutdown() ->
-            sprintf "Could not add new HTLC %A since shutdown is already in progress." op
-            |> apiMisuse
-        | AddHTLC op ->
-            result {
-                do! Validation.checkOperationAddHTLC cs.StaticChannelConfig.RemoteParams op
-                let add: UpdateAddHTLCMsg = {
-                    ChannelId = cs.StaticChannelConfig.ChannelId()
-                    HTLCId = cs.Commitments.LocalNextHTLCId
-                    Amount = op.Amount
-                    PaymentHash = op.PaymentHash
-                    CLTVExpiry = op.Expiry
-                    OnionRoutingPacket = op.Onion
-                }
-                let commitments1 =
-                    let commitments = {
-                        cs.Commitments.AddLocalProposal(add) with
-                            LocalNextHTLCId = cs.Commitments.LocalNextHTLCId + 1UL
-                    }
-                    match op.Origin with
-                    | None -> commitments
-                    | Some origin -> {
-                        commitments with
-                            OriginChannels =
-                                cs.Commitments.OriginChannels
-                                |> Map.add add.HTLCId origin
-                    }
-
-                let! remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "AddHTLC"
-                // we need to base the next current commitment on the last sig we sent, even if we didn't yet receive their revocation
-                let remoteCommit1 =
-                    match remoteNextCommitInfo with
-                    | Waiting nextRemoteCommit -> nextRemoteCommit
-                    | Revoked _info -> commitments1.RemoteCommit
-                let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
-                do!
-                    Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec
-                        reduced
-                        cs.StaticChannelConfig
-                        add
-                return [ WeAcceptedOperationAddHTLC(add, commitments1) ]
-            }
         | ApplyUpdateAddHTLC (msg, height) ->
             result {
                 do!
@@ -1094,8 +1101,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // ----- normal operation --------
-        | WeAcceptedOperationAddHTLC(_, newCommitments) ->
-            { c with Commitments = newCommitments }
         | WeAcceptedUpdateAddHTLC(newCommitments) ->
             { c with Commitments = newCommitments }
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -80,7 +80,6 @@ type ChannelWaitingForFundingSigned = {
             ShortChannelId = None
             LocalShutdownState = ShutdownState.ForNewChannel self.LocalShutdownScriptPubKey
             RemoteShutdownState = ShutdownState.ForNewChannel self.RemoteShutdownScriptPubKey
-            RemoteNextCommitInfo = None
         }
         let channel = {
             ChannelOptions = self.ChannelOptions
@@ -88,6 +87,7 @@ type ChannelWaitingForFundingSigned = {
             FeeEstimator = self.FeeEstimator
             RemoteNodeId = self.RemoteNodeId
             NodeSecret = self.NodeSecret
+            RemoteNextCommitInfo = None
             State = nextState
             Network = self.Network
             FundingTxMinimumDepth = self.FundingTxMinimumDepth
@@ -191,7 +191,6 @@ and ChannelWaitingForFundingCreated = {
             ShortChannelId = None
             LocalShutdownState = ShutdownState.ForNewChannel self.LocalShutdownScriptPubKey
             RemoteShutdownState = ShutdownState.ForNewChannel self.RemoteShutdownScriptPubKey
-            RemoteNextCommitInfo = None
         }
         let channel = {
             ChannelOptions = self.ChannelOptions
@@ -200,6 +199,7 @@ and ChannelWaitingForFundingCreated = {
             RemoteNodeId = self.RemoteNodeId
             NodeSecret = self.NodeSecret
             Network = self.Network
+            RemoteNextCommitInfo = None
             State = nextState
             FundingTxMinimumDepth = self.FundingTxMinimumDepth
             Commitments = commitments
@@ -349,6 +349,7 @@ and Channel = {
     FeeEstimator: IFeeEstimator
     RemoteNodeId: NodeId
     NodeSecret: NodeSecret
+    RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
     State: ChannelState
     Network: Network
     FundingTxMinimumDepth: BlockHeightOffset32
@@ -538,11 +539,8 @@ module Channel =
 
         let handleMutualClose (closingTx: FinalizedTx)
                               (_d: NegotiatingData)
-                              (remoteNextCommitInfoOpt: Option<RemoteNextCommitInfo>) =
-            let nextData =
-                ClosingData.Create
-                    remoteNextCommitInfoOpt
-            [ MutualClosePerformed (closingTx, nextData) ]
+                              (_remoteNextCommitInfoOpt: Option<RemoteNextCommitInfo>) =
+            [ MutualClosePerformed closingTx ]
             |> Ok
 
         let claimCurrentLocalCommitTxOutputs (channelPrivKeys: ChannelPrivKeys,
@@ -588,17 +586,18 @@ module Channel =
             |> apiMisuse
         | Some remoteNextCommitInfo -> Ok remoteNextCommitInfo
 
-    let remoteNextCommitInfoIfFundingLockedNormal (normalData: NormalData)
+    let remoteNextCommitInfoIfFundingLockedNormal (shortChannelIdOpt: Option<ShortChannelId>)
+                                                  (remoteNextCommitInfoOpt: Option<RemoteNextCommitInfo>)
                                                   (operation: string)
                                                       : Result<RemoteNextCommitInfo, ChannelError> =
-        match normalData.ShortChannelId with
+        match shortChannelIdOpt with
         | None ->
             sprintf
                 "cannot perform operation %s because funding is not confirmed"
                 operation
             |> apiMisuse
         | Some _ ->
-            remoteNextCommitInfoIfFundingLocked normalData.RemoteNextCommitInfo operation
+            remoteNextCommitInfoIfFundingLocked remoteNextCommitInfoOpt operation
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match cs.State, command with
@@ -609,7 +608,7 @@ module Channel =
         | ChannelState.Normal state, ApplyFundingLocked msg ->
             result {
                 do!
-                    match state.RemoteNextCommitInfo with
+                    match cs.RemoteNextCommitInfo with
                     | None -> Ok ()
                     | Some remoteNextCommitInfo ->
                         if remoteNextCommitInfo.PerCommitmentPoint() <> msg.NextPerCommitmentPoint then
@@ -620,12 +619,7 @@ module Channel =
                 | None ->
                     return [ TheySentFundingLocked msg ]
                 | Some _shortChannelId ->
-                    let nextState = {
-                        state with
-                            RemoteNextCommitInfo =
-                                Some <| RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
-                    }
-                    return [ BothFundingLocked(nextState) ]
+                    return [ BothFundingLocked(msg.NextPerCommitmentPoint) ]
             }
         | ChannelState.Normal state, ApplyFundingConfirmedOnBC(height, txindex, depth) ->
             match state.ShortChannelId with
@@ -653,7 +647,7 @@ module Channel =
                             |> uint16
                             |> TxOutIndex
                     }
-                    match state.RemoteNextCommitInfo with
+                    match cs.RemoteNextCommitInfo with
                     | None ->
                         [ FundingConfirmed (msgToSend, shortChannelId) ] |> Ok
                     | Some remoteNextCommitInfo ->
@@ -688,7 +682,7 @@ module Channel =
                 let commitments1 = cs.Commitments.AddLocalProposal(payment)
 
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "MonoHopUniDirectionalPayment"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "MonoHopUniDirectionalPayment"
                 let remoteCommit1 =
                     match remoteNextCommitInfo with
                     | Waiting nextRemoteCommit -> nextRemoteCommit
@@ -733,7 +727,7 @@ module Channel =
                     }
 
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "AddHTLC"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "AddHTLC"
                 // we need to base the next current commitment on the last sig we sent, even if we didn't yet receive their revocation
                 let remoteCommit1 =
                     match remoteNextCommitInfo with
@@ -762,7 +756,7 @@ module Channel =
         | ChannelState.Normal state, FulfillHTLC cmd ->
             result {
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "FulfillHTLC"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "FulfillHTLC"
                 let! t = Commitments.sendFulfill cmd cs.Commitments remoteNextCommitInfo
                 return [ WeAcceptedOperationFulfillHTLC t ]
             }
@@ -770,48 +764,48 @@ module Channel =
         | ChannelState.Normal state, ChannelCommand.ApplyUpdateFulfillHTLC msg ->
             result {
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyUpdateFulfullHTLC"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "ApplyUpdateFulfullHTLC"
                 return! Commitments.receiveFulfill msg cs.Commitments remoteNextCommitInfo
             }
 
         | ChannelState.Normal state, FailHTLC op ->
             result {
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "FailHTLC"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "FailHTLC"
                 return! Commitments.sendFail cs.NodeSecret op cs.Commitments remoteNextCommitInfo
             }
 
         | ChannelState.Normal state, FailMalformedHTLC op ->
             result {
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "FailMalformedHTLC"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "FailMalformedHTLC"
                 return! Commitments.sendFailMalformed op cs.Commitments remoteNextCommitInfo
             }
 
         | ChannelState.Normal state, ApplyUpdateFailHTLC msg ->
             result {
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyUpdateFailHTLC"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "ApplyUpdateFailHTLC"
                 return! Commitments.receiveFail msg cs.Commitments remoteNextCommitInfo
             }
 
         | ChannelState.Normal state, ApplyUpdateFailMalformedHTLC msg ->
             result {
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyUpdateFailMalformedHTLC"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "ApplyUpdateFailMalformedHTLC"
                 return! Commitments.receiveFailMalformed msg cs.Commitments remoteNextCommitInfo
             }
 
         | ChannelState.Normal state, UpdateFee op ->
             result {
                 let! _remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "UpdateFee"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "UpdateFee"
                 return! cs.Commitments |> Commitments.sendFee op
             }
         | ChannelState.Normal state, ApplyUpdateFee msg ->
             result {
                 let! _remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyUpdateFee"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "ApplyUpdateFee"
                 let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
                 return! cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
             }
@@ -820,7 +814,7 @@ module Channel =
             let cm = cs.Commitments
             result {
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "SignCommit"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "SignCommit"
                 match remoteNextCommitInfo with
                 | _ when (cm.LocalHasChanges() |> not) ->
                     // Ignore SignCommitment Command (nothing to sign)
@@ -835,14 +829,14 @@ module Channel =
         | ChannelState.Normal state, ApplyCommitmentSigned msg ->
             result {
                 let! _remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyCommitmentSigned"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "ApplyCommitmentSigned"
                 return! cs.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
             }
 
         | ChannelState.Normal state, ApplyRevokeAndACK msg ->
             result {
                 let! remoteNextCommitInfo =
-                    remoteNextCommitInfoIfFundingLockedNormal state "ApplyRevokeAndACK"
+                    remoteNextCommitInfoIfFundingLockedNormal state.ShortChannelId cs.RemoteNextCommitInfo "ApplyRevokeAndACK"
                 let cm = cs.Commitments
                 match remoteNextCommitInfo with
                 | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> cm.RemoteCommit.RemotePerCommitmentPoint) ->
@@ -925,7 +919,7 @@ module Channel =
                 // Do we have Unsigned Outgoing HTLCs?
                 else if (cm.LocalHasUnsignedOutgoingHTLCs()) then
                     let remoteNextCommitInfo =
-                        match state.RemoteNextCommitInfo with
+                        match cs.RemoteNextCommitInfo with
                         | None -> failwith "can't have unsigned outgoing htlcs if we haven't recieved funding_locked. this should never happen"
                         | Some remoteNextCommitInfo -> remoteNextCommitInfo
                     // Are we in the middle of a signature?
@@ -943,7 +937,7 @@ module Channel =
                         ]
                 else
                     let hasNoPendingHTLCs =
-                        match state.RemoteNextCommitInfo with
+                        match cs.RemoteNextCommitInfo with
                         | None -> true
                         | Some remoteNextCommitInfo -> cm.HasNoPendingHTLCs remoteNextCommitInfo
                     if hasNoPendingHTLCs then
@@ -967,7 +961,6 @@ module Channel =
                                     cs.Network
                                 ) |> expectTransactionError
                             let nextState = {
-                                RemoteNextCommitInfo = state.RemoteNextCommitInfo
                                 LocalShutdown = localShutdownScriptPubKey
                                 RemoteShutdown = msg.ScriptPubKey
                                 LocalClosingFeesProposed = [ closingFee ]
@@ -981,7 +974,6 @@ module Channel =
                             ]
                         else
                             let nextState = {
-                                RemoteNextCommitInfo = state.RemoteNextCommitInfo
                                 LocalShutdown = localShutdownScriptPubKey
                                 RemoteShutdown = msg.ScriptPubKey
                                 LocalClosingFeesProposed = []
@@ -1049,7 +1041,7 @@ module Channel =
                         Closing.handleMutualClose
                             finalizedTx
                             state
-                            state.RemoteNextCommitInfo
+                            cs.RemoteNextCommitInfo
                 else
                     let lastLocalClosingFee = state.LocalClosingFeesProposed |> List.tryHead
                     let! localF = 
@@ -1070,7 +1062,7 @@ module Channel =
                             Closing.handleMutualClose
                                 finalizedTx
                                 state
-                                state.RemoteNextCommitInfo
+                                cs.RemoteNextCommitInfo
                     else if (nextClosingFee = msg.FeeSatoshis) then
                         // we have reached on agreement!
                         let negoData = {
@@ -1083,7 +1075,7 @@ module Channel =
                             Closing.handleMutualClose
                                 finalizedTx
                                 negoData
-                                state.RemoteNextCommitInfo
+                                cs.RemoteNextCommitInfo
                     else
                         let! _closingTx, closingSignedMsg =
                             Closing.makeClosingTx (
@@ -1103,13 +1095,13 @@ module Channel =
                         }
                         return [ WeProposedNewClosingSigned(closingSignedMsg, nextState) ]
             }
-        | Closing state, FulfillHTLC op ->
+        | Closing, FulfillHTLC op ->
             // got valid payment preimage, recalculating txs to redeem the corresponding htlc on-chain
             result {
                 let cm = cs.Commitments
                 let! remoteNextCommitInfo =
                     remoteNextCommitInfoIfFundingLocked
-                        state.RemoteNextCommitInfo
+                        cs.RemoteNextCommitInfo
                         "FulfillHTC"
                 let! (_msgToSend, _newCommitments) =
                     Commitments.sendFulfill op cm remoteNextCommitInfo
@@ -1129,14 +1121,11 @@ module Channel =
                             ShortChannelId = Some shortChannelId
                     }
             }
-        | TheySentFundingLocked msg, ChannelState.Normal normalData ->
+        | TheySentFundingLocked msg, ChannelState.Normal _normalData ->
             {
                 c with
-                    State = ChannelState.Normal {
-                        normalData with
-                            RemoteNextCommitInfo =
-                                Some <| RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
-                    }
+                    RemoteNextCommitInfo =
+                        Some <| RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
             }
         // ----- normal operation --------
         | WeAcceptedOperationMonoHopUnidirectionalPayment(_, newCommitments), ChannelState.Normal _normalData ->
@@ -1168,28 +1157,22 @@ module Channel =
         | WeAcceptedUpdateFee(_msg, newCommitments), ChannelState.Normal _normalData ->
             { c with Commitments = newCommitments }
 
-        | WeAcceptedOperationSign(_msg, newCommitments, waitingForRevocation), ChannelState.Normal normalData ->
+        | WeAcceptedOperationSign(_msg, newCommitments, waitingForRevocation), ChannelState.Normal _normalData ->
             {
                 c with
                     Commitments = newCommitments
-                    State = ChannelState.Normal {
-                        normalData with
-                            RemoteNextCommitInfo =
-                                Some <| RemoteNextCommitInfo.Waiting waitingForRevocation
-                    }
+                    RemoteNextCommitInfo =
+                        Some <| RemoteNextCommitInfo.Waiting waitingForRevocation
             }
         | WeAcceptedCommitmentSigned(_msg, newCommitments), ChannelState.Normal _normalData ->
             { c with Commitments = newCommitments }
 
-        | WeAcceptedRevokeAndACK(newCommitments, remoteNextPerCommitmentPoint), ChannelState.Normal normalData ->
+        | WeAcceptedRevokeAndACK(newCommitments, remoteNextPerCommitmentPoint), ChannelState.Normal _normalData ->
             {
                 c with
                     Commitments = newCommitments
-                    State = ChannelState.Normal {
-                        normalData with
-                            RemoteNextCommitInfo =
-                                Some <| RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint
-                    }
+                    RemoteNextCommitInfo =
+                        Some <| RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint
             }
 
         // -----  closing ------
@@ -1216,8 +1199,8 @@ module Channel =
                 c with
                     State = ChannelState.Normal nextState
             }
-        | MutualClosePerformed (_txToPublish, nextState), ChannelState.Negotiating _d ->
-            { c with State = Closing nextState }
+        | MutualClosePerformed _txToPublish, ChannelState.Negotiating _d ->
+            { c with State = Closing }
         | WeProposedNewClosingSigned(_msg, nextState), ChannelState.Negotiating _d ->
             { c with State = Negotiating(nextState) }
         // ----- else -----

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -21,44 +21,52 @@ type ChannelWaitingForFundingSigned = {
     NodeSecret: NodeSecret
     Network: Network
     FundingTxMinimumDepth: BlockHeightOffset32
-    WaitForFundingSignedData: WaitForFundingSignedData
+    ChannelId: ChannelId
+    LocalParams: LocalParams
+    RemoteParams: RemoteParams
+    FundingTx: FinalizedTx
+    LocalSpec: CommitmentSpec
+    LocalCommitTx: CommitTx
+    RemoteCommit: RemoteCommit
+    ChannelFlags: uint8
+    LastSent: FundingCreatedMsg
+    InitialFeeRatePerKw: FeeRatePerKw
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
 } with
     member self.ApplyFundingSigned (msg: FundingSignedMsg)
                                        : Result<FinalizedTx * Channel, ChannelError> = result {
-        let state = self.WaitForFundingSignedData
-        let remoteChannelKeys = state.RemoteParams.ChannelPubKeys
+        let remoteChannelKeys = self.RemoteParams.ChannelPubKeys
         let! finalizedLocalCommitTx =
             let theirFundingPk = remoteChannelKeys.FundingPubKey.RawPubKey()
             let _, signedLocalCommitTx =
-                self.ChannelPrivKeys.SignWithFundingPrivKey state.LocalCommitTx.Value
+                self.ChannelPrivKeys.SignWithFundingPrivKey self.LocalCommitTx.Value
             let remoteSigPairOfLocalTx = (theirFundingPk,  TransactionSignature(msg.Signature.Value, SigHash.All))
             let sigPairs = seq [ remoteSigPairOfLocalTx; ]
-            Transactions.checkTxFinalized signedLocalCommitTx state.LocalCommitTx.WhichInput sigPairs |> expectTransactionError
+            Transactions.checkTxFinalized signedLocalCommitTx self.LocalCommitTx.WhichInput sigPairs |> expectTransactionError
         let commitments = {
-            Commitments.LocalParams = state.LocalParams
-            RemoteParams = state.RemoteParams
-            ChannelFlags = state.ChannelFlags
+            Commitments.LocalParams = self.LocalParams
+            RemoteParams = self.RemoteParams
+            ChannelFlags = self.ChannelFlags
             FundingScriptCoin =
                 let amount =
-                    let index = int state.LastSent.FundingOutputIndex.Value
-                    state.FundingTx.Value.Outputs.[index].Value
+                    let index = int self.LastSent.FundingOutputIndex.Value
+                    self.FundingTx.Value.Outputs.[index].Value
                 ChannelHelpers.getFundingScriptCoin
-                    state.LocalParams.ChannelPubKeys.FundingPubKey
+                    self.LocalParams.ChannelPubKeys.FundingPubKey
                     remoteChannelKeys.FundingPubKey
-                    state.LastSent.FundingTxId
-                    state.LastSent.FundingOutputIndex
+                    self.LastSent.FundingTxId
+                    self.LastSent.FundingOutputIndex
                     amount
             LocalCommit = {
                 Index = CommitmentNumber.FirstCommitment
-                Spec = state.LocalSpec
+                Spec = self.LocalSpec
                 PublishableTxs = {
                     PublishableTxs.CommitTx = finalizedLocalCommitTx
                     HTLCTxs = []
                 }
                 PendingHTLCSuccessTxs = []
             }
-            RemoteCommit = state.RemoteCommit
+            RemoteCommit = self.RemoteCommit
             LocalChanges = LocalChanges.Zero
             RemoteChanges = RemoteChanges.Zero
             LocalNextHTLCId = HTLCId.Zero
@@ -75,8 +83,8 @@ type ChannelWaitingForFundingSigned = {
         }
         let nextState = WaitForFundingConfirmed {
             Deferred = None
-            LastSent = Choice1Of2 state.LastSent
-            InitialFeeRatePerKw = state.InitialFeeRatePerKw
+            LastSent = Choice1Of2 self.LastSent
+            InitialFeeRatePerKw = self.InitialFeeRatePerKw
         }
         let channel = {
             ChannelOptions = self.ChannelOptions
@@ -90,7 +98,7 @@ type ChannelWaitingForFundingSigned = {
             LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
             Commitments = commitments
         }
-        return state.FundingTx, channel
+        return self.FundingTx, channel
     }
 
 and ChannelWaitingForFundingCreated = {
@@ -102,23 +110,30 @@ and ChannelWaitingForFundingCreated = {
     Network: Network
     FundingTxMinimumDepth: BlockHeightOffset32
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
-    WaitForFundingCreatedData: WaitForFundingCreatedData
+    TemporaryFailure: ChannelId
+    LocalParams: LocalParams
+    RemoteParams: RemoteParams
+    FundingSatoshis: Money
+    PushMSat: LNMoney
+    InitialFeeRatePerKw: FeeRatePerKw
+    RemoteFirstPerCommitmentPoint: PerCommitmentPoint
+    ChannelFlags: uint8
+    LastSent: AcceptChannelMsg
 } with
     member self.ApplyFundingCreated (msg: FundingCreatedMsg)
                                         : Result<FundingSignedMsg * Channel, ChannelError> = result {
-        let state = self.WaitForFundingCreatedData
-        let remoteChannelKeys = state.RemoteParams.ChannelPubKeys
+        let remoteChannelKeys = self.RemoteParams.ChannelPubKeys
         let! (localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
             ChannelHelpers.makeFirstCommitTxs
-                state.LocalParams
-                state.RemoteParams
-                state.FundingSatoshis
-                state.PushMSat
-                state.InitialFeeRatePerKw
+                self.LocalParams
+                self.RemoteParams
+                self.FundingSatoshis
+                self.PushMSat
+                self.InitialFeeRatePerKw
                 msg.FundingOutputIndex
                 msg.FundingTxId
-                state.LastSent.FirstPerCommitmentPoint
-                state.RemoteFirstPerCommitmentPoint
+                self.LastSent.FirstPerCommitmentPoint
+                self.RemoteFirstPerCommitmentPoint
                 self.Network
         assert (localCommitTx.Value.IsReadyToSign())
         let _s, signedLocalCommitTx =
@@ -132,16 +147,16 @@ and ChannelWaitingForFundingCreated = {
         let localSigOfRemoteCommit, _ =
             self.ChannelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
         let commitments = {
-            LocalParams = state.LocalParams
-            RemoteParams = state.RemoteParams
-            ChannelFlags = state.ChannelFlags
+            LocalParams = self.LocalParams
+            RemoteParams = self.RemoteParams
+            ChannelFlags = self.ChannelFlags
             FundingScriptCoin =
                 ChannelHelpers.getFundingScriptCoin
-                    state.LocalParams.ChannelPubKeys.FundingPubKey
+                    self.LocalParams.ChannelPubKeys.FundingPubKey
                     remoteChannelKeys.FundingPubKey
                     msg.FundingTxId
                     msg.FundingOutputIndex
-                    state.FundingSatoshis
+                    self.FundingSatoshis
             LocalCommit = {
                 Index = CommitmentNumber.FirstCommitment
                 Spec = localSpec
@@ -155,7 +170,7 @@ and ChannelWaitingForFundingCreated = {
                 Index = CommitmentNumber.FirstCommitment
                 Spec = remoteSpec
                 TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
-                RemotePerCommitmentPoint = state.RemoteFirstPerCommitmentPoint
+                RemotePerCommitmentPoint = self.RemoteFirstPerCommitmentPoint
             }
             LocalChanges = LocalChanges.Zero
             RemoteChanges = RemoteChanges.Zero
@@ -178,7 +193,7 @@ and ChannelWaitingForFundingCreated = {
         let nextState = WaitForFundingConfirmed {
             Deferred = None
             LastSent = msgToSend |> Choice2Of2
-            InitialFeeRatePerKw = state.InitialFeeRatePerKw
+            InitialFeeRatePerKw = self.InitialFeeRatePerKw
         }
         let channel = {
             ChannelOptions = self.ChannelOptions
@@ -203,55 +218,46 @@ and ChannelWaitingForFundingTx = {
     NodeSecret: NodeSecret
     Network: Network
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
-    WaitForFundingTxData: WaitForFundingTxData
+    LastSent: OpenChannelMsg
+    LastReceived: AcceptChannelMsg
+    TemporaryChannelId: ChannelId
+    FundingSatoshis: Money
+    PushMSat: LNMoney
+    InitFeeRatePerKw: FeeRatePerKw
+    FundingTxFeeRatePerKw: FeeRatePerKw
+    LocalParams: LocalParams
+    RemoteInit: InitMsg
+    ChannelFlags: uint8
 } with
     member self.CreateFundingTx (fundingTx: FinalizedTx)
                                 (outIndex: TxOutIndex)
                                     : Result<FundingCreatedMsg * ChannelWaitingForFundingSigned, ChannelError> = result {
-        let state = self.WaitForFundingTxData
-        let remoteParams = RemoteParams.FromAcceptChannel self.RemoteNodeId (state.InputInitFunder.RemoteInit) state.LastReceived
-        let localParams = state.InputInitFunder.LocalParams
-        assert (state.LastSent.FundingPubKey = localParams.ChannelPubKeys.FundingPubKey)
-        let commitmentSpec = state.InputInitFunder.DeriveCommitmentSpec()
-        let commitmentSeed = state.InputInitFunder.ChannelPrivKeys.CommitmentSeed
+        let remoteParams = RemoteParams.FromAcceptChannel self.RemoteNodeId (self.RemoteInit) self.LastReceived
+        let localParams = self.LocalParams
+        assert (self.LastSent.FundingPubKey = localParams.ChannelPubKeys.FundingPubKey)
+        let commitmentSpec = CommitmentSpec.Create (self.FundingSatoshis.ToLNMoney() - self.PushMSat) self.PushMSat self.FundingTxFeeRatePerKw
+        let commitmentSeed = self.ChannelPrivKeys.CommitmentSeed
         let fundingTxId = fundingTx.Value.GetTxId()
         let! (_localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
             ChannelHelpers.makeFirstCommitTxs localParams
                                        remoteParams
-                                       state.LastSent.FundingSatoshis
-                                       state.LastSent.PushMSat
-                                       state.LastSent.FeeRatePerKw
+                                       self.LastSent.FundingSatoshis
+                                       self.LastSent.PushMSat
+                                       self.LastSent.FeeRatePerKw
                                        outIndex
                                        fundingTxId
                                        (commitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment)
-                                       state.LastReceived.FirstPerCommitmentPoint
+                                       self.LastReceived.FirstPerCommitmentPoint
                                        self.Network
         let localSigOfRemoteCommit, _ =
             self.ChannelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
         let nextMsg: FundingCreatedMsg = {
-            TemporaryChannelId = state.LastReceived.TemporaryChannelId
+            TemporaryChannelId = self.LastReceived.TemporaryChannelId
             FundingTxId = fundingTxId
             FundingOutputIndex = outIndex
             Signature = !>localSigOfRemoteCommit.Signature
         }
         let channelId = OutPoint(fundingTxId.Value, uint32 outIndex.Value).ToChannelId()
-        let waitForFundingSignedData = {
-            Data.WaitForFundingSignedData.ChannelId = channelId
-            LocalParams = localParams
-            RemoteParams = remoteParams
-            Data.WaitForFundingSignedData.FundingTx = fundingTx
-            Data.WaitForFundingSignedData.LocalSpec = commitmentSpec
-            LocalCommitTx = localCommitTx
-            RemoteCommit = {
-                RemoteCommit.Index = CommitmentNumber.FirstCommitment
-                Spec = remoteSpec
-                TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
-                RemotePerCommitmentPoint = state.LastReceived.FirstPerCommitmentPoint
-            }
-            ChannelFlags = state.InputInitFunder.ChannelFlags
-            LastSent = nextMsg
-            InitialFeeRatePerKw = state.InputInitFunder.InitFeeRatePerKw
-        }
         let channelWaitingForFundingSigned = {
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
@@ -259,9 +265,23 @@ and ChannelWaitingForFundingTx = {
             RemoteNodeId = self.RemoteNodeId
             NodeSecret = self.NodeSecret
             Network = self.Network
-            FundingTxMinimumDepth = state.LastReceived.MinimumDepth
-            WaitForFundingSignedData = waitForFundingSignedData
+            FundingTxMinimumDepth = self.LastReceived.MinimumDepth
             LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
+            ChannelId = channelId
+            LocalParams = localParams
+            RemoteParams = remoteParams
+            FundingTx = fundingTx
+            LocalSpec = commitmentSpec
+            LocalCommitTx = localCommitTx
+            RemoteCommit = {
+                RemoteCommit.Index = CommitmentNumber.FirstCommitment
+                Spec = remoteSpec
+                TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
+                RemotePerCommitmentPoint = self.LastReceived.FirstPerCommitmentPoint
+            }
+            ChannelFlags = self.ChannelFlags
+            LastSent = nextMsg
+            InitialFeeRatePerKw = self.InitFeeRatePerKw
         }
         return nextMsg, channelWaitingForFundingSigned
     }
@@ -276,23 +296,25 @@ and ChannelWaitingForAcceptChannel = {
     NodeSecret: NodeSecret
     Network: Network
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
-    WaitForAcceptChannelData: WaitForAcceptChannelData
+    LastSent: OpenChannelMsg
+    TemporaryChannelId: ChannelId
+    FundingSatoshis: Money
+    PushMSat: LNMoney
+    InitFeeRatePerKw: FeeRatePerKw
+    FundingTxFeeRatePerKw: FeeRatePerKw
+    LocalParams: LocalParams
+    RemoteInit: InitMsg
+    ChannelFlags: uint8
 } with
     member self.ApplyAcceptChannel (msg: AcceptChannelMsg)
                                        : Result<IDestination * Money * ChannelWaitingForFundingTx, ChannelError> = result {
-        let state = self.WaitForAcceptChannelData
-        do! Validation.checkAcceptChannelMsgAcceptable self.ChannelHandshakeLimits state msg
+        do! Validation.checkAcceptChannelMsgAcceptable self.ChannelHandshakeLimits self.FundingSatoshis self.LastSent msg
         let redeem =
             Scripts.funding
-                (state.InputInitFunder.ChannelPrivKeys.ToChannelPubKeys().FundingPubKey)
+                (self.ChannelPrivKeys.ToChannelPubKeys().FundingPubKey)
                 msg.FundingPubKey
         let destination = redeem.WitHash :> IDestination
-        let amount = state.InputInitFunder.FundingSatoshis
-        let waitForFundingTxData = {
-            InputInitFunder = state.InputInitFunder
-            LastSent = state.LastSent
-            LastReceived = msg
-        }
+        let amount = self.FundingSatoshis
         let channelWaitingForFundingTx = {
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
@@ -301,7 +323,16 @@ and ChannelWaitingForAcceptChannel = {
             NodeSecret = self.NodeSecret
             Network = self.Network
             LocalShutdownScriptPubKey = self.LocalShutdownScriptPubKey
-            WaitForFundingTxData = waitForFundingTxData
+            LastSent = self.LastSent
+            LastReceived = msg
+            TemporaryChannelId = self.TemporaryChannelId
+            FundingSatoshis = self.FundingSatoshis
+            PushMSat = self.PushMSat
+            InitFeeRatePerKw = self.InitFeeRatePerKw
+            FundingTxFeeRatePerKw = self.FundingTxFeeRatePerKw
+            LocalParams = self.LocalParams
+            RemoteInit = self.RemoteInit
+            ChannelFlags = self.ChannelFlags
         }
         return destination, amount, channelWaitingForFundingTx
     }
@@ -326,38 +357,42 @@ and Channel = {
                                   feeEstimator: IFeeEstimator,
                                   network: Network,
                                   remoteNodeId: NodeId,
-                                  inputInitFunder: InputInitFunder,
-                                  shutdownScriptPubKey: Option<ShutdownScriptPubKey>
+                                  shutdownScriptPubKey: Option<ShutdownScriptPubKey>,
+                                  temporaryChannelId: ChannelId,
+                                  fundingSatoshis: Money,
+                                  pushMSat: LNMoney,
+                                  initFeeRatePerKw: FeeRatePerKw,
+                                  fundingTxFeeRatePerKw: FeeRatePerKw,
+                                  localParams: LocalParams,
+                                  remoteInit: InitMsg,
+                                  channelFlags: uint8,
+                                  channelPrivKeys: ChannelPrivKeys
                                  ): Result<OpenChannelMsg * ChannelWaitingForAcceptChannel, ChannelError> =
             let openChannelMsgToSend: OpenChannelMsg = {
                 Chainhash = network.Consensus.HashGenesisBlock
-                TemporaryChannelId = inputInitFunder.TemporaryChannelId
-                FundingSatoshis = inputInitFunder.FundingSatoshis
-                PushMSat = inputInitFunder.PushMSat
-                DustLimitSatoshis = inputInitFunder.LocalParams.DustLimitSatoshis
-                MaxHTLCValueInFlightMsat = inputInitFunder.LocalParams.MaxHTLCValueInFlightMSat
-                ChannelReserveSatoshis = inputInitFunder.LocalParams.ChannelReserveSatoshis
-                HTLCMinimumMsat = inputInitFunder.LocalParams.HTLCMinimumMSat
-                FeeRatePerKw = inputInitFunder.InitFeeRatePerKw
-                ToSelfDelay = inputInitFunder.LocalParams.ToSelfDelay
-                MaxAcceptedHTLCs = inputInitFunder.LocalParams.MaxAcceptedHTLCs
-                FundingPubKey = inputInitFunder.ChannelPrivKeys.FundingPrivKey.FundingPubKey()
-                RevocationBasepoint = inputInitFunder.ChannelPrivKeys.RevocationBasepointSecret.RevocationBasepoint()
-                PaymentBasepoint = inputInitFunder.ChannelPrivKeys.PaymentBasepointSecret.PaymentBasepoint()
-                DelayedPaymentBasepoint = inputInitFunder.ChannelPrivKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
-                HTLCBasepoint = inputInitFunder.ChannelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
-                FirstPerCommitmentPoint = inputInitFunder.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
-                ChannelFlags = inputInitFunder.ChannelFlags
+                TemporaryChannelId = temporaryChannelId
+                FundingSatoshis = fundingSatoshis
+                PushMSat = pushMSat
+                DustLimitSatoshis = localParams.DustLimitSatoshis
+                MaxHTLCValueInFlightMsat = localParams.MaxHTLCValueInFlightMSat
+                ChannelReserveSatoshis = localParams.ChannelReserveSatoshis
+                HTLCMinimumMsat = localParams.HTLCMinimumMSat
+                FeeRatePerKw = initFeeRatePerKw
+                ToSelfDelay = localParams.ToSelfDelay
+                MaxAcceptedHTLCs = localParams.MaxAcceptedHTLCs
+                FundingPubKey = channelPrivKeys.FundingPrivKey.FundingPubKey()
+                RevocationBasepoint = channelPrivKeys.RevocationBasepointSecret.RevocationBasepoint()
+                PaymentBasepoint = channelPrivKeys.PaymentBasepointSecret.PaymentBasepoint()
+                DelayedPaymentBasepoint = channelPrivKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
+                HTLCBasepoint = channelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
+                FirstPerCommitmentPoint = channelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
+                ChannelFlags = channelFlags
                 ShutdownScriptPubKey = shutdownScriptPubKey
             }
             result {
                 do! Validation.checkOurOpenChannelMsgAcceptable openChannelMsgToSend
                 let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
                 let nodeSecret = nodeMasterPrivKey.NodeSecret()
-                let waitForAcceptChannelData = {
-                    InputInitFunder = inputInitFunder
-                    LastSent = openChannelMsgToSend
-                }
                 let channelWaitingForAcceptChannel = {
                     ChannelHandshakeLimits = channelHandshakeLimits
                     ChannelOptions = channelOptions
@@ -366,8 +401,16 @@ and Channel = {
                     RemoteNodeId = remoteNodeId
                     NodeSecret = nodeSecret
                     Network = network
-                    WaitForAcceptChannelData = waitForAcceptChannelData
+                    LastSent = openChannelMsgToSend
                     LocalShutdownScriptPubKey = shutdownScriptPubKey
+                    TemporaryChannelId = temporaryChannelId
+                    FundingSatoshis = fundingSatoshis
+                    PushMSat = pushMSat
+                    InitFeeRatePerKw = initFeeRatePerKw
+                    FundingTxFeeRatePerKw = fundingTxFeeRatePerKw
+                    LocalParams = localParams
+                    RemoteInit = remoteInit
+                    ChannelFlags = channelFlags
                 }
                 return (openChannelMsgToSend, channelWaitingForAcceptChannel)
             }
@@ -379,15 +422,17 @@ and Channel = {
                                   feeEstimator: IFeeEstimator,
                                   network: Network,
                                   remoteNodeId: NodeId,
-                                  inputInitFundee: InputInitFundee,
                                   minimumDepth: BlockHeightOffset32,
                                   shutdownScriptPubKey: Option<ShutdownScriptPubKey>,
-                                  openChannelMsg: OpenChannelMsg
+                                  openChannelMsg: OpenChannelMsg,
+                                  localParams: LocalParams,
+                                  remoteInit: InitMsg,
+                                  channelPrivKeys: ChannelPrivKeys
                                  ): Result<AcceptChannelMsg * ChannelWaitingForFundingCreated, ChannelError> =
             result {
                 do! Validation.checkOpenChannelMsgAcceptable feeEstimator channelHandshakeLimits channelOptions openChannelMsg
-                let localParams = inputInitFundee.LocalParams
-                let channelKeys = inputInitFundee.ChannelPrivKeys
+                let localParams = localParams
+                let channelKeys = channelPrivKeys
                 let localCommitmentPubKey = channelKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
                 let acceptChannelMsg: AcceptChannelMsg = {
                     TemporaryChannelId = openChannelMsg.TemporaryChannelId
@@ -406,8 +451,7 @@ and Channel = {
                     FirstPerCommitmentPoint = localCommitmentPubKey
                     ShutdownScriptPubKey = shutdownScriptPubKey
                 }
-                let remoteParams = RemoteParams.FromOpenChannel remoteNodeId inputInitFundee.RemoteInit openChannelMsg
-                let waitForFundingCreatedData = Data.WaitForFundingCreatedData.Create localParams remoteParams openChannelMsg acceptChannelMsg
+                let remoteParams = RemoteParams.FromOpenChannel remoteNodeId remoteInit openChannelMsg
                 let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
                 let nodeSecret = nodeMasterPrivKey.NodeSecret()
                 let channelWaitingForFundingCreated = {
@@ -419,7 +463,15 @@ and Channel = {
                     Network = network
                     FundingTxMinimumDepth = minimumDepth
                     LocalShutdownScriptPubKey = shutdownScriptPubKey
-                    WaitForFundingCreatedData = waitForFundingCreatedData
+                    ChannelFlags = openChannelMsg.ChannelFlags
+                    TemporaryFailure = openChannelMsg.TemporaryChannelId
+                    LocalParams = localParams
+                    RemoteParams = remoteParams
+                    FundingSatoshis = openChannelMsg.FundingSatoshis
+                    PushMSat = openChannelMsg.PushMSat
+                    InitialFeeRatePerKw = openChannelMsg.FeeRatePerKw
+                    RemoteFirstPerCommitmentPoint = openChannelMsg.FirstPerCommitmentPoint
+                    LastSent = acceptChannelMsg
                 }
                 return (acceptChannelMsg, channelWaitingForFundingCreated)
             }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -745,6 +745,23 @@ and Channel = {
         return channel, updateFailHTLCMsg
     }
 
+    member self.FailMalformedHTLC (op: OperationFailMalformedHTLC)
+                                      : Result<Channel * UpdateFailMalformedHTLCMsg, ChannelError> = result {
+        let! remoteNextCommitInfo =
+            self.RemoteNextCommitInfoIfFundingLockedNormal "FailMalformedHTLC"
+        let! updateFailMalformedHTLCMsg, newCommitments =
+            Commitments.sendFailMalformed
+                op
+                self.Commitments
+                self.StaticChannelConfig
+                remoteNextCommitInfo
+        let channel = {
+            self with
+                Commitments = newCommitments
+        }
+        return channel, updateFailMalformedHTLCMsg
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -798,17 +815,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | FailMalformedHTLC op ->
-            result {
-                let! remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "FailMalformedHTLC"
-                return!
-                    Commitments.sendFailMalformed
-                        op
-                        cs.Commitments
-                        cs.StaticChannelConfig
-                        remoteNextCommitInfo
-            }
         | ApplyUpdateFailHTLC msg ->
             result {
                 let! remoteNextCommitInfo =
@@ -1126,8 +1132,6 @@ module Channel =
         | WeAcceptedFailHTLC(_origin, _msg, newCommitments) ->
             { c with Commitments = newCommitments }
 
-        | WeAcceptedOperationFailMalformedHTLC(_msg, newCommitments) ->
-            { c with Commitments = newCommitments }
         | WeAcceptedFailMalformedHTLC(_origin, _msg, newCommitments) ->
             { c with Commitments = newCommitments }
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -652,7 +652,6 @@ module Channel =
                                            None)
             let nextState = {
                 ShortChannelId = state.ShortChannelId
-                ChannelAnnouncement = None
                 ChannelUpdate = initialChannelUpdate
                 LocalShutdown = None
                 RemoteShutdown = None
@@ -1112,7 +1111,6 @@ module Channel =
             let nextState = {
                 RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
                 ShortChannelId = s.ShortChannelId
-                ChannelAnnouncement = None
                 ChannelUpdate = channelUpdate
                 LocalShutdown = None
                 RemoteShutdown = None

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -35,33 +35,44 @@ type ChannelWaitingForFundingSigned = {
             let remoteSigPairOfLocalTx = (theirFundingPk,  TransactionSignature(msg.Signature.Value, SigHash.All))
             let sigPairs = seq [ remoteSigPairOfLocalTx; ]
             Transactions.checkTxFinalized signedLocalCommitTx state.LocalCommitTx.WhichInput sigPairs |> expectTransactionError
-        let commitments = { Commitments.LocalParams = state.LocalParams
-                            RemoteParams = state.RemoteParams
-                            ChannelFlags = state.ChannelFlags
-                            FundingScriptCoin =
-                                let amount = state.FundingTx.Value.Outputs.[int state.LastSent.FundingOutputIndex.Value].Value
-                                ChannelHelpers.getFundingScriptCoin
-                                    state.LocalParams.ChannelPubKeys.FundingPubKey
-                                    remoteChannelKeys.FundingPubKey
-                                    state.LastSent.FundingTxId
-                                    state.LastSent.FundingOutputIndex
-                                    amount
-                            LocalCommit = { Index = CommitmentNumber.FirstCommitment;
-                                            Spec = state.LocalSpec;
-                                            PublishableTxs = { PublishableTxs.CommitTx = finalizedLocalCommitTx
-                                                               HTLCTxs = [] }
-                                            PendingHTLCSuccessTxs = [] }
-                            RemoteCommit = state.RemoteCommit
-                            LocalChanges = LocalChanges.Zero
-                            RemoteChanges = RemoteChanges.Zero
-                            LocalNextHTLCId = HTLCId.Zero
-                            RemoteNextHTLCId = HTLCId.Zero
-                            OriginChannels = Map.empty
-                            // we will receive their next per-commitment point in the next msg, so we temporarily put a random byte array
-                            RemoteNextCommitInfo = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101") |> fun h -> new Key(h) |> fun k -> k.PubKey |> PerCommitmentPoint |> RemoteNextCommitInfo.Revoked
-                            RemotePerCommitmentSecrets = PerCommitmentSecretStore()
-                            ChannelId =
-                                msg.ChannelId }
+        let commitments = {
+            Commitments.LocalParams = state.LocalParams
+            RemoteParams = state.RemoteParams
+            ChannelFlags = state.ChannelFlags
+            FundingScriptCoin =
+                let amount =
+                    let index = int state.LastSent.FundingOutputIndex.Value
+                    state.FundingTx.Value.Outputs.[index].Value
+                ChannelHelpers.getFundingScriptCoin
+                    state.LocalParams.ChannelPubKeys.FundingPubKey
+                    remoteChannelKeys.FundingPubKey
+                    state.LastSent.FundingTxId
+                    state.LastSent.FundingOutputIndex
+                    amount
+            LocalCommit = {
+                Index = CommitmentNumber.FirstCommitment
+                Spec = state.LocalSpec
+                PublishableTxs = {
+                    PublishableTxs.CommitTx = finalizedLocalCommitTx
+                    HTLCTxs = []
+                }
+                PendingHTLCSuccessTxs = []
+            }
+            RemoteCommit = state.RemoteCommit
+            LocalChanges = LocalChanges.Zero
+            RemoteChanges = RemoteChanges.Zero
+            LocalNextHTLCId = HTLCId.Zero
+            RemoteNextHTLCId = HTLCId.Zero
+            OriginChannels = Map.empty
+            // we will receive their next per-commitment point in the next msg, so we temporarily put a random byte array
+            RemoteNextCommitInfo =
+                let dummyBytes = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101")
+                let dummyKey = new Key(dummyBytes)
+                dummyKey.PubKey
+                |> PerCommitmentPoint
+                |> RemoteNextCommitInfo.Revoked
+            RemotePerCommitmentSecrets = PerCommitmentSecretStore()
+        }
         let nextState = WaitForFundingConfirmed {
             Deferred = None
             LastSent = Choice1Of2 state.LastSent
@@ -120,35 +131,50 @@ and ChannelWaitingForFundingCreated = {
             |> expectTransactionError
         let localSigOfRemoteCommit, _ =
             self.ChannelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
-        let channelId = OutPoint(msg.FundingTxId.Value, uint32 msg.FundingOutputIndex.Value).ToChannelId()
-        let msgToSend: FundingSignedMsg = { ChannelId = channelId; Signature = !>localSigOfRemoteCommit.Signature }
-        let commitments = { Commitments.LocalParams = state.LocalParams
-                            RemoteParams = state.RemoteParams
-                            ChannelFlags = state.ChannelFlags
-                            FundingScriptCoin =
-                                ChannelHelpers.getFundingScriptCoin
-                                    state.LocalParams.ChannelPubKeys.FundingPubKey
-                                    remoteChannelKeys.FundingPubKey
-                                    msg.FundingTxId
-                                    msg.FundingOutputIndex
-                                    state.FundingSatoshis
-                            LocalCommit = { LocalCommit.Index = CommitmentNumber.FirstCommitment
-                                            Spec = localSpec
-                                            PublishableTxs = { PublishableTxs.CommitTx = finalizedCommitTx;
-                                                               HTLCTxs = [] }
-                                            PendingHTLCSuccessTxs = [] }
-                            RemoteCommit = { RemoteCommit.Index = CommitmentNumber.FirstCommitment
-                                             Spec = remoteSpec
-                                             TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
-                                             RemotePerCommitmentPoint = state.RemoteFirstPerCommitmentPoint }
-                            LocalChanges = LocalChanges.Zero
-                            RemoteChanges = RemoteChanges.Zero
-                            LocalNextHTLCId = HTLCId.Zero
-                            RemoteNextHTLCId = HTLCId.Zero
-                            OriginChannels = Map.empty
-                            RemoteNextCommitInfo = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101") |> fun h -> new Key(h) |> fun k -> k.PubKey |> PerCommitmentPoint |> RemoteNextCommitInfo.Revoked
-                            RemotePerCommitmentSecrets = PerCommitmentSecretStore()
-                            ChannelId = channelId }
+        let commitments = {
+            LocalParams = state.LocalParams
+            RemoteParams = state.RemoteParams
+            ChannelFlags = state.ChannelFlags
+            FundingScriptCoin =
+                ChannelHelpers.getFundingScriptCoin
+                    state.LocalParams.ChannelPubKeys.FundingPubKey
+                    remoteChannelKeys.FundingPubKey
+                    msg.FundingTxId
+                    msg.FundingOutputIndex
+                    state.FundingSatoshis
+            LocalCommit = {
+                Index = CommitmentNumber.FirstCommitment
+                Spec = localSpec
+                PublishableTxs = {
+                    PublishableTxs.CommitTx = finalizedCommitTx
+                    HTLCTxs = []
+                }
+                PendingHTLCSuccessTxs = []
+            }
+            RemoteCommit = {
+                Index = CommitmentNumber.FirstCommitment
+                Spec = remoteSpec
+                TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
+                RemotePerCommitmentPoint = state.RemoteFirstPerCommitmentPoint
+            }
+            LocalChanges = LocalChanges.Zero
+            RemoteChanges = RemoteChanges.Zero
+            LocalNextHTLCId = HTLCId.Zero
+            RemoteNextHTLCId = HTLCId.Zero
+            OriginChannels = Map.empty
+            RemoteNextCommitInfo =
+                let dummyBytes = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101")
+                let dummyKey = new Key(dummyBytes)
+                dummyKey.PubKey
+                |> PerCommitmentPoint
+                |> RemoteNextCommitInfo.Revoked
+            RemotePerCommitmentSecrets = PerCommitmentSecretStore()
+        }
+        let channelId = commitments.ChannelId()
+        let msgToSend: FundingSignedMsg = {
+            ChannelId = channelId
+            Signature = !>localSigOfRemoteCommit.Signature
+        }
         let nextState = WaitForFundingConfirmed {
             Deferred = None
             LastSent = msgToSend |> Choice2Of2
@@ -424,7 +450,7 @@ module Channel =
                 let! closingTx = Transactions.makeClosingTx (cm.FundingScriptCoin) (localSpk) (remoteSpk) (cm.LocalParams.IsFunder) (dustLimitSatoshis) (closingFee) (cm.LocalCommit.Spec) network
                 let localSignature, psbtUpdated = channelPrivKeys.SignWithFundingPrivKey closingTx.Value
                 let msg: ClosingSignedMsg = {
-                    ChannelId = cm.ChannelId
+                    ChannelId = cm.ChannelId()
                     FeeSatoshis = closingFee
                     Signature = localSignature.Signature |> LNECDSASignature
                 }
@@ -490,7 +516,7 @@ module Channel =
         let commitmentSeed = channelPrivKeys.CommitmentSeed
         let ourChannelReestablish =
             {
-                ChannelId = commitments.ChannelId
+                ChannelId = commitments.ChannelId()
                 NextCommitmentNumber =
                     (commitments.RemotePerCommitmentSecrets.NextCommitmentNumber().NextCommitment())
                 NextRevocationNumber =
@@ -522,7 +548,7 @@ module Channel =
                     cs.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint
                         (CommitmentNumber.FirstCommitment.NextCommitment())
                 let msgToSend: FundingLockedMsg = {
-                    ChannelId = cs.Commitments.ChannelId
+                    ChannelId = cs.Commitments.ChannelId()
                     NextPerCommitmentPoint = nextPerCommitmentPoint
                 }
 
@@ -594,7 +620,7 @@ module Channel =
         | ChannelState.Normal _state, MonoHopUnidirectionalPayment op ->
             result {
                 let payment: MonoHopUnidirectionalPaymentMsg = {
-                    ChannelId = cs.Commitments.ChannelId
+                    ChannelId = cs.Commitments.ChannelId()
                     Amount = op.Amount
                 }
                 let commitments1 = cs.Commitments.AddLocalProposal(payment)
@@ -621,7 +647,7 @@ module Channel =
             result {
                 do! Validation.checkOperationAddHTLC cs.Commitments op
                 let add: UpdateAddHTLCMsg = {
-                    ChannelId = cs.Commitments.ChannelId
+                    ChannelId = cs.Commitments.ChannelId()
                     HTLCId = cs.Commitments.LocalNextHTLCId
                     Amount = op.Amount
                     PaymentHash = op.PaymentHash
@@ -747,7 +773,7 @@ module Channel =
                 if (cs.Commitments.LocalHasUnsignedOutgoingHTLCs()) then
                     do! cannotCloseChannel "Cannot close with unsigned outgoing htlcs"
                 let shutdownMsg: ShutdownMsg = {
-                    ChannelId = cs.Commitments.ChannelId
+                    ChannelId = cs.Commitments.ChannelId()
                     ScriptPubKey = localShutdownScriptPubKey
                 }
                 return [ AcceptedOperationShutdown shutdownMsg ]
@@ -812,7 +838,7 @@ module Channel =
                         | Some localShutdown -> (localShutdown, [])
                         | None ->
                             let localShutdown: ShutdownMsg = {
-                                ChannelId = cs.Commitments.ChannelId
+                                ChannelId = cs.Commitments.ChannelId()
                                 ScriptPubKey = localShutdownScriptPubKey
                             }
                             (localShutdown, [ localShutdown ])

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -23,7 +23,6 @@ type ChannelWaitingForFundingSigned = {
     LocalSpec: CommitmentSpec
     LocalCommitTx: CommitTx
     RemoteCommit: RemoteCommit
-    LastSent: FundingCreatedMsg
 } with
     member self.ApplyFundingSigned (msg: FundingSignedMsg)
                                        : Result<FinalizedTx * Channel, ChannelError> = result {
@@ -259,7 +258,6 @@ and ChannelWaitingForFundingTx = {
                 Spec = remoteSpec
                 RemotePerCommitmentPoint = self.LastReceived.FirstPerCommitmentPoint
             }
-            LastSent = nextMsg
         }
         return nextMsg, channelWaitingForFundingSigned
     }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -716,6 +716,17 @@ and Channel = {
         return channel, updateFulfillHTLCMsg
     }
 
+    member self.ApplyUpdateFulfillHTLC (msg: UpdateFulfillHTLCMsg)
+                                           : Result<Channel, ChannelError> = result {
+        let! remoteNextCommitInfo =
+            self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyUpdateFulfullHTLC"
+        let! newCommitments = Commitments.receiveFulfill msg self.Commitments remoteNextCommitInfo
+        return {
+            self with
+                Commitments = newCommitments
+        }
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -769,12 +780,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | ChannelCommand.ApplyUpdateFulfillHTLC msg ->
-            result {
-                let! remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "ApplyUpdateFulfullHTLC"
-                return! Commitments.receiveFulfill msg cs.Commitments remoteNextCommitInfo
-            }
         | FailHTLC op ->
             result {
                 let! remoteNextCommitInfo =
@@ -1112,9 +1117,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // ----- normal operation --------
-        | WeAcceptedFulfillHTLC(_msg, _origin, _htlc, newCommitments) ->
-            { c with Commitments = newCommitments }
-
         | WeAcceptedOperationFailHTLC(_msg, newCommitments) ->
             { c with Commitments = newCommitments }
         | WeAcceptedFailHTLC(_origin, _msg, newCommitments) ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -577,7 +577,6 @@ module Channel =
                                                  RemoteCommit = theirNextCommit
                                                  RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
                                                  RemotePerCommitmentSecrets = remotePerCommitmentSecrets }
-                    Console.WriteLine("WARNING: revocation is not implemented yet")
                     Ok [ WeAcceptedRevokeAndACK(commitments1) ]
 
         | ChannelState.Normal state, ChannelCommand.Close cmd ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -328,33 +328,97 @@ and Channel = {
     NegotiatingState: NegotiatingState
     Commitments: Commitments
  }
-        with
-        static member NewOutbound(channelHandshakeLimits: ChannelHandshakeLimits,
-                                  channelOptions: ChannelOptions,
-                                  announceChannel: bool,
-                                  nodeMasterPrivKey: NodeMasterPrivKey,
-                                  channelIndex: int,
-                                  network: Network,
-                                  remoteNodeId: NodeId,
-                                  shutdownScriptPubKey: Option<ShutdownScriptPubKey>,
-                                  temporaryChannelId: ChannelId,
-                                  fundingSatoshis: Money,
-                                  pushMSat: LNMoney,
-                                  initFeeRatePerKw: FeeRatePerKw,
-                                  localParams: LocalParams,
-                                  remoteInit: InitMsg,
-                                  channelPrivKeys: ChannelPrivKeys
-                                 ): Result<OpenChannelMsg * ChannelWaitingForAcceptChannel, ChannelError> =
-            let openChannelMsgToSend: OpenChannelMsg = {
-                Chainhash = network.Consensus.HashGenesisBlock
+    with
+    static member NewOutbound (channelHandshakeLimits: ChannelHandshakeLimits)
+                              (channelOptions: ChannelOptions)
+                              (announceChannel: bool)
+                              (nodeMasterPrivKey: NodeMasterPrivKey)
+                              (channelIndex: int)
+                              (network: Network)
+                              (remoteNodeId: NodeId)
+                              (shutdownScriptPubKey: Option<ShutdownScriptPubKey>)
+                              (temporaryChannelId: ChannelId)
+                              (fundingSatoshis: Money)
+                              (pushMSat: LNMoney)
+                              (initFeeRatePerKw: FeeRatePerKw)
+                              (localParams: LocalParams)
+                              (remoteInit: InitMsg)
+                                  : Result<OpenChannelMsg * ChannelWaitingForAcceptChannel, ChannelError> =
+        let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
+        let openChannelMsgToSend: OpenChannelMsg = {
+            Chainhash = network.Consensus.HashGenesisBlock
+            TemporaryChannelId = temporaryChannelId
+            FundingSatoshis = fundingSatoshis
+            PushMSat = pushMSat
+            DustLimitSatoshis = localParams.DustLimitSatoshis
+            MaxHTLCValueInFlightMsat = localParams.MaxHTLCValueInFlightMSat
+            ChannelReserveSatoshis = localParams.ChannelReserveSatoshis
+            HTLCMinimumMsat = localParams.HTLCMinimumMSat
+            FeeRatePerKw = initFeeRatePerKw
+            ToSelfDelay = localParams.ToSelfDelay
+            MaxAcceptedHTLCs = localParams.MaxAcceptedHTLCs
+            FundingPubKey = channelPrivKeys.FundingPrivKey.FundingPubKey()
+            RevocationBasepoint = channelPrivKeys.RevocationBasepointSecret.RevocationBasepoint()
+            PaymentBasepoint = channelPrivKeys.PaymentBasepointSecret.PaymentBasepoint()
+            DelayedPaymentBasepoint = channelPrivKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
+            HTLCBasepoint = channelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
+            FirstPerCommitmentPoint = channelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
+            ChannelFlags = {
+                AnnounceChannel = announceChannel
+            }
+            ShutdownScriptPubKey = shutdownScriptPubKey
+        }
+        result {
+            do! Validation.checkOurOpenChannelMsgAcceptable openChannelMsgToSend
+            let nodeSecret = nodeMasterPrivKey.NodeSecret()
+            let channelWaitingForAcceptChannel = {
+                AnnounceChannel = announceChannel
+                ChannelHandshakeLimits = channelHandshakeLimits
+                ChannelOptions = channelOptions
+                ChannelPrivKeys = channelPrivKeys
+                RemoteNodeId = remoteNodeId
+                NodeSecret = nodeSecret
+                Network = network
+                LocalStaticShutdownScriptPubKey = shutdownScriptPubKey
                 TemporaryChannelId = temporaryChannelId
                 FundingSatoshis = fundingSatoshis
                 PushMSat = pushMSat
+                InitFeeRatePerKw = initFeeRatePerKw
+                LocalParams = localParams
+                RemoteInit = remoteInit
+            }
+            return (openChannelMsgToSend, channelWaitingForAcceptChannel)
+        }
+
+    static member NewInbound (channelHandshakeLimits: ChannelHandshakeLimits)
+                             (channelOptions: ChannelOptions)
+                             (announceChannel: bool)
+                             (nodeMasterPrivKey: NodeMasterPrivKey)
+                             (channelIndex: int)
+                             (network: Network)
+                             (remoteNodeId: NodeId)
+                             (minimumDepth: BlockHeightOffset32)
+                             (shutdownScriptPubKey: Option<ShutdownScriptPubKey>)
+                             (openChannelMsg: OpenChannelMsg)
+                             (localParams: LocalParams)
+                             (remoteInit: InitMsg)
+                                 : Result<AcceptChannelMsg * ChannelWaitingForFundingCreated, ChannelError> =
+        result {
+            let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
+            do!
+                Validation.checkOpenChannelMsgAcceptable
+                    channelHandshakeLimits
+                    channelOptions
+                    announceChannel
+                    openChannelMsg
+            let firstPerCommitmentPoint = channelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
+            let acceptChannelMsg: AcceptChannelMsg = {
+                TemporaryChannelId = openChannelMsg.TemporaryChannelId
                 DustLimitSatoshis = localParams.DustLimitSatoshis
                 MaxHTLCValueInFlightMsat = localParams.MaxHTLCValueInFlightMSat
                 ChannelReserveSatoshis = localParams.ChannelReserveSatoshis
-                HTLCMinimumMsat = localParams.HTLCMinimumMSat
-                FeeRatePerKw = initFeeRatePerKw
+                HTLCMinimumMSat = localParams.HTLCMinimumMSat
+                MinimumDepth = minimumDepth
                 ToSelfDelay = localParams.ToSelfDelay
                 MaxAcceptedHTLCs = localParams.MaxAcceptedHTLCs
                 FundingPubKey = channelPrivKeys.FundingPrivKey.FundingPubKey()
@@ -362,106 +426,40 @@ and Channel = {
                 PaymentBasepoint = channelPrivKeys.PaymentBasepointSecret.PaymentBasepoint()
                 DelayedPaymentBasepoint = channelPrivKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
                 HTLCBasepoint = channelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
-                FirstPerCommitmentPoint = channelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
-                ChannelFlags = {
-                    AnnounceChannel = announceChannel
-                }
+                FirstPerCommitmentPoint = firstPerCommitmentPoint
                 ShutdownScriptPubKey = shutdownScriptPubKey
             }
-            result {
-                do! Validation.checkOurOpenChannelMsgAcceptable openChannelMsgToSend
-                let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
-                let nodeSecret = nodeMasterPrivKey.NodeSecret()
-                let channelWaitingForAcceptChannel = {
-                    AnnounceChannel = announceChannel
-                    ChannelHandshakeLimits = channelHandshakeLimits
-                    ChannelOptions = channelOptions
-                    ChannelPrivKeys = channelPrivKeys
-                    RemoteNodeId = remoteNodeId
-                    NodeSecret = nodeSecret
-                    Network = network
-                    LocalStaticShutdownScriptPubKey = shutdownScriptPubKey
-                    TemporaryChannelId = temporaryChannelId
-                    FundingSatoshis = fundingSatoshis
-                    PushMSat = pushMSat
-                    InitFeeRatePerKw = initFeeRatePerKw
-                    LocalParams = localParams
-                    RemoteInit = remoteInit
-                }
-                return (openChannelMsgToSend, channelWaitingForAcceptChannel)
+            let remoteChannelPubKeys = {
+                FundingPubKey = openChannelMsg.FundingPubKey
+                RevocationBasepoint = openChannelMsg.RevocationBasepoint
+                PaymentBasepoint = openChannelMsg.PaymentBasepoint
+                DelayedPaymentBasepoint = openChannelMsg.DelayedPaymentBasepoint
+                HtlcBasepoint = openChannelMsg.HTLCBasepoint
             }
-
-        static member NewInbound (channelHandshakeLimits: ChannelHandshakeLimits,
-                                  channelOptions: ChannelOptions,
-                                  announceChannel: bool,
-                                  nodeMasterPrivKey: NodeMasterPrivKey,
-                                  channelIndex: int,
-                                  network: Network,
-                                  remoteNodeId: NodeId,
-                                  minimumDepth: BlockHeightOffset32,
-                                  shutdownScriptPubKey: Option<ShutdownScriptPubKey>,
-                                  openChannelMsg: OpenChannelMsg,
-                                  localParams: LocalParams,
-                                  remoteInit: InitMsg,
-                                  channelPrivKeys: ChannelPrivKeys
-                                 ): Result<AcceptChannelMsg * ChannelWaitingForFundingCreated, ChannelError> =
-            result {
-                do!
-                    Validation.checkOpenChannelMsgAcceptable
-                        channelHandshakeLimits
-                        channelOptions
-                        announceChannel
-                        openChannelMsg
-                let firstPerCommitmentPoint = channelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
-                let acceptChannelMsg: AcceptChannelMsg = {
-                    TemporaryChannelId = openChannelMsg.TemporaryChannelId
-                    DustLimitSatoshis = localParams.DustLimitSatoshis
-                    MaxHTLCValueInFlightMsat = localParams.MaxHTLCValueInFlightMSat
-                    ChannelReserveSatoshis = localParams.ChannelReserveSatoshis
-                    HTLCMinimumMSat = localParams.HTLCMinimumMSat
-                    MinimumDepth = minimumDepth
-                    ToSelfDelay = localParams.ToSelfDelay
-                    MaxAcceptedHTLCs = localParams.MaxAcceptedHTLCs
-                    FundingPubKey = channelPrivKeys.FundingPrivKey.FundingPubKey()
-                    RevocationBasepoint = channelPrivKeys.RevocationBasepointSecret.RevocationBasepoint()
-                    PaymentBasepoint = channelPrivKeys.PaymentBasepointSecret.PaymentBasepoint()
-                    DelayedPaymentBasepoint = channelPrivKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
-                    HTLCBasepoint = channelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
-                    FirstPerCommitmentPoint = firstPerCommitmentPoint
-                    ShutdownScriptPubKey = shutdownScriptPubKey
-                }
-                let remoteChannelPubKeys = {
-                    FundingPubKey = openChannelMsg.FundingPubKey
-                    RevocationBasepoint = openChannelMsg.RevocationBasepoint
-                    PaymentBasepoint = openChannelMsg.PaymentBasepoint
-                    DelayedPaymentBasepoint = openChannelMsg.DelayedPaymentBasepoint
-                    HtlcBasepoint = openChannelMsg.HTLCBasepoint
-                }
-                let remoteParams = RemoteParams.FromOpenChannel remoteInit openChannelMsg
-                let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
-                let nodeSecret = nodeMasterPrivKey.NodeSecret()
-                let channelWaitingForFundingCreated = {
-                    AnnounceChannel = openChannelMsg.ChannelFlags.AnnounceChannel
-                    RemoteNodeId = remoteNodeId
-                    Network = network
-                    FundingTxMinimumDepth = minimumDepth
-                    LocalStaticShutdownScriptPubKey = shutdownScriptPubKey
-                    RemoteStaticShutdownScriptPubKey = openChannelMsg.ShutdownScriptPubKey
-                    IsFunder = false
-                    ChannelOptions = channelOptions
-                    ChannelPrivKeys = channelPrivKeys
-                    NodeSecret = nodeSecret
-                    TemporaryFailure = openChannelMsg.TemporaryChannelId
-                    LocalParams = localParams
-                    RemoteParams = remoteParams
-                    RemoteChannelPubKeys = remoteChannelPubKeys
-                    FundingSatoshis = openChannelMsg.FundingSatoshis
-                    PushMSat = openChannelMsg.PushMSat
-                    InitialFeeRatePerKw = openChannelMsg.FeeRatePerKw
-                    RemoteFirstPerCommitmentPoint = openChannelMsg.FirstPerCommitmentPoint
-                }
-                return (acceptChannelMsg, channelWaitingForFundingCreated)
+            let remoteParams = RemoteParams.FromOpenChannel remoteInit openChannelMsg
+            let nodeSecret = nodeMasterPrivKey.NodeSecret()
+            let channelWaitingForFundingCreated = {
+                AnnounceChannel = openChannelMsg.ChannelFlags.AnnounceChannel
+                RemoteNodeId = remoteNodeId
+                Network = network
+                FundingTxMinimumDepth = minimumDepth
+                LocalStaticShutdownScriptPubKey = shutdownScriptPubKey
+                RemoteStaticShutdownScriptPubKey = openChannelMsg.ShutdownScriptPubKey
+                IsFunder = false
+                ChannelOptions = channelOptions
+                ChannelPrivKeys = channelPrivKeys
+                NodeSecret = nodeSecret
+                TemporaryFailure = openChannelMsg.TemporaryChannelId
+                LocalParams = localParams
+                RemoteParams = remoteParams
+                RemoteChannelPubKeys = remoteChannelPubKeys
+                FundingSatoshis = openChannelMsg.FundingSatoshis
+                PushMSat = openChannelMsg.PushMSat
+                InitialFeeRatePerKw = openChannelMsg.FeeRatePerKw
+                RemoteFirstPerCommitmentPoint = openChannelMsg.FirstPerCommitmentPoint
             }
+            return (acceptChannelMsg, channelWaitingForFundingCreated)
+        }
 
 module Channel =
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -73,13 +73,6 @@ type ChannelWaitingForFundingSigned = {
             LocalNextHTLCId = HTLCId.Zero
             RemoteNextHTLCId = HTLCId.Zero
             OriginChannels = Map.empty
-            // we will receive their next per-commitment point in the next msg, so we temporarily put a random byte array
-            RemoteNextCommitInfo =
-                let dummyBytes = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101")
-                let dummyKey = new Key(dummyBytes)
-                dummyKey.PubKey
-                |> PerCommitmentPoint
-                |> RemoteNextCommitInfo.Revoked
             RemotePerCommitmentSecrets = PerCommitmentSecretStore()
         }
         let nextState = WaitForFundingConfirmed {
@@ -183,12 +176,6 @@ and ChannelWaitingForFundingCreated = {
             LocalNextHTLCId = HTLCId.Zero
             RemoteNextHTLCId = HTLCId.Zero
             OriginChannels = Map.empty
-            RemoteNextCommitInfo =
-                let dummyBytes = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101")
-                let dummyKey = new Key(dummyBytes)
-                dummyKey.PubKey
-                |> PerCommitmentPoint
-                |> RemoteNextCommitInfo.Revoked
             RemotePerCommitmentSecrets = PerCommitmentSecretStore()
         }
         let channelId = commitments.ChannelId()
@@ -552,13 +539,16 @@ module Channel =
             ((localClosingFee.Satoshi + remoteClosingFee.Satoshi) / 4L) * 2L
             |> Money.Satoshis
 
-        let handleMutualClose (closingTx: FinalizedTx, d: NegotiatingData) =
+        let handleMutualClose (closingTx: FinalizedTx)
+                              (d: NegotiatingData)
+                              (remoteNextCommitInfo: RemoteNextCommitInfo) =
             let nextData =
                 ClosingData.Create
                     None
                     DateTime.Now
                     (d.ClosingTxProposed |> List.collect id |> List.map (fun tx -> tx.UnsignedTx))
                     closingTx
+                    remoteNextCommitInfo
             [ MutualClosePerformed (closingTx, nextData) ]
             |> Ok
 
@@ -660,25 +650,21 @@ module Channel =
                                            cs.ChannelOptions.FeeProportionalMillionths,
                                            true,
                                            None)
-            let nextCommitments = {
-                cs.Commitments with
-                    RemoteNextCommitInfo =
-                        RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint)
-            }
             let nextState = {
                 ShortChannelId = state.ShortChannelId
                 ChannelAnnouncement = None
                 ChannelUpdate = initialChannelUpdate
                 LocalShutdown = None
                 RemoteShutdown = None
+                RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint)
             }
-            [ BothFundingLocked(nextState, nextCommitments) ] |> Ok
+            [ BothFundingLocked(nextState) ] |> Ok
 
         // ---------- normal operation ---------
         | ChannelState.Normal state, MonoHopUnidirectionalPayment op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
             sprintf "Could not send mono-hop unidirectional payment %A since shutdown is already in progress." op
             |> apiMisuse
-        | ChannelState.Normal _state, MonoHopUnidirectionalPayment op ->
+        | ChannelState.Normal state, MonoHopUnidirectionalPayment op ->
             result {
                 let payment: MonoHopUnidirectionalPaymentMsg = {
                     ChannelId = cs.Commitments.ChannelId()
@@ -687,7 +673,7 @@ module Channel =
                 let commitments1 = cs.Commitments.AddLocalProposal(payment)
 
                 let remoteCommit1 =
-                    match commitments1.RemoteNextCommitInfo with
+                    match state.RemoteNextCommitInfo with
                     | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
                     | RemoteNextCommitInfo.Revoked _info -> commitments1.RemoteCommit
                 let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
@@ -704,7 +690,7 @@ module Channel =
         | ChannelState.Normal state, AddHTLC op when state.LocalShutdown.IsSome || state.RemoteShutdown.IsSome ->
             sprintf "Could not add new HTLC %A since shutdown is already in progress." op
             |> apiMisuse
-        | ChannelState.Normal _state, AddHTLC op ->
+        | ChannelState.Normal state, AddHTLC op ->
             result {
                 do! Validation.checkOperationAddHTLC cs.Commitments op
                 let add: UpdateAddHTLCMsg = {
@@ -731,7 +717,7 @@ module Channel =
 
                 // we need to base the next current commitment on the last sig we sent, even if we didn't yet receive their revocation
                 let remoteCommit1 =
-                    match commitments1.RemoteNextCommitInfo with
+                    match state.RemoteNextCommitInfo with
                     | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
                     | RemoteNextCommitInfo.Revoked _info -> commitments1.RemoteCommit
                 let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.LocalChanges.Proposed) |> expectTransactionError
@@ -754,26 +740,26 @@ module Channel =
                 return [ WeAcceptedUpdateAddHTLC commitments1 ]
             }
 
-        | ChannelState.Normal _state, FulfillHTLC cmd ->
+        | ChannelState.Normal state, FulfillHTLC cmd ->
             result {
-                let! t = cs.Commitments |> Commitments.sendFulfill (cmd)
+                let! t = Commitments.sendFulfill cmd cs.Commitments state.RemoteNextCommitInfo
                 return [ WeAcceptedOperationFulfillHTLC t ]
             }
 
-        | ChannelState.Normal _state, ChannelCommand.ApplyUpdateFulfillHTLC msg ->
-            cs.Commitments |> Commitments.receiveFulfill msg
+        | ChannelState.Normal state, ChannelCommand.ApplyUpdateFulfillHTLC msg ->
+            Commitments.receiveFulfill msg cs.Commitments state.RemoteNextCommitInfo
 
-        | ChannelState.Normal _state, FailHTLC op ->
-            cs.Commitments |> Commitments.sendFail cs.NodeSecret op
+        | ChannelState.Normal state, FailHTLC op ->
+            Commitments.sendFail cs.NodeSecret op cs.Commitments state.RemoteNextCommitInfo
 
-        | ChannelState.Normal _state, FailMalformedHTLC op ->
-            cs.Commitments |> Commitments.sendFailMalformed op
+        | ChannelState.Normal state, FailMalformedHTLC op ->
+            Commitments.sendFailMalformed op cs.Commitments state.RemoteNextCommitInfo
 
-        | ChannelState.Normal _state, ApplyUpdateFailHTLC msg ->
-            cs.Commitments |> Commitments.receiveFail msg
+        | ChannelState.Normal state, ApplyUpdateFailHTLC msg ->
+            Commitments.receiveFail msg cs.Commitments state.RemoteNextCommitInfo
 
-        | ChannelState.Normal _state, ApplyUpdateFailMalformedHTLC msg ->
-            cs.Commitments |> Commitments.receiveFailMalformed msg
+        | ChannelState.Normal state, ApplyUpdateFailMalformedHTLC msg ->
+            Commitments.receiveFailMalformed msg cs.Commitments state.RemoteNextCommitInfo
 
         | ChannelState.Normal _state, UpdateFee op ->
             cs.Commitments |> Commitments.sendFee op
@@ -781,15 +767,15 @@ module Channel =
             let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
             cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
 
-        | ChannelState.Normal _state, SignCommitment ->
+        | ChannelState.Normal state, SignCommitment ->
             let cm = cs.Commitments
             result {
-                match cm.RemoteNextCommitInfo with
+                match state.RemoteNextCommitInfo with
                 | _ when (cm.LocalHasChanges() |> not) ->
                     // Ignore SignCommitment Command (nothing to sign)
                     return []
                 | RemoteNextCommitInfo.Revoked _ ->
-                    return! cm |> Commitments.sendCommit cs.ChannelPrivKeys (cs.Network)
+                    return! Commitments.sendCommit cs.ChannelPrivKeys cs.Network cm state.RemoteNextCommitInfo
                 | RemoteNextCommitInfo.Waiting _ ->
                     // Already in the process of signing
                     return []
@@ -798,9 +784,9 @@ module Channel =
         | ChannelState.Normal _state, ApplyCommitmentSigned msg ->
             cs.Commitments |> Commitments.receiveCommit cs.ChannelPrivKeys msg cs.Network
 
-        | ChannelState.Normal _state, ApplyRevokeAndACK msg ->
+        | ChannelState.Normal state, ApplyRevokeAndACK msg ->
             let cm = cs.Commitments
-            match cm.RemoteNextCommitInfo with
+            match state.RemoteNextCommitInfo with
             | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> cm.RemoteCommit.RemotePerCommitmentPoint) ->
                 let errorMsg = sprintf "Invalid revoke_and_ack %A; must be %A" msg.PerCommitmentSecret cm.RemoteCommit.RemotePerCommitmentPoint
                 invalidRevokeAndACK msg errorMsg
@@ -815,12 +801,21 @@ module Channel =
                 match remotePerCommitmentSecretsOpt with
                 | Error err -> invalidRevokeAndACK msg err.Message
                 | Ok remotePerCommitmentSecrets ->
-                    let commitments1 = { cm with LocalChanges = { cm.LocalChanges with Signed = []; ACKed = cm.LocalChanges.ACKed @ cm.LocalChanges.Signed }
-                                                 RemoteChanges = { cm.RemoteChanges with Signed = [] }
-                                                 RemoteCommit = theirNextCommit
-                                                 RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
-                                                 RemotePerCommitmentSecrets = remotePerCommitmentSecrets }
-                    Ok [ WeAcceptedRevokeAndACK(commitments1) ]
+                    let commitments1 = {
+                        cm with
+                            LocalChanges = {
+                                cm.LocalChanges with
+                                    Signed = [];
+                                    ACKed = cm.LocalChanges.ACKed @ cm.LocalChanges.Signed
+                            }
+                            RemoteChanges = {
+                                cm.RemoteChanges with
+                                    Signed = []
+                            }
+                            RemoteCommit = theirNextCommit
+                            RemotePerCommitmentSecrets = remotePerCommitmentSecrets
+                    }
+                    Ok [ WeAcceptedRevokeAndACK(commitments1, msg.NextPerCommitmentPoint) ]
 
         | ChannelState.Normal state, ChannelCommand.Close localShutdownScriptPubKey ->
             result {
@@ -870,7 +865,7 @@ module Channel =
                         return failwith "can't have pending unsigned outgoing htlcs after having sent Shutdown. this should never happen"
                     else
                         // Are we in the middle of a signature?
-                        match cm.RemoteNextCommitInfo with
+                        match state.RemoteNextCommitInfo with
                         // yes.
                         | RemoteNextCommitInfo.Waiting _waitingForRevocation ->
                             return [
@@ -892,7 +887,7 @@ module Channel =
                                 ScriptPubKey = localShutdownScriptPubKey
                             }
                             (localShutdown, [ localShutdown ])
-                    if (cm.HasNoPendingHTLCs()) then
+                    if (cm.HasNoPendingHTLCs state.RemoteNextCommitInfo) then
                         // we have to send first closing_signed msg iif we are the funder
                         if (cm.IsFunder) then
                             let! (closingTx, closingSignedMsg) =
@@ -905,6 +900,7 @@ module Channel =
                                     cs.Network
                                 )
                             let nextState = {
+                                RemoteNextCommitInfo = state.RemoteNextCommitInfo
                                 LocalShutdown = localShutdown
                                 RemoteShutdown = msg
                                 ClosingTxProposed = [[{
@@ -921,6 +917,7 @@ module Channel =
                             ]
                         else
                             let nextState = {
+                                RemoteNextCommitInfo = state.RemoteNextCommitInfo
                                 LocalShutdown = localShutdown
                                 RemoteShutdown = msg
                                 ClosingTxProposed = [ [] ]
@@ -931,36 +928,37 @@ module Channel =
                         let nextState = {
                             LocalShutdown = localShutdown
                             RemoteShutdown = msg
+                            RemoteNextCommitInfo = state.RemoteNextCommitInfo
                         }
                         return [ AcceptedShutdownWhenWeHavePendingHTLCs(nextState) ]
             }
         // ----------- closing ---------
-        | Shutdown _state, FulfillHTLC op ->
+        | Shutdown state, FulfillHTLC op ->
             result {
-                let! t = cs.Commitments |> Commitments.sendFulfill op
+                let! t = Commitments.sendFulfill op cs.Commitments state.RemoteNextCommitInfo
                 return [ WeAcceptedOperationFulfillHTLC t ]
             }
-        | Shutdown _state, ApplyUpdateFulfillHTLC msg ->
-            cs.Commitments |> Commitments.receiveFulfill msg
-        | Shutdown _state, FailHTLC op ->
-            cs.Commitments |> Commitments.sendFail cs.NodeSecret op
-        | Shutdown _state, FailMalformedHTLC op ->
-            cs.Commitments |> Commitments.sendFailMalformed op
-        | Shutdown _state, ApplyUpdateFailMalformedHTLC msg ->
-            cs.Commitments |> Commitments.receiveFailMalformed msg
+        | Shutdown state, ApplyUpdateFulfillHTLC msg ->
+            Commitments.receiveFulfill msg cs.Commitments state.RemoteNextCommitInfo
+        | Shutdown state, FailHTLC op ->
+            Commitments.sendFail cs.NodeSecret op cs.Commitments state.RemoteNextCommitInfo
+        | Shutdown state, FailMalformedHTLC op ->
+            Commitments.sendFailMalformed op cs.Commitments state.RemoteNextCommitInfo
+        | Shutdown state, ApplyUpdateFailMalformedHTLC msg ->
+            Commitments.receiveFailMalformed msg cs.Commitments state.RemoteNextCommitInfo
         | Shutdown _state, UpdateFee op ->
             cs.Commitments |> Commitments.sendFee op
         | Shutdown _state, ApplyUpdateFee msg ->
             let localFeerate = cs.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority)
             cs.Commitments |> Commitments.receiveFee cs.ChannelOptions localFeerate msg
-        | Shutdown _state, SignCommitment ->
+        | Shutdown state, SignCommitment ->
             let cm = cs.Commitments
-            match cm.RemoteNextCommitInfo with
+            match state.RemoteNextCommitInfo with
             | _ when (not <| cm.LocalHasChanges()) ->
                 // nothing to sign
                 [] |> Ok
             | RemoteNextCommitInfo.Revoked _ ->
-                cm |> Commitments.sendCommit cs.ChannelPrivKeys (cs.Network)
+                Commitments.sendCommit cs.ChannelPrivKeys cs.Network cm state.RemoteNextCommitInfo
             | RemoteNextCommitInfo.Waiting _waitForRevocation ->
                 // Already in the process of signing.
                 [] |> Ok
@@ -1004,7 +1002,11 @@ module Channel =
                 let hasTooManyNegotiationDone =
                     (state.ClosingTxProposed |> List.collect (id) |> List.length) >= cs.ChannelOptions.MaxClosingNegotiationIterations
                 if (areWeInDeal || hasTooManyNegotiationDone) then
-                    return! Closing.handleMutualClose (finalizedTx, { state with MaybeBestUnpublishedTx = Some(finalizedTx) })
+                    return!
+                        Closing.handleMutualClose
+                            finalizedTx
+                            { state with MaybeBestUnpublishedTx = Some(finalizedTx) }
+                            state.RemoteNextCommitInfo
                 else
                     let lastLocalClosingFee = state.ClosingTxProposed |> List.tryHead |> Option.bind (List.tryHead) |> Option.map (fun txp -> txp.LocalClosingSigned.FeeSatoshis)
                     let! localF = 
@@ -1021,7 +1023,11 @@ module Channel =
                     let nextClosingFee =
                         Closing.nextClosingFee (localF, msg.FeeSatoshis)
                     if (Some nextClosingFee = lastLocalClosingFee) then
-                        return! Closing.handleMutualClose (finalizedTx, { state with MaybeBestUnpublishedTx = Some(finalizedTx) })
+                        return!
+                            Closing.handleMutualClose
+                                finalizedTx
+                                { state with MaybeBestUnpublishedTx = Some(finalizedTx) }
+                                state.RemoteNextCommitInfo
                     else if (nextClosingFee = msg.FeeSatoshis) then
                         // we have reached on agreement!
                         let closingTxProposed1 =
@@ -1030,7 +1036,11 @@ module Channel =
                             newProposed :: state.ClosingTxProposed
                         let negoData = { state with ClosingTxProposed = closingTxProposed1
                                                     MaybeBestUnpublishedTx = Some(finalizedTx) }
-                        return! Closing.handleMutualClose (finalizedTx, negoData)
+                        return!
+                            Closing.handleMutualClose
+                            finalizedTx
+                            negoData
+                            state.RemoteNextCommitInfo
                     else
                         let! closingTx, closingSignedMsg =
                             Closing.makeClosingTx (
@@ -1053,7 +1063,8 @@ module Channel =
             // got valid payment preimage, recalculating txs to redeem the corresponding htlc on-chain
             result {
                 let cm = cs.Commitments
-                let! (_msgToSend, newCommitments) = cm |> Commitments.sendFulfill op
+                let! (_msgToSend, newCommitments) =
+                    Commitments.sendFulfill op cm state.RemoteNextCommitInfo
                 let _localCommitPublished =
                     state.LocalCommitPublished
                     |> Option.map (fun localCommitPublished ->
@@ -1075,7 +1086,7 @@ module Channel =
             { c with State = WaitForFundingLocked data }
         | TheySentFundingLocked msg, WaitForFundingConfirmed s ->
             { c with State = WaitForFundingConfirmed({ s with Deferred = Some(msg) }) }
-        | TheySentFundingLocked _msg, WaitForFundingLocked s ->
+        | TheySentFundingLocked msg, WaitForFundingLocked s ->
             let feeRate = c.Commitments.LocalCommit.Spec.FeeRatePerKw
             let feeBase =
                 ChannelHelpers.getOurFeeBaseMSat
@@ -1093,6 +1104,7 @@ module Channel =
                                                            true,
                                                            None)
             let nextState = {
+                RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
                 ShortChannelId = s.ShortChannelId
                 ChannelAnnouncement = None
                 ChannelUpdate = channelUpdate
@@ -1130,13 +1142,28 @@ module Channel =
         | WeAcceptedUpdateFee(_msg, newCommitments), ChannelState.Normal _normalData ->
             { c with Commitments = newCommitments }
 
-        | WeAcceptedOperationSign(_msg, newCommitments), ChannelState.Normal _normalData ->
-            { c with Commitments = newCommitments }
+        | WeAcceptedOperationSign(_msg, newCommitments, waitingForRevocation), ChannelState.Normal normalData ->
+            {
+                c with
+                    Commitments = newCommitments
+                    State = ChannelState.Normal {
+                        normalData with
+                            RemoteNextCommitInfo = RemoteNextCommitInfo.Waiting waitingForRevocation
+                    }
+            }
         | WeAcceptedCommitmentSigned(_msg, newCommitments), ChannelState.Normal _normalData ->
             { c with Commitments = newCommitments }
 
-        | WeAcceptedRevokeAndACK(newCommitments), ChannelState.Normal _normalData ->
-            { c with Commitments = newCommitments }
+        | WeAcceptedRevokeAndACK(newCommitments, remoteNextPerCommitmentPoint), ChannelState.Normal normalData ->
+            {
+                c with
+                    Commitments = newCommitments
+                    State = ChannelState.Normal {
+                        normalData with
+                            RemoteNextCommitInfo =
+                                RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint
+                    }
+            }
 
         // -----  closing ------
         | AcceptedOperationShutdown msg, ChannelState.Normal d ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -31,7 +31,6 @@ type ChannelWaitingForFundingSigned = {
     RemoteCommit: RemoteCommit
     ChannelFlags: uint8
     LastSent: FundingCreatedMsg
-    InitialFeeRatePerKw: FeeRatePerKw
     LocalShutdownScriptPubKey: Option<ShutdownScriptPubKey>
 } with
     member self.ApplyFundingSigned (msg: FundingSignedMsg)
@@ -85,7 +84,6 @@ type ChannelWaitingForFundingSigned = {
         }
         let nextState = WaitForFundingConfirmed {
             Deferred = None
-            InitialFeeRatePerKw = self.InitialFeeRatePerKw
         }
         let channel = {
             ChannelOptions = self.ChannelOptions
@@ -200,7 +198,6 @@ and ChannelWaitingForFundingCreated = {
         }
         let nextState = WaitForFundingConfirmed {
             Deferred = None
-            InitialFeeRatePerKw = self.InitialFeeRatePerKw
         }
         let channel = {
             ChannelOptions = self.ChannelOptions
@@ -292,7 +289,6 @@ and ChannelWaitingForFundingTx = {
             }
             ChannelFlags = self.ChannelFlags
             LastSent = nextMsg
-            InitialFeeRatePerKw = self.InitFeeRatePerKw
         }
         return nextMsg, channelWaitingForFundingSigned
     }
@@ -642,7 +638,6 @@ module Channel =
                     OurMessage = msgToSend
                     TheirMessage = None
                     HaveWeSentFundingLocked = false
-                    InitialFeeRatePerKw = state.InitialFeeRatePerKw
                 }
                 
                 match (state.Deferred) with
@@ -658,7 +653,12 @@ module Channel =
         | WaitForFundingLocked state, ApplyFundingLocked msg ->
             if (state.HaveWeSentFundingLocked) then
                 let initialChannelUpdate =
-                    let feeBase = ChannelHelpers.getOurFeeBaseMSat cs.FeeEstimator state.InitialFeeRatePerKw cs.Commitments.IsFunder
+                    let feeRate = cs.Commitments.LocalCommit.Spec.FeeRatePerKw
+                    let feeBase =
+                        ChannelHelpers.getOurFeeBaseMSat
+                            cs.FeeEstimator
+                            feeRate
+                            cs.Commitments.IsFunder
                     ChannelHelpers.makeChannelUpdate (cs.Network.Consensus.HashGenesisBlock,
                                                cs.NodeSecret,
                                                cs.RemoteNodeId,
@@ -1099,7 +1099,12 @@ module Channel =
         | TheySentFundingLocked msg, WaitForFundingConfirmed s ->
             { c with State = WaitForFundingConfirmed({ s with Deferred = Some(msg) }) }
         | TheySentFundingLocked _msg, WaitForFundingLocked s ->
-            let feeBase = ChannelHelpers.getOurFeeBaseMSat c.FeeEstimator s.InitialFeeRatePerKw c.Commitments.IsFunder
+            let feeRate = c.Commitments.LocalCommit.Spec.FeeRatePerKw
+            let feeBase =
+                ChannelHelpers.getOurFeeBaseMSat
+                    c.FeeEstimator
+                    feeRate
+                    c.Commitments.IsFunder
             let channelUpdate = ChannelHelpers.makeChannelUpdate (c.Network.Consensus.HashGenesisBlock,
                                                            c.NodeSecret,
                                                            c.RemoteNodeId,

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -974,7 +974,7 @@ module Channel =
                                 RemoteNextCommitInfo = state.RemoteNextCommitInfo
                                 LocalShutdown = localShutdownScriptPubKey
                                 RemoteShutdown = msg.ScriptPubKey
-                                ClosingTxProposed = [ Some {
+                                ClosingTxProposed = [{
                                     ClosingTxProposed.UnsignedTx = closingTx
                                     LocalClosingSigned = closingSignedMsg
                                 }]
@@ -991,7 +991,7 @@ module Channel =
                                 RemoteNextCommitInfo = state.RemoteNextCommitInfo
                                 LocalShutdown = localShutdownScriptPubKey
                                 RemoteShutdown = msg.ScriptPubKey
-                                ClosingTxProposed = [ None ]
+                                ClosingTxProposed = []
                                 MaybeBestUnpublishedTx = None
                             }
                             return [ AcceptedShutdownWhenNoPendingHTLCs(None, nextState) ]
@@ -1042,11 +1042,10 @@ module Channel =
                 let maybeLocalFee =
                     state.ClosingTxProposed
                     |> List.tryHead
-                    |> Option.bind id
                     |> Option.map (fun v -> v.LocalClosingSigned.FeeSatoshis)
                 let areWeInDeal = Some(msg.FeeSatoshis) = maybeLocalFee
                 let hasTooManyNegotiationDone =
-                    (state.ClosingTxProposed |> List.choose (id) |> List.length) >= cs.ChannelOptions.MaxClosingNegotiationIterations
+                    (state.ClosingTxProposed |> List.length) >= cs.ChannelOptions.MaxClosingNegotiationIterations
                 if (areWeInDeal || hasTooManyNegotiationDone) then
                     return!
                         Closing.handleMutualClose
@@ -1054,7 +1053,7 @@ module Channel =
                             { state with MaybeBestUnpublishedTx = Some(finalizedTx) }
                             state.RemoteNextCommitInfo
                 else
-                    let lastLocalClosingFee = state.ClosingTxProposed |> List.tryHead |> Option.bind id |> Option.map (fun txp -> txp.LocalClosingSigned.FeeSatoshis)
+                    let lastLocalClosingFee = state.ClosingTxProposed |> List.tryHead |> Option.map (fun txp -> txp.LocalClosingSigned.FeeSatoshis)
                     let! localF = 
                         match lastLocalClosingFee with
                         | Some v -> Ok v
@@ -1077,7 +1076,7 @@ module Channel =
                     else if (nextClosingFee = msg.FeeSatoshis) then
                         // we have reached on agreement!
                         let closingTxProposed1 =
-                            let newProposed = Some {
+                            let newProposed = {
                                 ClosingTxProposed.UnsignedTx = closingTx
                                 LocalClosingSigned = closingSignedMsg
                             }
@@ -1101,7 +1100,7 @@ module Channel =
                             )
                             |> expectTransactionError
                         let closingTxProposed1 =
-                            let newProposed = Some {
+                            let newProposed = {
                                 ClosingTxProposed.UnsignedTx = closingTx
                                 LocalClosingSigned = closingSignedMsg
                             }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -633,26 +633,8 @@ module Channel =
             else
                 onceConfirmedFundingTxHasBecomeUnconfirmed(height, depth)
         | WaitForFundingLocked state, ApplyFundingLocked msg ->
-            let initialChannelUpdate =
-                let feeRate = cs.Commitments.LocalCommit.Spec.FeeRatePerKw
-                let feeBase =
-                    ChannelHelpers.getOurFeeBaseMSat
-                        cs.FeeEstimator
-                        feeRate
-                        cs.Commitments.IsFunder
-                ChannelHelpers.makeChannelUpdate (cs.Network.Consensus.HashGenesisBlock,
-                                           cs.NodeSecret,
-                                           cs.RemoteNodeId,
-                                           state.ShortChannelId,
-                                           cs.Commitments.LocalParams.ToSelfDelay,
-                                           cs.Commitments.RemoteParams.HTLCMinimumMSat,
-                                           feeBase,
-                                           cs.ChannelOptions.FeeProportionalMillionths,
-                                           true,
-                                           None)
             let nextState = {
                 ShortChannelId = state.ShortChannelId
-                ChannelUpdate = initialChannelUpdate
                 LocalShutdown = None
                 RemoteShutdown = None
                 RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked(msg.NextPerCommitmentPoint)
@@ -1092,26 +1074,9 @@ module Channel =
                     }
             }
         | TheySentFundingLocked msg, WaitForFundingLocked s ->
-            let feeRate = c.Commitments.LocalCommit.Spec.FeeRatePerKw
-            let feeBase =
-                ChannelHelpers.getOurFeeBaseMSat
-                    c.FeeEstimator
-                    feeRate
-                    c.Commitments.IsFunder
-            let channelUpdate = ChannelHelpers.makeChannelUpdate (c.Network.Consensus.HashGenesisBlock,
-                                                           c.NodeSecret,
-                                                           c.RemoteNodeId,
-                                                           s.ShortChannelId,
-                                                           c.Commitments.LocalParams.ToSelfDelay,
-                                                           c.Commitments.RemoteParams.HTLCMinimumMSat,
-                                                           feeBase,
-                                                           c.ChannelOptions.FeeProportionalMillionths,
-                                                           true,
-                                                           None)
             let nextState = {
                 RemoteNextCommitInfo = RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
                 ShortChannelId = s.ShortChannelId
-                ChannelUpdate = channelUpdate
                 LocalShutdown = None
                 RemoteShutdown = None
             }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -926,165 +926,153 @@ and Channel = {
         return channel, shutdownMsg
     }
 
-module Channel =
-
-    let private hex = NBitcoin.DataEncoders.HexEncoder()
-    let private ascii = System.Text.ASCIIEncoding.ASCII
-    let private dummyPrivKey = new Key(hex.DecodeData("0101010101010101010101010101010101010101010101010101010101010101"))
-    let private dummyPubKey = dummyPrivKey.PubKey
-    let private dummySig =
-        "01010101010101010101010101010101" |> ascii.GetBytes
+    static member private Hex = NBitcoin.DataEncoders.HexEncoder()
+    static member private Ascii = System.Text.ASCIIEncoding.ASCII
+    static member private DummyPrivKey = new Key(Channel.Hex.DecodeData("0101010101010101010101010101010101010101010101010101010101010101"))
+    static member private DummySig =
+        "01010101010101010101010101010101" |> Channel.Ascii.GetBytes
         |> uint256
-        |> fun m -> dummyPrivKey.SignCompact(m)
+        |> fun m -> Channel.DummyPrivKey.SignCompact(m)
         |> fun d -> LNECDSASignature.FromBytesCompact(d, true)
         |> fun ecdsaSig -> TransactionSignature(ecdsaSig.Value, SigHash.All)
 
-    module Closing =
-        let makeClosingTx (channelPrivKeys: ChannelPrivKeys)
-                          (cm: Commitments)
-                          (localSpk: ShutdownScriptPubKey)
-                          (remoteSpk: ShutdownScriptPubKey)
-                          (closingFee: Money)
-                          (staticChannelConfig: StaticChannelConfig) =
-            let dustLimitSatoshis = Money.Max(staticChannelConfig.LocalParams.DustLimitSatoshis, staticChannelConfig.RemoteParams.DustLimitSatoshis)
-            result {
-                let! closingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin (localSpk) (remoteSpk) staticChannelConfig.IsFunder (dustLimitSatoshis) (closingFee) (cm.LocalCommit.Spec) staticChannelConfig.Network
-                let localSignature, psbtUpdated = channelPrivKeys.SignWithFundingPrivKey closingTx.Value
-                let msg: ClosingSignedMsg = {
-                    ChannelId = staticChannelConfig.ChannelId()
-                    FeeSatoshis = closingFee
-                    Signature = localSignature.Signature |> LNECDSASignature
+    member internal self.MakeClosingTx (localSpk: ShutdownScriptPubKey)
+                                       (remoteSpk: ShutdownScriptPubKey)
+                                       (closingFee: Money) = result {
+        let channelPrivKeys = self.ChannelPrivKeys
+        let cm = self.Commitments
+        let staticChannelConfig = self.StaticChannelConfig
+        let dustLimitSatoshis = Money.Max(staticChannelConfig.LocalParams.DustLimitSatoshis, staticChannelConfig.RemoteParams.DustLimitSatoshis)
+        let! closingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin (localSpk) (remoteSpk) staticChannelConfig.IsFunder (dustLimitSatoshis) (closingFee) (cm.LocalCommit.Spec) staticChannelConfig.Network
+        let localSignature, psbtUpdated = channelPrivKeys.SignWithFundingPrivKey closingTx.Value
+        let msg: ClosingSignedMsg = {
+            ChannelId = staticChannelConfig.ChannelId()
+            FeeSatoshis = closingFee
+            Signature = localSignature.Signature |> LNECDSASignature
+        }
+        return (ClosingTx psbtUpdated, msg)
+    }
+
+    member internal self.FirstClosingFee (localSpk: ShutdownScriptPubKey)
+                                         (remoteSpk: ShutdownScriptPubKey) = result {
+        let cm = self.Commitments
+        let feeEst = self.ChannelOptions.FeeEstimator
+        let staticChannelConfig = self.StaticChannelConfig
+        let! dummyClosingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin localSpk remoteSpk staticChannelConfig.IsFunder Money.Zero Money.Zero cm.LocalCommit.Spec staticChannelConfig.Network
+        let tx = dummyClosingTx.Value.GetGlobalTransaction()
+        tx.Inputs.[0].WitScript <-
+            let witness = seq [ Channel.DummySig.ToBytes(); Channel.DummySig.ToBytes(); dummyClosingTx.Value.Inputs.[0].WitnessScript.ToBytes() ]
+            WitScript(witness)
+        let feeRatePerKw = FeeRatePerKw.Max (feeEst.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority), cm.LocalCommit.Spec.FeeRatePerKw)
+        return feeRatePerKw.CalculateFeeFromVirtualSize(tx)
+    }
+
+    static member internal NextClosingFee (localClosingFee: Money, remoteClosingFee: Money) =
+        ((localClosingFee.Satoshi + remoteClosingFee.Satoshi) / 4L) * 2L
+        |> Money.Satoshis
+
+    member self.RemoteShutdown (msg: ShutdownMsg)
+                               (localShutdownScriptPubKey: ShutdownScriptPubKey)
+                                   : Result<Channel * Option<ShutdownMsg> * Option<ClosingSignedMsg>, ChannelError> = result {
+        let remoteShutdownScriptPubKey = msg.ScriptPubKey
+        do!
+            Validation.checkShutdownScriptPubKeyAcceptable
+                self.StaticChannelConfig.LocalStaticShutdownScriptPubKey
+                localShutdownScriptPubKey
+        do!
+            Validation.checkShutdownScriptPubKeyAcceptable
+                self.StaticChannelConfig.RemoteStaticShutdownScriptPubKey
+                remoteShutdownScriptPubKey
+        let cm = self.Commitments
+        // They have pending unsigned htlcs => they violated the spec, close the channel
+        // they don't have pending unsigned htlcs
+        //      We have pending unsigned htlcs
+        //          We already sent a shutdown msg => spec violation (we can't send htlcs after having sent shutdown)
+        //          We did not send a shutdown msg
+        //              We are ready to sign => we stop sending further htlcs, we initiate a signature
+        //              We are waiting for a rev => we stop sending further htlcs, we wait for their revocation, will resign immediately after, and then we will send our shutdown msg
+        //      We have no pending unsigned htlcs
+        //          we already sent a shutdown msg
+        //              There are pending signed htlcs => send our shutdown msg, go to SHUTDOWN state
+        //              there are no htlcs => send our shutdown msg, goto NEGOTIATING state
+        //          We did not send a shutdown msg
+        //              There are pending signed htlcs => go to SHUTDOWN state
+        //              there are no HTLCs => go to NEGOTIATING state
+        
+        if (cm.RemoteHasUnsignedOutgoingHTLCs()) then
+            return! receivedShutdownWhenRemoteHasUnsignedOutgoingHTLCs msg
+        // Do we have Unsigned Outgoing HTLCs?
+        else if (cm.LocalHasUnsignedOutgoingHTLCs()) then
+            let channel = {
+                self with
+                    NegotiatingState = {
+                        self.NegotiatingState with
+                            RemoteRequestedShutdown = Some remoteShutdownScriptPubKey
+                    }
+            }
+            return channel, None, None
+        else
+            let hasNoPendingHTLCs =
+                match self.RemoteNextCommitInfo with
+                | None -> true
+                | Some remoteNextCommitInfo -> cm.HasNoPendingHTLCs remoteNextCommitInfo
+            if hasNoPendingHTLCs then
+                // we have to send first closing_signed msg iif we are the funder
+                if self.StaticChannelConfig.IsFunder then
+                    let! closingFee =
+                        self.FirstClosingFee
+                            localShutdownScriptPubKey
+                            remoteShutdownScriptPubKey
+                        |> expectTransactionError
+                    let! (_closingTx, closingSignedMsg) =
+                        self.MakeClosingTx
+                            localShutdownScriptPubKey
+                            remoteShutdownScriptPubKey
+                            closingFee
+                        |> expectTransactionError
+                    let nextState = {
+                        LocalRequestedShutdown = Some localShutdownScriptPubKey
+                        RemoteRequestedShutdown = Some remoteShutdownScriptPubKey
+                        LocalClosingFeesProposed = [ closingFee ]
+                        RemoteClosingFeeProposed = None
+                    }
+                    let channel = {
+                        self with
+                            NegotiatingState = nextState
+                    }
+                    return channel, None, Some closingSignedMsg
+                else
+                    let nextState = {
+                        LocalRequestedShutdown = Some localShutdownScriptPubKey
+                        RemoteRequestedShutdown = Some remoteShutdownScriptPubKey
+                        LocalClosingFeesProposed = []
+                        RemoteClosingFeeProposed = None
+                    }
+                    let channel = {
+                        self with
+                            NegotiatingState = nextState
+                    }
+                    return channel, None, None
+            else
+                let localShutdownMsg: ShutdownMsg = {
+                    ChannelId = self.StaticChannelConfig.ChannelId()
+                    ScriptPubKey = localShutdownScriptPubKey
                 }
-                return (ClosingTx psbtUpdated, msg)
-            }
+                let channel = {
+                    self with
+                        NegotiatingState = {
+                            self.NegotiatingState with
+                                LocalRequestedShutdown = Some localShutdownScriptPubKey
+                                RemoteRequestedShutdown = Some remoteShutdownScriptPubKey
+                        }
+                }
+                return channel, Some localShutdownMsg, None
+    }
 
-        let firstClosingFee (cm: Commitments)
-                            (localSpk: ShutdownScriptPubKey)
-                            (remoteSpk: ShutdownScriptPubKey)
-                            (feeEst: IFeeEstimator)
-                            (staticChannelConfig: StaticChannelConfig) =
-            result {
-                let! dummyClosingTx = Transactions.makeClosingTx staticChannelConfig.FundingScriptCoin localSpk remoteSpk staticChannelConfig.IsFunder Money.Zero Money.Zero cm.LocalCommit.Spec staticChannelConfig.Network
-                let tx = dummyClosingTx.Value.GetGlobalTransaction()
-                tx.Inputs.[0].WitScript <-
-                    let witness = seq [ dummySig.ToBytes(); dummySig.ToBytes(); dummyClosingTx.Value.Inputs.[0].WitnessScript.ToBytes() ]
-                    WitScript(witness)
-                let feeRatePerKw = FeeRatePerKw.Max (feeEst.GetEstSatPer1000Weight(ConfirmationTarget.HighPriority), cm.LocalCommit.Spec.FeeRatePerKw)
-                return feeRatePerKw.CalculateFeeFromVirtualSize(tx)
-            }
-
-        let nextClosingFee (localClosingFee: Money, remoteClosingFee: Money) =
-            ((localClosingFee.Satoshi + remoteClosingFee.Satoshi) / 4L) * 2L
-            |> Money.Satoshis
+module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | RemoteShutdown(msg, localShutdownScriptPubKey) ->
-            result {
-                let remoteShutdownScriptPubKey = msg.ScriptPubKey
-                do!
-                    Validation.checkShutdownScriptPubKeyAcceptable
-                        cs.StaticChannelConfig.LocalStaticShutdownScriptPubKey
-                        localShutdownScriptPubKey
-                do!
-                    Validation.checkShutdownScriptPubKeyAcceptable
-                        cs.StaticChannelConfig.RemoteStaticShutdownScriptPubKey
-                        remoteShutdownScriptPubKey
-                let cm = cs.Commitments
-                // They have pending unsigned htlcs => they violated the spec, close the channel
-                // they don't have pending unsigned htlcs
-                //      We have pending unsigned htlcs
-                //          We already sent a shutdown msg => spec violation (we can't send htlcs after having sent shutdown)
-                //          We did not send a shutdown msg
-                //              We are ready to sign => we stop sending further htlcs, we initiate a signature
-                //              We are waiting for a rev => we stop sending further htlcs, we wait for their revocation, will resign immediately after, and then we will send our shutdown msg
-                //      We have no pending unsigned htlcs
-                //          we already sent a shutdown msg
-                //              There are pending signed htlcs => send our shutdown msg, go to SHUTDOWN state
-                //              there are no htlcs => send our shutdown msg, goto NEGOTIATING state
-                //          We did not send a shutdown msg
-                //              There are pending signed htlcs => go to SHUTDOWN state
-                //              there are no HTLCs => go to NEGOTIATING state
-                
-                if (cm.RemoteHasUnsignedOutgoingHTLCs()) then
-                    return! receivedShutdownWhenRemoteHasUnsignedOutgoingHTLCs msg
-                // Do we have Unsigned Outgoing HTLCs?
-                else if (cm.LocalHasUnsignedOutgoingHTLCs()) then
-                    let remoteNextCommitInfo =
-                        match cs.RemoteNextCommitInfo with
-                        | None -> failwith "can't have unsigned outgoing htlcs if we haven't recieved funding_locked. this should never happen"
-                        | Some remoteNextCommitInfo -> remoteNextCommitInfo
-                    // Are we in the middle of a signature?
-                    match remoteNextCommitInfo with
-                    // yes.
-                    | RemoteNextCommitInfo.Waiting _waitingForRevocation ->
-                        return [
-                            AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdownScriptPubKey
-                        ]
-                    // No. let's sign right away.
-                    | RemoteNextCommitInfo.Revoked _ ->
-                        return [
-                            ChannelStateRequestedSignCommitment;
-                            AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdownScriptPubKey
-                        ]
-                else
-                    let hasNoPendingHTLCs =
-                        match cs.RemoteNextCommitInfo with
-                        | None -> true
-                        | Some remoteNextCommitInfo -> cm.HasNoPendingHTLCs remoteNextCommitInfo
-                    if hasNoPendingHTLCs then
-                        // we have to send first closing_signed msg iif we are the funder
-                        if cs.StaticChannelConfig.IsFunder then
-                            let! closingFee =
-                                Closing.firstClosingFee
-                                    cm
-                                    localShutdownScriptPubKey
-                                    remoteShutdownScriptPubKey
-                                    cs.ChannelOptions.FeeEstimator
-                                    cs.StaticChannelConfig
-                                |> expectTransactionError
-                            let! (_closingTx, closingSignedMsg) =
-                                Closing.makeClosingTx
-                                    cs.ChannelPrivKeys
-                                    cm
-                                    localShutdownScriptPubKey
-                                    remoteShutdownScriptPubKey
-                                    closingFee
-                                    cs.StaticChannelConfig
-                                |> expectTransactionError
-                            let nextState = {
-                                LocalRequestedShutdown = Some localShutdownScriptPubKey
-                                RemoteRequestedShutdown = Some remoteShutdownScriptPubKey
-                                LocalClosingFeesProposed = [ closingFee ]
-                                RemoteClosingFeeProposed = None
-                            }
-                            return [
-                                AcceptedShutdownWhenNoPendingHTLCs(
-                                    closingSignedMsg |> Some,
-                                    nextState
-                                )
-                            ]
-                        else
-                            let nextState = {
-                                LocalRequestedShutdown = Some localShutdownScriptPubKey
-                                RemoteRequestedShutdown = Some remoteShutdownScriptPubKey
-                                LocalClosingFeesProposed = []
-                                RemoteClosingFeeProposed = None
-                            }
-                            return [ AcceptedShutdownWhenNoPendingHTLCs(None, nextState) ]
-                    else
-                        let localShutdownMsg: ShutdownMsg = {
-                            ChannelId = cs.StaticChannelConfig.ChannelId()
-                            ScriptPubKey = localShutdownScriptPubKey
-                        }
-                        return [
-                            AcceptedShutdownWhenWeHavePendingHTLCs(
-                                localShutdownMsg,
-                                localShutdownScriptPubKey,
-                                remoteShutdownScriptPubKey
-                            )
-                        ]
-            }
         | ApplyClosingSigned msg ->
             result {
                 let! localShutdownScriptPubKey, remoteShutdownScriptPubKey =
@@ -1110,13 +1098,10 @@ module Channel =
                         msg.FeeSatoshis
 
                 let! closingTx, _closingSignedMsg =
-                    Closing.makeClosingTx
-                        cs.ChannelPrivKeys
-                        cm
+                    cs.MakeClosingTx
                         localShutdownScriptPubKey
                         remoteShutdownScriptPubKey
                         msg.FeeSatoshis
-                        cs.StaticChannelConfig
                     |> expectTransactionError
                 let! finalizedTx =
                     Transactions.checkTxFinalized
@@ -1141,15 +1126,12 @@ module Channel =
                         match lastLocalClosingFee with
                         | Some v -> Ok v
                         | None ->
-                            Closing.firstClosingFee
-                                cs.Commitments
+                            cs.FirstClosingFee
                                 localShutdownScriptPubKey
                                 remoteShutdownScriptPubKey
-                                cs.ChannelOptions.FeeEstimator
-                                cs.StaticChannelConfig
                             |> expectTransactionError
                     let nextClosingFee =
-                        Closing.nextClosingFee (localF, msg.FeeSatoshis)
+                        Channel.NextClosingFee (localF, msg.FeeSatoshis)
                     if (Some nextClosingFee = lastLocalClosingFee) then
                         return [ MutualClosePerformed finalizedTx ]
                     else if (nextClosingFee = msg.FeeSatoshis) then
@@ -1157,13 +1139,10 @@ module Channel =
                         return [ MutualClosePerformed finalizedTx ]
                     else
                         let! _closingTx, closingSignedMsg =
-                            Closing.makeClosingTx
-                                cs.ChannelPrivKeys
-                                cm
+                            cs.MakeClosingTx
                                 localShutdownScriptPubKey
                                 remoteShutdownScriptPubKey
                                 nextClosingFee
-                                cs.StaticChannelConfig
                             |> expectTransactionError
                         let nextState = {
                             cs.NegotiatingState with
@@ -1179,28 +1158,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // -----  closing ------
-        | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdownScriptPubKey ->
-            { 
-                c with
-                    NegotiatingState = {
-                        c.NegotiatingState with
-                            RemoteRequestedShutdown = Some remoteShutdownScriptPubKey
-                    }
-            }
-        | AcceptedShutdownWhenNoPendingHTLCs(_maybeMsg, nextNegotiatingState) ->
-            {
-                c with
-                    NegotiatingState = nextNegotiatingState
-            }
-        | AcceptedShutdownWhenWeHavePendingHTLCs(_localShutdownMsg, localShutdownScriptPubKey, remoteShutdownScriptPubKey) ->
-            {
-                c with
-                    NegotiatingState = {
-                        c.NegotiatingState with
-                            LocalRequestedShutdown = Some localShutdownScriptPubKey
-                            RemoteRequestedShutdown = Some remoteShutdownScriptPubKey
-                    }
-            }
         | MutualClosePerformed _txToPublish -> c
         | WeProposedNewClosingSigned(_msg, nextNegotiatingState) ->
             {

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -762,6 +762,17 @@ and Channel = {
         return channel, updateFailMalformedHTLCMsg
     }
 
+    member self.ApplyUpdateFailHTLC (msg: UpdateFailHTLCMsg)
+                                        : Result<Channel, ChannelError> = result {
+        let! remoteNextCommitInfo =
+            self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyUpdateFailHTLC"
+        let! newCommitments = Commitments.receiveFail msg self.Commitments remoteNextCommitInfo
+        return {
+            self with
+                Commitments = newCommitments
+        }
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -815,12 +826,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | ApplyUpdateFailHTLC msg ->
-            result {
-                let! remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "ApplyUpdateFailHTLC"
-                return! Commitments.receiveFail msg cs.Commitments remoteNextCommitInfo
-            }
         | ApplyUpdateFailMalformedHTLC msg ->
             result {
                 let! remoteNextCommitInfo =
@@ -1129,9 +1134,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // ----- normal operation --------
-        | WeAcceptedFailHTLC(_origin, _msg, newCommitments) ->
-            { c with Commitments = newCommitments }
-
         | WeAcceptedFailMalformedHTLC(_origin, _msg, newCommitments) ->
             { c with Commitments = newCommitments }
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -75,7 +75,6 @@ and ChannelWaitingForFundingCreated = {
     ChannelOptions: ChannelOptions
     ChannelPrivKeys: ChannelPrivKeys
     NodeSecret: NodeSecret
-    TemporaryFailure: ChannelId
     LocalParams: LocalParams
     RemoteParams: RemoteParams
     RemoteChannelPubKeys: ChannelPubKeys
@@ -469,7 +468,6 @@ and Channel = {
                 ChannelOptions = channelOptions
                 ChannelPrivKeys = channelPrivKeys
                 NodeSecret = nodeSecret
-                TemporaryFailure = openChannelMsg.TemporaryChannelId
                 LocalParams = localParams
                 RemoteParams = remoteParams
                 RemoteChannelPubKeys = remoteChannelPubKeys

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -843,6 +843,23 @@ and Channel = {
             return self, None
     }
 
+    member self.ApplyCommitmentSigned (msg: CommitmentSignedMsg)
+                                          : Result<Channel * RevokeAndACKMsg, ChannelError> = result {
+        let! _remoteNextCommitInfo =
+            self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyCommitmentSigned"
+        let! revokeAndACKMsg, newCommitments =
+            Commitments.receiveCommit
+                self.ChannelPrivKeys
+                msg
+                self.StaticChannelConfig
+                self.Commitments
+        let channel = {
+            self with
+                Commitments = newCommitments
+        }
+        return channel, revokeAndACKMsg
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -896,17 +913,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | ApplyCommitmentSigned msg ->
-            result {
-                let! _remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "ApplyCommitmentSigned"
-                return!
-                    Commitments.receiveCommit
-                        cs.ChannelPrivKeys
-                        msg
-                        cs.StaticChannelConfig
-                        cs.Commitments
-            }
         | ApplyRevokeAndACK msg ->
             result {
                 let! remoteNextCommitInfo =
@@ -1159,9 +1165,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // ----- normal operation --------
-        | WeAcceptedCommitmentSigned(_msg, newCommitments) ->
-            { c with Commitments = newCommitments }
-
         | WeAcceptedRevokeAndACK(newCommitments, remoteNextPerCommitmentPoint) ->
             {
                 c with

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -843,20 +843,18 @@ and Channel = {
         }
     }
 
-    member self.SignCommitment(): Result<Channel * Option<CommitmentSignedMsg>, ChannelError> = result {
+    member self.SignCommitment(): Result<Channel * CommitmentSignedMsg, ChannelError> = result {
         let! remoteNextCommitInfo =
             self.RemoteNextCommitInfoIfFundingLockedNormal "SignCommit"
         match remoteNextCommitInfo with
         | _ when (self.LocalHasChanges() |> not) ->
-            // Ignore SignCommitment Command (nothing to sign)
-            return self, None
+            return! Error NoUpdatesToSign
         | RemoteNextCommitInfo.Revoked _ ->
             let! commitmentSignedMsg, channel =
                 self.sendCommit remoteNextCommitInfo
-            return channel, Some commitmentSignedMsg
+            return channel, commitmentSignedMsg
         | RemoteNextCommitInfo.Waiting _ ->
-            // Already in the process of signing
-            return self, None
+            return! Error CannotSignCommitmentBeforeRevocation
     }
 
     member self.ApplyCommitmentSigned (msg: CommitmentSignedMsg)

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -960,24 +960,15 @@ module Channel =
                         // yes.
                         | RemoteNextCommitInfo.Waiting _waitingForRevocation ->
                             return [
-                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs msg
+                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs msg.ScriptPubKey
                             ]
                         // No. let's sign right away.
                         | RemoteNextCommitInfo.Revoked _ ->
                             return [
                                 ChannelStateRequestedSignCommitment;
-                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs msg
+                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs msg.ScriptPubKey
                             ]
                 else
-                    let (localShutdown, _sendList) =
-                        match state.LocalShutdown with
-                        | Some localShutdown -> (localShutdown, [])
-                        | None ->
-                            let localShutdown: ShutdownMsg = {
-                                ChannelId = cs.Commitments.ChannelId()
-                                ScriptPubKey = localShutdownScriptPubKey
-                            }
-                            (localShutdown, [ localShutdown ])
                     let hasNoPendingHTLCs =
                         match state.RemoteNextCommitInfo with
                         | None -> true
@@ -989,15 +980,15 @@ module Channel =
                                 Closing.makeFirstClosingTx (
                                     cs.ChannelPrivKeys,
                                     cm,
-                                    localShutdown.ScriptPubKey,
+                                    localShutdownScriptPubKey,
                                     msg.ScriptPubKey,
                                     cs.FeeEstimator,
                                     cs.Network
                                 )
                             let nextState = {
                                 RemoteNextCommitInfo = state.RemoteNextCommitInfo
-                                LocalShutdown = localShutdown
-                                RemoteShutdown = msg
+                                LocalShutdown = localShutdownScriptPubKey
+                                RemoteShutdown = msg.ScriptPubKey
                                 ClosingTxProposed = [[{
                                     ClosingTxProposed.UnsignedTx = closingTx
                                     LocalClosingSigned = closingSignedMsg
@@ -1013,14 +1004,23 @@ module Channel =
                         else
                             let nextState = {
                                 RemoteNextCommitInfo = state.RemoteNextCommitInfo
-                                LocalShutdown = localShutdown
-                                RemoteShutdown = msg
+                                LocalShutdown = localShutdownScriptPubKey
+                                RemoteShutdown = msg.ScriptPubKey
                                 ClosingTxProposed = [ [] ]
                                 MaybeBestUnpublishedTx = None
                             }
                             return [ AcceptedShutdownWhenNoPendingHTLCs(None, nextState) ]
                     else
-                        return [ AcceptedShutdownWhenWeHavePendingHTLCs(localShutdown, msg) ]
+                        let localShutdownMsg: ShutdownMsg = {
+                            ChannelId = cs.Commitments.ChannelId()
+                            ScriptPubKey = localShutdownScriptPubKey
+                        }
+                        return [
+                            AcceptedShutdownWhenWeHavePendingHTLCs(
+                                localShutdownMsg,
+                                msg.ScriptPubKey
+                            )
+                        ]
             }
         // ----------- closing ---------
         | Negotiating state, ApplyClosingSigned msg ->
@@ -1034,8 +1034,8 @@ module Channel =
                     Closing.makeClosingTx (
                         cs.ChannelPrivKeys,
                         cm,
-                        state.LocalShutdown.ScriptPubKey,
-                        state.RemoteShutdown.ScriptPubKey,
+                        state.LocalShutdown,
+                        state.RemoteShutdown,
                         msg.FeeSatoshis,
                         cs.Network
                     )
@@ -1071,8 +1071,8 @@ module Channel =
                         | None ->
                             Closing.firstClosingFee
                                 cs.Commitments
-                                state.LocalShutdown.ScriptPubKey
-                                state.RemoteShutdown.ScriptPubKey
+                                state.LocalShutdown
+                                state.RemoteShutdown
                                 cs.FeeEstimator
                                 cs.Network
                             |> expectTransactionError
@@ -1102,8 +1102,8 @@ module Channel =
                             Closing.makeClosingTx (
                                 cs.ChannelPrivKeys,
                                 cm,
-                                state.LocalShutdown.ScriptPubKey,
-                                state.RemoteShutdown.ScriptPubKey,
+                                state.LocalShutdown,
+                                state.RemoteShutdown,
                                 nextClosingFee,
                                 cs.Network
                             )
@@ -1214,25 +1214,31 @@ module Channel =
             }
 
         // -----  closing ------
-        | AcceptedOperationShutdown msg, ChannelState.Normal d ->
-            { c with State = ChannelState.Normal({ d with LocalShutdown = Some msg }) }
-        | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdown, ChannelState.Normal normalData ->
-            { 
-                c with
-                    State = ChannelState.Normal {
-                        normalData with
-                            RemoteShutdown = Some remoteShutdown
-                    }
-            }
-        | AcceptedShutdownWhenNoPendingHTLCs(_maybeMsg, nextState), ChannelState.Normal _d ->
-            { c with State = Negotiating nextState }
-        | AcceptedShutdownWhenWeHavePendingHTLCs(localShutdown, remoteShutdown), ChannelState.Normal normalData ->
+        | AcceptedOperationShutdown msg, ChannelState.Normal normalData ->
             {
                 c with
                     State = ChannelState.Normal {
                         normalData with
-                            LocalShutdown = Some localShutdown
-                            RemoteShutdown = Some remoteShutdown
+                            LocalShutdown = Some msg.ScriptPubKey
+                    }
+            }
+        | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdownScriptPubKey, ChannelState.Normal normalData ->
+            { 
+                c with
+                    State = ChannelState.Normal {
+                        normalData with
+                            RemoteShutdown = Some remoteShutdownScriptPubKey
+                    }
+            }
+        | AcceptedShutdownWhenNoPendingHTLCs(_maybeMsg, nextState), ChannelState.Normal _d ->
+            { c with State = Negotiating nextState }
+        | AcceptedShutdownWhenWeHavePendingHTLCs(localShutdown, remoteShutdownScriptPubKey), ChannelState.Normal normalData ->
+            {
+                c with
+                    State = ChannelState.Normal {
+                        normalData with
+                            LocalShutdown = Some localShutdown.ScriptPubKey
+                            RemoteShutdown = Some remoteShutdownScriptPubKey
                     }
             }
         | MutualClosePerformed (_txToPublish, nextState), ChannelState.Negotiating _d ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -698,6 +698,24 @@ and Channel = {
         }
     }
 
+    member self.FulFillHTLC (cmd: OperationFulfillHTLC)
+                                : Result<Channel * UpdateFulfillHTLCMsg, ChannelError> = result {
+        let! remoteNextCommitInfo =
+            self.RemoteNextCommitInfoIfFundingLockedNormal "FulfillHTLC"
+        let! updateFulfillHTLCMsg, newCommitments =
+            Commitments.sendFulfill
+                cmd
+                self.Commitments
+                self.StaticChannelConfig
+                remoteNextCommitInfo
+
+        let channel = {
+            self with
+                Commitments = newCommitments
+        }
+        return channel, updateFulfillHTLCMsg
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -751,18 +769,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | FulfillHTLC cmd ->
-            result {
-                let! remoteNextCommitInfo =
-                    cs.RemoteNextCommitInfoIfFundingLockedNormal "FulfillHTLC"
-                let! t =
-                    Commitments.sendFulfill
-                        cmd
-                        cs.Commitments
-                        cs.StaticChannelConfig
-                        remoteNextCommitInfo
-                return [ WeAcceptedOperationFulfillHTLC t ]
-            }
         | ChannelCommand.ApplyUpdateFulfillHTLC msg ->
             result {
                 let! remoteNextCommitInfo =
@@ -1106,8 +1112,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // ----- normal operation --------
-        | WeAcceptedOperationFulfillHTLC(_, newCommitments) ->
-            { c with Commitments = newCommitments }
         | WeAcceptedFulfillHTLC(_msg, _origin, _htlc, newCommitments) ->
             { c with Commitments = newCommitments }
 

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -13,7 +13,258 @@ open System
 open ResultUtils
 open ResultUtils.Portability
 
-type Channel = {
+type ChannelWaitingForFundingSigned = {
+    Config: ChannelConfig
+    ChannelPrivKeys: ChannelPrivKeys
+    FeeEstimator: IFeeEstimator
+    RemoteNodeId: NodeId
+    NodeSecret: NodeSecret
+    Network: Network
+    WaitForFundingSignedData: WaitForFundingSignedData
+} with
+    member self.ApplyFundingSigned (msg: FundingSignedMsg)
+                                       : Result<FinalizedTx * Channel, ChannelError> = result {
+        let state = self.WaitForFundingSignedData
+        let remoteChannelKeys = state.RemoteParams.ChannelPubKeys
+        let! finalizedLocalCommitTx =
+            let theirFundingPk = remoteChannelKeys.FundingPubKey.RawPubKey()
+            let _, signedLocalCommitTx =
+                self.ChannelPrivKeys.SignWithFundingPrivKey state.LocalCommitTx.Value
+            let remoteSigPairOfLocalTx = (theirFundingPk,  TransactionSignature(msg.Signature.Value, SigHash.All))
+            let sigPairs = seq [ remoteSigPairOfLocalTx; ]
+            Transactions.checkTxFinalized signedLocalCommitTx state.LocalCommitTx.WhichInput sigPairs |> expectTransactionError
+        let commitments = { Commitments.LocalParams = state.LocalParams
+                            RemoteParams = state.RemoteParams
+                            ChannelFlags = state.ChannelFlags
+                            FundingScriptCoin =
+                                let amount = state.FundingTx.Value.Outputs.[int state.LastSent.FundingOutputIndex.Value].Value
+                                ChannelHelpers.getFundingScriptCoin
+                                    state.LocalParams.ChannelPubKeys.FundingPubKey
+                                    remoteChannelKeys.FundingPubKey
+                                    state.LastSent.FundingTxId
+                                    state.LastSent.FundingOutputIndex
+                                    amount
+                            LocalCommit = { Index = CommitmentNumber.FirstCommitment;
+                                            Spec = state.LocalSpec;
+                                            PublishableTxs = { PublishableTxs.CommitTx = finalizedLocalCommitTx
+                                                               HTLCTxs = [] }
+                                            PendingHTLCSuccessTxs = [] }
+                            RemoteCommit = state.RemoteCommit
+                            LocalChanges = LocalChanges.Zero
+                            RemoteChanges = RemoteChanges.Zero
+                            LocalNextHTLCId = HTLCId.Zero
+                            RemoteNextHTLCId = HTLCId.Zero
+                            OriginChannels = Map.empty
+                            // we will receive their next per-commitment point in the next msg, so we temporarily put a random byte array
+                            RemoteNextCommitInfo = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101") |> fun h -> new Key(h) |> fun k -> k.PubKey |> PerCommitmentPoint |> RemoteNextCommitInfo.Revoked
+                            RemotePerCommitmentSecrets = PerCommitmentSecretStore()
+                            ChannelId =
+                                msg.ChannelId }
+        let nextState = { WaitForFundingConfirmedData.Commitments = commitments
+                          Deferred = None
+                          LastSent = Choice1Of2 state.LastSent
+                          InitialFeeRatePerKw = state.InitialFeeRatePerKw
+                          ChannelId = msg.ChannelId }
+        let channel = {
+            Config = self.Config
+            ChannelPrivKeys = self.ChannelPrivKeys
+            FeeEstimator = self.FeeEstimator
+            RemoteNodeId = self.RemoteNodeId
+            NodeSecret = self.NodeSecret
+            State = WaitForFundingConfirmed nextState
+            Network = self.Network
+        }
+        return state.FundingTx, channel
+    }
+
+and ChannelWaitingForFundingCreated = {
+    Config: ChannelConfig
+    ChannelPrivKeys: ChannelPrivKeys
+    FeeEstimator: IFeeEstimator
+    RemoteNodeId: NodeId
+    NodeSecret: NodeSecret
+    Network: Network
+    WaitForFundingCreatedData: WaitForFundingCreatedData
+} with
+    member self.ApplyFundingCreated (msg: FundingCreatedMsg)
+                                        : Result<FundingSignedMsg * Channel, ChannelError> = result {
+        let state = self.WaitForFundingCreatedData
+        let remoteChannelKeys = state.RemoteParams.ChannelPubKeys
+        let! (localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
+            ChannelHelpers.makeFirstCommitTxs
+                state.LocalParams
+                state.RemoteParams
+                state.FundingSatoshis
+                state.PushMSat
+                state.InitialFeeRatePerKw
+                msg.FundingOutputIndex
+                msg.FundingTxId
+                state.LastSent.FirstPerCommitmentPoint
+                state.RemoteFirstPerCommitmentPoint
+                self.Network
+        assert (localCommitTx.Value.IsReadyToSign())
+        let _s, signedLocalCommitTx =
+            self.ChannelPrivKeys.SignWithFundingPrivKey localCommitTx.Value
+        let remoteTxSig = TransactionSignature(msg.Signature.Value, SigHash.All)
+        let theirSigPair = (remoteChannelKeys.FundingPubKey.RawPubKey(), remoteTxSig)
+        let sigPairs = seq [ theirSigPair ]
+        let! finalizedCommitTx =
+            Transactions.checkTxFinalized (signedLocalCommitTx) (localCommitTx.WhichInput) sigPairs
+            |> expectTransactionError
+        let localSigOfRemoteCommit, _ =
+            self.ChannelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
+        let channelId = OutPoint(msg.FundingTxId.Value, uint32 msg.FundingOutputIndex.Value).ToChannelId()
+        let msgToSend: FundingSignedMsg = { ChannelId = channelId; Signature = !>localSigOfRemoteCommit.Signature }
+        let commitments = { Commitments.LocalParams = state.LocalParams
+                            RemoteParams = state.RemoteParams
+                            ChannelFlags = state.ChannelFlags
+                            FundingScriptCoin =
+                                ChannelHelpers.getFundingScriptCoin
+                                    state.LocalParams.ChannelPubKeys.FundingPubKey
+                                    remoteChannelKeys.FundingPubKey
+                                    msg.FundingTxId
+                                    msg.FundingOutputIndex
+                                    state.FundingSatoshis
+                            LocalCommit = { LocalCommit.Index = CommitmentNumber.FirstCommitment
+                                            Spec = localSpec
+                                            PublishableTxs = { PublishableTxs.CommitTx = finalizedCommitTx;
+                                                               HTLCTxs = [] }
+                                            PendingHTLCSuccessTxs = [] }
+                            RemoteCommit = { RemoteCommit.Index = CommitmentNumber.FirstCommitment
+                                             Spec = remoteSpec
+                                             TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
+                                             RemotePerCommitmentPoint = state.RemoteFirstPerCommitmentPoint }
+                            LocalChanges = LocalChanges.Zero
+                            RemoteChanges = RemoteChanges.Zero
+                            LocalNextHTLCId = HTLCId.Zero
+                            RemoteNextHTLCId = HTLCId.Zero
+                            OriginChannels = Map.empty
+                            RemoteNextCommitInfo = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101") |> fun h -> new Key(h) |> fun k -> k.PubKey |> PerCommitmentPoint |> RemoteNextCommitInfo.Revoked
+                            RemotePerCommitmentSecrets = PerCommitmentSecretStore()
+                            ChannelId = channelId }
+        let nextState = { WaitForFundingConfirmedData.Commitments = commitments
+                          Deferred = None
+                          LastSent = msgToSend |> Choice2Of2
+                          InitialFeeRatePerKw = state.InitialFeeRatePerKw
+                          ChannelId = channelId }
+        let channel = {
+            Config = self.Config
+            ChannelPrivKeys = self.ChannelPrivKeys
+            FeeEstimator = self.FeeEstimator
+            RemoteNodeId = self.RemoteNodeId
+            NodeSecret = self.NodeSecret
+            Network = self.Network
+            State = WaitForFundingConfirmed nextState
+        }
+        return msgToSend, channel
+    }
+
+and ChannelWaitingForFundingTx = {
+    Config: ChannelConfig
+    ChannelPrivKeys: ChannelPrivKeys
+    FeeEstimator: IFeeEstimator
+    RemoteNodeId: NodeId
+    NodeSecret: NodeSecret
+    Network: Network
+    WaitForFundingTxData: WaitForFundingTxData
+} with
+    member self.CreateFundingTx (fundingTx: FinalizedTx)
+                                (outIndex: TxOutIndex)
+                                    : Result<FundingCreatedMsg * ChannelWaitingForFundingSigned, ChannelError> = result {
+        let state = self.WaitForFundingTxData
+        let remoteParams = RemoteParams.FromAcceptChannel self.RemoteNodeId (state.InputInitFunder.RemoteInit) state.LastReceived
+        let localParams = state.InputInitFunder.LocalParams
+        assert (state.LastSent.FundingPubKey = localParams.ChannelPubKeys.FundingPubKey)
+        let commitmentSpec = state.InputInitFunder.DeriveCommitmentSpec()
+        let commitmentSeed = state.InputInitFunder.ChannelPrivKeys.CommitmentSeed
+        let fundingTxId = fundingTx.Value.GetTxId()
+        let! (_localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
+            ChannelHelpers.makeFirstCommitTxs localParams
+                                       remoteParams
+                                       state.LastSent.FundingSatoshis
+                                       state.LastSent.PushMSat
+                                       state.LastSent.FeeRatePerKw
+                                       outIndex
+                                       fundingTxId
+                                       (commitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment)
+                                       state.LastReceived.FirstPerCommitmentPoint
+                                       self.Network
+        let localSigOfRemoteCommit, _ =
+            self.ChannelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
+        let nextMsg: FundingCreatedMsg = {
+            TemporaryChannelId = state.LastReceived.TemporaryChannelId
+            FundingTxId = fundingTxId
+            FundingOutputIndex = outIndex
+            Signature = !>localSigOfRemoteCommit.Signature
+        }
+        let channelId = OutPoint(fundingTxId.Value, uint32 outIndex.Value).ToChannelId()
+        let waitForFundingSignedData = {
+            Data.WaitForFundingSignedData.ChannelId = channelId
+            LocalParams = localParams
+            RemoteParams = remoteParams
+            Data.WaitForFundingSignedData.FundingTx = fundingTx
+            Data.WaitForFundingSignedData.LocalSpec = commitmentSpec
+            LocalCommitTx = localCommitTx
+            RemoteCommit = {
+                RemoteCommit.Index = CommitmentNumber.FirstCommitment
+                Spec = remoteSpec
+                TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
+                RemotePerCommitmentPoint = state.LastReceived.FirstPerCommitmentPoint
+            }
+            ChannelFlags = state.InputInitFunder.ChannelFlags
+            LastSent = nextMsg
+            InitialFeeRatePerKw = state.InputInitFunder.InitFeeRatePerKw
+        }
+        let channelWaitingForFundingSigned = {
+            Config = self.Config
+            ChannelPrivKeys = self.ChannelPrivKeys
+            FeeEstimator = self.FeeEstimator
+            RemoteNodeId = self.RemoteNodeId
+            NodeSecret = self.NodeSecret
+            Network = self.Network
+            WaitForFundingSignedData = waitForFundingSignedData
+        }
+        return nextMsg, channelWaitingForFundingSigned
+    }
+
+
+and ChannelWaitingForAcceptChannel = {
+    Config: ChannelConfig
+    ChannelPrivKeys: ChannelPrivKeys
+    FeeEstimator: IFeeEstimator
+    RemoteNodeId: NodeId
+    NodeSecret: NodeSecret
+    Network: Network
+    WaitForAcceptChannelData: WaitForAcceptChannelData
+} with
+    member self.ApplyAcceptChannel (msg: AcceptChannelMsg)
+                                       : Result<IDestination * Money * ChannelWaitingForFundingTx, ChannelError> = result {
+        let state = self.WaitForAcceptChannelData
+        do! Validation.checkAcceptChannelMsgAcceptable (self.Config) state msg
+        let redeem =
+            Scripts.funding
+                (state.InputInitFunder.ChannelPrivKeys.ToChannelPubKeys().FundingPubKey)
+                msg.FundingPubKey
+        let destination = redeem.WitHash :> IDestination
+        let amount = state.InputInitFunder.FundingSatoshis
+        let waitForFundingTxData = {
+            InputInitFunder = state.InputInitFunder
+            LastSent = state.LastSent
+            LastReceived = msg
+        }
+        let channelWaitingForFundingTx = {
+            Config = self.Config
+            ChannelPrivKeys = self.ChannelPrivKeys
+            FeeEstimator = self.FeeEstimator
+            RemoteNodeId = self.RemoteNodeId
+            NodeSecret = self.NodeSecret
+            Network = self.Network
+            WaitForFundingTxData = waitForFundingTxData
+        }
+        return destination, amount, channelWaitingForFundingTx
+    }
+
+and Channel = {
     Config: ChannelConfig
     ChannelPrivKeys: ChannelPrivKeys
     FeeEstimator: IFeeEstimator
@@ -23,25 +274,101 @@ type Channel = {
     Network: Network
  }
         with
-        static member Create (config: ChannelConfig,
-                              nodeMasterPrivKey: NodeMasterPrivKey,
-                              channelIndex: int,
-                              feeEstimator: IFeeEstimator,
-                              n: Network,
-                              remoteNodeId: NodeId
-                             ) =
-            let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
-            let nodeSecret = nodeMasterPrivKey.NodeSecret()
-            {
-                Config = config
-                ChannelPrivKeys = channelPrivKeys
-                FeeEstimator = feeEstimator
-                RemoteNodeId = remoteNodeId
-                NodeSecret = nodeSecret
-                State = WaitForInitInternal
-                Network = n
+        static member NewOutbound(config: ChannelConfig,
+                                  nodeMasterPrivKey: NodeMasterPrivKey,
+                                  channelIndex: int,
+                                  feeEstimator: IFeeEstimator,
+                                  network: Network,
+                                  remoteNodeId: NodeId,
+                                  inputInitFunder: InputInitFunder
+                                 ): Result<OpenChannelMsg * ChannelWaitingForAcceptChannel, ChannelError> =
+            let openChannelMsgToSend: OpenChannelMsg = {
+                Chainhash = network.Consensus.HashGenesisBlock
+                TemporaryChannelId = inputInitFunder.TemporaryChannelId
+                FundingSatoshis = inputInitFunder.FundingSatoshis
+                PushMSat = inputInitFunder.PushMSat
+                DustLimitSatoshis = inputInitFunder.LocalParams.DustLimitSatoshis
+                MaxHTLCValueInFlightMsat = inputInitFunder.LocalParams.MaxHTLCValueInFlightMSat
+                ChannelReserveSatoshis = inputInitFunder.LocalParams.ChannelReserveSatoshis
+                HTLCMinimumMsat = inputInitFunder.LocalParams.HTLCMinimumMSat
+                FeeRatePerKw = inputInitFunder.InitFeeRatePerKw
+                ToSelfDelay = inputInitFunder.LocalParams.ToSelfDelay
+                MaxAcceptedHTLCs = inputInitFunder.LocalParams.MaxAcceptedHTLCs
+                FundingPubKey = inputInitFunder.ChannelPrivKeys.FundingPrivKey.FundingPubKey()
+                RevocationBasepoint = inputInitFunder.ChannelPrivKeys.RevocationBasepointSecret.RevocationBasepoint()
+                PaymentBasepoint = inputInitFunder.ChannelPrivKeys.PaymentBasepointSecret.PaymentBasepoint()
+                DelayedPaymentBasepoint = inputInitFunder.ChannelPrivKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
+                HTLCBasepoint = inputInitFunder.ChannelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
+                FirstPerCommitmentPoint = inputInitFunder.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
+                ChannelFlags = inputInitFunder.ChannelFlags
+                ShutdownScriptPubKey = config.ChannelOptions.ShutdownScriptPubKey
             }
-        static member CreateCurried = curry6 (Channel.Create)
+            result {
+                do! Validation.checkOurOpenChannelMsgAcceptable config openChannelMsgToSend
+                let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
+                let nodeSecret = nodeMasterPrivKey.NodeSecret()
+                let waitForAcceptChannelData = {
+                    InputInitFunder = inputInitFunder
+                    LastSent = openChannelMsgToSend
+                }
+                let channelWaitingForAcceptChannel = {
+                    Config = config
+                    ChannelPrivKeys = channelPrivKeys
+                    FeeEstimator = feeEstimator
+                    RemoteNodeId = remoteNodeId
+                    NodeSecret = nodeSecret
+                    Network = network
+                    WaitForAcceptChannelData = waitForAcceptChannelData
+                }
+                return (openChannelMsgToSend, channelWaitingForAcceptChannel)
+            }
+
+        static member NewInbound (config: ChannelConfig,
+                                  nodeMasterPrivKey: NodeMasterPrivKey,
+                                  channelIndex: int,
+                                  feeEstimator: IFeeEstimator,
+                                  network: Network,
+                                  remoteNodeId: NodeId,
+                                  inputInitFundee: InputInitFundee,
+                                  openChannelMsg: OpenChannelMsg
+                                 ): Result<AcceptChannelMsg * ChannelWaitingForFundingCreated, ChannelError> =
+            result {
+                do! Validation.checkOpenChannelMsgAcceptable feeEstimator config openChannelMsg
+                let localParams = inputInitFundee.LocalParams
+                let channelKeys = inputInitFundee.ChannelPrivKeys
+                let localCommitmentPubKey = channelKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
+                let acceptChannelMsg: AcceptChannelMsg = {
+                    TemporaryChannelId = openChannelMsg.TemporaryChannelId
+                    DustLimitSatoshis = localParams.DustLimitSatoshis
+                    MaxHTLCValueInFlightMsat = localParams.MaxHTLCValueInFlightMSat
+                    ChannelReserveSatoshis = localParams.ChannelReserveSatoshis
+                    HTLCMinimumMSat = localParams.HTLCMinimumMSat
+                    MinimumDepth = config.ChannelHandshakeConfig.MinimumDepth
+                    ToSelfDelay = localParams.ToSelfDelay
+                    MaxAcceptedHTLCs = localParams.MaxAcceptedHTLCs
+                    FundingPubKey = channelKeys.FundingPrivKey.FundingPubKey()
+                    RevocationBasepoint = channelKeys.RevocationBasepointSecret.RevocationBasepoint()
+                    PaymentBasepoint = channelKeys.PaymentBasepointSecret.PaymentBasepoint()
+                    DelayedPaymentBasepoint = channelKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
+                    HTLCBasepoint = channelKeys.HtlcBasepointSecret.HtlcBasepoint()
+                    FirstPerCommitmentPoint = localCommitmentPubKey
+                    ShutdownScriptPubKey = config.ChannelOptions.ShutdownScriptPubKey
+                }
+                let remoteParams = RemoteParams.FromOpenChannel remoteNodeId inputInitFundee.RemoteInit openChannelMsg config.ChannelHandshakeConfig
+                let waitForFundingCreatedData = Data.WaitForFundingCreatedData.Create localParams remoteParams openChannelMsg acceptChannelMsg
+                let channelPrivKeys = nodeMasterPrivKey.ChannelPrivKeys channelIndex
+                let nodeSecret = nodeMasterPrivKey.NodeSecret()
+                let channelWaitingForFundingCreated = {
+                    Config = config
+                    ChannelPrivKeys = channelPrivKeys
+                    FeeEstimator = feeEstimator
+                    RemoteNodeId = remoteNodeId
+                    NodeSecret = nodeSecret
+                    Network = network
+                    WaitForFundingCreatedData = waitForFundingCreatedData
+                }
+                return (acceptChannelMsg, channelWaitingForFundingCreated)
+            }
 
 module Channel =
 
@@ -147,242 +474,10 @@ module Channel =
         match cs.State, command with
 
         // --------------- open channel procedure: case we are funder -------------
-        | WaitForInitInternal, CreateOutbound inputInitFunder ->
-            let openChannelMsgToSend: OpenChannelMsg = {
-                Chainhash = cs.Network.Consensus.HashGenesisBlock
-                TemporaryChannelId = inputInitFunder.TemporaryChannelId
-                FundingSatoshis = inputInitFunder.FundingSatoshis
-                PushMSat = inputInitFunder.PushMSat
-                DustLimitSatoshis = inputInitFunder.LocalParams.DustLimitSatoshis
-                MaxHTLCValueInFlightMsat = inputInitFunder.LocalParams.MaxHTLCValueInFlightMSat
-                ChannelReserveSatoshis = inputInitFunder.LocalParams.ChannelReserveSatoshis
-                HTLCMinimumMsat = inputInitFunder.LocalParams.HTLCMinimumMSat
-                FeeRatePerKw = inputInitFunder.InitFeeRatePerKw
-                ToSelfDelay = inputInitFunder.LocalParams.ToSelfDelay
-                MaxAcceptedHTLCs = inputInitFunder.LocalParams.MaxAcceptedHTLCs
-                FundingPubKey = inputInitFunder.ChannelPrivKeys.FundingPrivKey.FundingPubKey()
-                RevocationBasepoint = inputInitFunder.ChannelPrivKeys.RevocationBasepointSecret.RevocationBasepoint()
-                PaymentBasepoint = inputInitFunder.ChannelPrivKeys.PaymentBasepointSecret.PaymentBasepoint()
-                DelayedPaymentBasepoint = inputInitFunder.ChannelPrivKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
-                HTLCBasepoint = inputInitFunder.ChannelPrivKeys.HtlcBasepointSecret.HtlcBasepoint()
-                FirstPerCommitmentPoint = inputInitFunder.ChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
-                ChannelFlags = inputInitFunder.ChannelFlags
-                ShutdownScriptPubKey = cs.Config.ChannelOptions.ShutdownScriptPubKey
-            }
-            result {
-                do! Validation.checkOurOpenChannelMsgAcceptable (cs.Config) openChannelMsgToSend
-                return [
-                    NewOutboundChannelStarted(
-                        openChannelMsgToSend, {
-                            InputInitFunder = inputInitFunder
-                            LastSent = openChannelMsgToSend
-                    })
-                ]
-            }
-        | WaitForAcceptChannel state, ApplyAcceptChannel msg ->
-            result {
-                do! Validation.checkAcceptChannelMsgAcceptable (cs.Config) state msg
-                let redeem =
-                    Scripts.funding
-                        (state.InputInitFunder.ChannelPrivKeys.ToChannelPubKeys().FundingPubKey)
-                        msg.FundingPubKey
-                let destination = redeem.WitHash :> IDestination
-                let amount = state.InputInitFunder.FundingSatoshis
-                let nextState = {
-                    InputInitFunder = state.InputInitFunder
-                    LastSent = state.LastSent
-                    LastReceived = msg
-                }
-
-                return [ WeAcceptedAcceptChannel(destination, amount, nextState) ]
-            }
-        | WaitForFundingTx state, CreateFundingTx(fundingTx, outIndex) ->
-            result {
-                let remoteParams = RemoteParams.FromAcceptChannel cs.RemoteNodeId (state.InputInitFunder.RemoteInit) state.LastReceived
-                let localParams = state.InputInitFunder.LocalParams
-                assert (state.LastSent.FundingPubKey = localParams.ChannelPubKeys.FundingPubKey)
-                let commitmentSpec = state.InputInitFunder.DeriveCommitmentSpec()
-                let commitmentSeed = state.InputInitFunder.ChannelPrivKeys.CommitmentSeed
-                let fundingTxId = fundingTx.Value.GetTxId()
-                let! (_localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
-                    ChannelHelpers.makeFirstCommitTxs localParams
-                                               remoteParams
-                                               state.LastSent.FundingSatoshis
-                                               state.LastSent.PushMSat
-                                               state.LastSent.FeeRatePerKw
-                                               outIndex
-                                               fundingTxId
-                                               (commitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment)
-                                               state.LastReceived.FirstPerCommitmentPoint
-                                               cs.Network
-                let localSigOfRemoteCommit, _ =
-                    cs.ChannelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
-                let nextMsg: FundingCreatedMsg = {
-                    TemporaryChannelId = state.LastReceived.TemporaryChannelId
-                    FundingTxId = fundingTxId
-                    FundingOutputIndex = outIndex
-                    Signature = !>localSigOfRemoteCommit.Signature
-                }
-                let channelId = OutPoint(fundingTxId.Value, uint32 outIndex.Value).ToChannelId()
-                let data = { Data.WaitForFundingSignedData.ChannelId = channelId
-                             LocalParams = localParams
-                             RemoteParams = remoteParams
-                             Data.WaitForFundingSignedData.FundingTx = fundingTx
-                             Data.WaitForFundingSignedData.LocalSpec = commitmentSpec
-                             LocalCommitTx = localCommitTx
-                             RemoteCommit = { RemoteCommit.Index = CommitmentNumber.FirstCommitment
-                                              Spec = remoteSpec
-                                              TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
-                                              RemotePerCommitmentPoint = state.LastReceived.FirstPerCommitmentPoint }
-                             ChannelFlags = state.InputInitFunder.ChannelFlags
-                             LastSent = nextMsg
-                             InitialFeeRatePerKw = state.InputInitFunder.InitFeeRatePerKw }
-                return [ WeCreatedFundingTx(nextMsg, data) ]
-            }
-        | WaitForFundingSigned state, ApplyFundingSigned msg ->
-            result {
-                let remoteChannelKeys = state.RemoteParams.ChannelPubKeys
-                let! finalizedLocalCommitTx =
-                    let theirFundingPk = remoteChannelKeys.FundingPubKey.RawPubKey()
-                    let _, signedLocalCommitTx =
-                        cs.ChannelPrivKeys.SignWithFundingPrivKey state.LocalCommitTx.Value
-                    let remoteSigPairOfLocalTx = (theirFundingPk,  TransactionSignature(msg.Signature.Value, SigHash.All))
-                    let sigPairs = seq [ remoteSigPairOfLocalTx; ]
-                    Transactions.checkTxFinalized signedLocalCommitTx state.LocalCommitTx.WhichInput sigPairs |> expectTransactionError
-                let commitments = { Commitments.LocalParams = state.LocalParams
-                                    RemoteParams = state.RemoteParams
-                                    ChannelFlags = state.ChannelFlags
-                                    FundingScriptCoin =
-                                        let amount = state.FundingTx.Value.Outputs.[int state.LastSent.FundingOutputIndex.Value].Value
-                                        ChannelHelpers.getFundingScriptCoin
-                                            state.LocalParams.ChannelPubKeys.FundingPubKey
-                                            remoteChannelKeys.FundingPubKey
-                                            state.LastSent.FundingTxId
-                                            state.LastSent.FundingOutputIndex
-                                            amount
-                                    LocalCommit = { Index = CommitmentNumber.FirstCommitment;
-                                                    Spec = state.LocalSpec;
-                                                    PublishableTxs = { PublishableTxs.CommitTx = finalizedLocalCommitTx
-                                                                       HTLCTxs = [] }
-                                                    PendingHTLCSuccessTxs = [] }
-                                    RemoteCommit = state.RemoteCommit
-                                    LocalChanges = LocalChanges.Zero
-                                    RemoteChanges = RemoteChanges.Zero
-                                    LocalNextHTLCId = HTLCId.Zero
-                                    RemoteNextHTLCId = HTLCId.Zero
-                                    OriginChannels = Map.empty
-                                    // we will receive their next per-commitment point in the next msg, so we temporarily put a random byte array
-                                    RemoteNextCommitInfo = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101") |> fun h -> new Key(h) |> fun k -> k.PubKey |> PerCommitmentPoint |> RemoteNextCommitInfo.Revoked
-                                    RemotePerCommitmentSecrets = PerCommitmentSecretStore()
-                                    ChannelId =
-                                        msg.ChannelId }
-                let nextState = { WaitForFundingConfirmedData.Commitments = commitments
-                                  Deferred = None
-                                  LastSent = Choice1Of2 state.LastSent
-                                  InitialFeeRatePerKw = state.InitialFeeRatePerKw
-                                  ChannelId = msg.ChannelId }
-                return [ WeAcceptedFundingSigned(state.FundingTx, nextState) ]
-            }
-        // --------------- open channel procedure: case we are fundee -------------
-        | WaitForInitInternal, CreateInbound inputInitFundee ->
-            [ NewInboundChannelStarted({ InitFundee = inputInitFundee }) ] |> Ok
-
         | WaitForFundingConfirmed state, CreateChannelReestablish ->
             makeChannelReestablish cs.ChannelPrivKeys state
         | ChannelState.Normal state, CreateChannelReestablish ->
             makeChannelReestablish cs.ChannelPrivKeys state
-        | WaitForOpenChannel state, ApplyOpenChannel msg ->
-            result {
-                do! Validation.checkOpenChannelMsgAcceptable (cs.FeeEstimator) (cs.Config) msg
-                let localParams = state.InitFundee.LocalParams
-                let channelKeys = state.InitFundee.ChannelPrivKeys
-                let localCommitmentPubKey = channelKeys.CommitmentSeed.DerivePerCommitmentPoint CommitmentNumber.FirstCommitment
-                let acceptChannelMsg: AcceptChannelMsg = {
-                    TemporaryChannelId = msg.TemporaryChannelId
-                    DustLimitSatoshis = localParams.DustLimitSatoshis
-                    MaxHTLCValueInFlightMsat = localParams.MaxHTLCValueInFlightMSat
-                    ChannelReserveSatoshis = localParams.ChannelReserveSatoshis
-                    HTLCMinimumMSat = localParams.HTLCMinimumMSat
-                    MinimumDepth = cs.Config.ChannelHandshakeConfig.MinimumDepth
-                    ToSelfDelay = localParams.ToSelfDelay
-                    MaxAcceptedHTLCs = localParams.MaxAcceptedHTLCs
-                    FundingPubKey = channelKeys.FundingPrivKey.FundingPubKey()
-                    RevocationBasepoint = channelKeys.RevocationBasepointSecret.RevocationBasepoint()
-                    PaymentBasepoint = channelKeys.PaymentBasepointSecret.PaymentBasepoint()
-                    DelayedPaymentBasepoint = channelKeys.DelayedPaymentBasepointSecret.DelayedPaymentBasepoint()
-                    HTLCBasepoint = channelKeys.HtlcBasepointSecret.HtlcBasepoint()
-                    FirstPerCommitmentPoint = localCommitmentPubKey
-                    ShutdownScriptPubKey = cs.Config.ChannelOptions.ShutdownScriptPubKey
-                }
-                let remoteParams = RemoteParams.FromOpenChannel cs.RemoteNodeId state.InitFundee.RemoteInit msg cs.Config.ChannelHandshakeConfig
-                let data = Data.WaitForFundingCreatedData.Create localParams remoteParams msg acceptChannelMsg
-                return [ WeAcceptedOpenChannel(acceptChannelMsg, data) ]
-            }
-        | WaitForOpenChannel _state, ChannelCommand.Close _spk ->
-            [ ChannelEvent.Closed ] |> Ok
-
-        | WaitForFundingCreated state, ApplyFundingCreated msg ->
-            result {
-                let remoteChannelKeys = state.RemoteParams.ChannelPubKeys
-                let! (localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
-                    ChannelHelpers.makeFirstCommitTxs
-                        state.LocalParams
-                        state.RemoteParams
-                        state.FundingSatoshis
-                        state.PushMSat
-                        state.InitialFeeRatePerKw
-                        msg.FundingOutputIndex
-                        msg.FundingTxId
-                        state.LastSent.FirstPerCommitmentPoint
-                        state.RemoteFirstPerCommitmentPoint
-                        cs.Network
-                assert (localCommitTx.Value.IsReadyToSign())
-                let _s, signedLocalCommitTx =
-                    cs.ChannelPrivKeys.SignWithFundingPrivKey localCommitTx.Value
-                let remoteTxSig = TransactionSignature(msg.Signature.Value, SigHash.All)
-                let theirSigPair = (remoteChannelKeys.FundingPubKey.RawPubKey(), remoteTxSig)
-                let sigPairs = seq [ theirSigPair ]
-                let! finalizedCommitTx =
-                    Transactions.checkTxFinalized (signedLocalCommitTx) (localCommitTx.WhichInput) sigPairs
-                    |> expectTransactionError
-                let localSigOfRemoteCommit, _ =
-                    cs.ChannelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
-                let channelId = OutPoint(msg.FundingTxId.Value, uint32 msg.FundingOutputIndex.Value).ToChannelId()
-                let msgToSend: FundingSignedMsg = { ChannelId = channelId; Signature = !>localSigOfRemoteCommit.Signature }
-                let commitments = { Commitments.LocalParams = state.LocalParams
-                                    RemoteParams = state.RemoteParams
-                                    ChannelFlags = state.ChannelFlags
-                                    FundingScriptCoin =
-                                        ChannelHelpers.getFundingScriptCoin
-                                            state.LocalParams.ChannelPubKeys.FundingPubKey
-                                            remoteChannelKeys.FundingPubKey
-                                            msg.FundingTxId
-                                            msg.FundingOutputIndex
-                                            state.FundingSatoshis
-                                    LocalCommit = { LocalCommit.Index = CommitmentNumber.FirstCommitment
-                                                    Spec = localSpec
-                                                    PublishableTxs = { PublishableTxs.CommitTx = finalizedCommitTx;
-                                                                       HTLCTxs = [] }
-                                                    PendingHTLCSuccessTxs = [] }
-                                    RemoteCommit = { RemoteCommit.Index = CommitmentNumber.FirstCommitment
-                                                     Spec = remoteSpec
-                                                     TxId = remoteCommitTx.Value.GetGlobalTransaction().GetTxId()
-                                                     RemotePerCommitmentPoint = state.RemoteFirstPerCommitmentPoint }
-                                    LocalChanges = LocalChanges.Zero
-                                    RemoteChanges = RemoteChanges.Zero
-                                    LocalNextHTLCId = HTLCId.Zero
-                                    RemoteNextHTLCId = HTLCId.Zero
-                                    OriginChannels = Map.empty
-                                    RemoteNextCommitInfo = DataEncoders.HexEncoder().DecodeData("0101010101010101010101010101010101010101010101010101010101010101") |> fun h -> new Key(h) |> fun k -> k.PubKey |> PerCommitmentPoint |> RemoteNextCommitInfo.Revoked
-                                    RemotePerCommitmentSecrets = PerCommitmentSecretStore()
-                                    ChannelId = channelId }
-                let nextState = { WaitForFundingConfirmedData.Commitments = commitments
-                                  Deferred = None
-                                  LastSent = msgToSend |> Choice2Of2
-                                  InitialFeeRatePerKw = state.InitialFeeRatePerKw
-                                  ChannelId = channelId }
-                return [ WeAcceptedFundingCreated(msgToSend, nextState) ]
-            }
         | WaitForFundingConfirmed _state, ApplyFundingLocked msg ->
             [ TheySentFundingLocked msg ] |> Ok
         | WaitForFundingConfirmed state, ApplyFundingConfirmedOnBC(height, txindex, depth) ->
@@ -803,26 +898,6 @@ module Channel =
 
     let applyEvent c (e: ChannelEvent): Channel =
         match e, c.State with
-        | NewOutboundChannelStarted(_, data), WaitForInitInternal ->
-            { c with State = (WaitForAcceptChannel data) }
-        | NewInboundChannelStarted(data), WaitForInitInternal ->
-            { c with State = (WaitForOpenChannel data) }
-        // --------- init fundee -----
-        | WeAcceptedOpenChannel(_, data), WaitForOpenChannel _ ->
-            let state = WaitForFundingCreated data
-            { c with State = state }
-        | WeAcceptedFundingCreated(_, data), WaitForFundingCreated _ ->
-            let state = WaitForFundingConfirmed data
-            { c with State = state }
-
-        // --------- init funder -----
-        | WeAcceptedAcceptChannel(_, _, data), WaitForAcceptChannel _ ->
-            { c with State = WaitForFundingTx data }
-        | WeCreatedFundingTx(_, data), WaitForFundingTx _ ->
-            { c with State = WaitForFundingSigned data }
-        | WeAcceptedFundingSigned(_, data), WaitForFundingSigned _ ->
-            { c with State = WaitForFundingConfirmed data }
-
         // --------- init both ------
         | FundingConfirmed data, WaitForFundingConfirmed _ ->
             { c with State = WaitForFundingLocked data }
@@ -851,10 +926,6 @@ module Channel =
             { c with State = ChannelState.Normal nextState }
         | WeSentFundingLocked msg, WaitForFundingLocked prevState ->
             { c with State = WaitForFundingLocked { prevState with OurMessage = msg; HaveWeSentFundingLocked = true } }
-        | BothFundingLocked data, WaitForFundingSigned _s ->
-            { c with State = ChannelState.Normal data }
-        | BothFundingLocked data, WaitForFundingLocked _s ->
-            { c with State = ChannelState.Normal data }
 
         // ----- normal operation --------
         | WeAcceptedOperationMonoHopUnidirectionalPayment(_, newCommitments), ChannelState.Normal normalData ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -945,13 +945,13 @@ module Channel =
                         // yes.
                         | RemoteNextCommitInfo.Waiting _waitingForRevocation ->
                             return [
-                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(msg, cm)
+                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs msg
                             ]
                         // No. let's sign right away.
                         | RemoteNextCommitInfo.Revoked _ ->
                             return [
                                 ChannelStateRequestedSignCommitment;
-                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(msg, cm)
+                                AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs msg
                             ]
                 else
                     let (localShutdown, _sendList) =
@@ -1291,10 +1291,9 @@ module Channel =
         // -----  closing ------
         | AcceptedOperationShutdown msg, ChannelState.Normal d ->
             { c with State = ChannelState.Normal({ d with LocalShutdown = Some msg }) }
-        | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs(remoteShutdown, nextCommitments), ChannelState.Normal normalData ->
+        | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdown, ChannelState.Normal normalData ->
             { 
                 c with
-                    Commitments = nextCommitments
                     State = ChannelState.Normal {
                         normalData with
                             RemoteShutdown = Some remoteShutdown

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -62,7 +62,6 @@ module Channel =
                            localSpk: Script,
                            remoteSpk: Script,
                            closingFee: Money,
-                           localFundingPk: FundingPubKey,
                            network: Network
                           ) =
             assert (Scripts.isValidFinalScriptPubKey (remoteSpk) && Scripts.isValidFinalScriptPubKey (localSpk))
@@ -94,12 +93,11 @@ module Channel =
                                 localSpk: Script,
                                 remoteSpk: Script,
                                 feeEst: IFeeEstimator,
-                                localFundingPk: FundingPubKey,
                                 network: Network
                                ) =
             result {
                 let! closingFee = firstClosingFee (commitments, localSpk, remoteSpk, feeEst, network)
-                return! makeClosingTx (channelPrivKeys, commitments, localSpk, remoteSpk, closingFee, localFundingPk, network)
+                return! makeClosingTx (channelPrivKeys, commitments, localSpk, remoteSpk, closingFee, network)
             } |> expectTransactionError
 
         let nextClosingFee (localClosingFee: Money, remoteClosingFee: Money) =
@@ -622,7 +620,6 @@ module Channel =
                                                             localShutdown.ScriptPubKey,
                                                             msg.ScriptPubKey,
                                                             cs.FeeEstimator,
-                                                            cm.LocalParams.ChannelPubKeys.FundingPubKey,
                                                             cs.Network)
                             let nextState = { NegotiatingData.ChannelId = cm.ChannelId
                                               Commitments = cm
@@ -695,7 +692,6 @@ module Channel =
                         state.LocalShutdown.ScriptPubKey,
                         state.RemoteShutdown.ScriptPubKey,
                         msg.FeeSatoshis,
-                        cm.LocalParams.ChannelPubKeys.FundingPubKey,
                         cs.Network
                     )
                     |> expectTransactionError
@@ -751,7 +747,6 @@ module Channel =
                                 state.LocalShutdown.ScriptPubKey,
                                 state.RemoteShutdown.ScriptPubKey,
                                 nextClosingFee,
-                                cm.LocalParams.ChannelPubKeys.FundingPubKey,
                                 cs.Network
                             )
                             |> expectTransactionError

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -630,7 +630,6 @@ module Channel =
                 }
                 let nextState = {
                     ShortChannelId = shortChannelId
-                    OurMessage = msgToSend
                     TheirMessage = None
                     HaveWeSentFundingLocked = false
                 }
@@ -1119,8 +1118,8 @@ module Channel =
                 RemoteShutdown = None
             }
             { c with State = ChannelState.Normal nextState }
-        | WeSentFundingLocked msg, WaitForFundingLocked prevState ->
-            { c with State = WaitForFundingLocked { prevState with OurMessage = msg; HaveWeSentFundingLocked = true } }
+        | WeSentFundingLocked _msg, WaitForFundingLocked prevState ->
+            { c with State = WaitForFundingLocked { prevState with HaveWeSentFundingLocked = true } }
 
         // ----- normal operation --------
         | WeAcceptedOperationMonoHopUnidirectionalPayment(_, newCommitments), ChannelState.Normal _normalData ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -549,14 +549,10 @@ module Channel =
             |> Money.Satoshis
 
         let handleMutualClose (closingTx: FinalizedTx)
-                              (d: NegotiatingData)
+                              (_d: NegotiatingData)
                               (remoteNextCommitInfoOpt: Option<RemoteNextCommitInfo>) =
             let nextData =
                 ClosingData.Create
-                    None
-                    DateTime.Now
-                    (d.ClosingTxProposed |> List.collect id |> List.map (fun tx -> tx.UnsignedTx))
-                    closingTx
                     remoteNextCommitInfoOpt
             [ MutualClosePerformed (closingTx, nextData) ]
             |> Ok
@@ -1117,17 +1113,8 @@ module Channel =
                     remoteNextCommitInfoIfFundingLocked
                         state.RemoteNextCommitInfo
                         "FulfillHTC"
-                let! (_msgToSend, newCommitments) =
+                let! (_msgToSend, _newCommitments) =
                     Commitments.sendFulfill op cm remoteNextCommitInfo
-                let _localCommitPublished =
-                    state.LocalCommitPublished
-                    |> Option.map (fun localCommitPublished ->
-                        Closing.claimCurrentLocalCommitTxOutputs (
-                            cs.ChannelPrivKeys,
-                            newCommitments,
-                            localCommitPublished.CommitTx
-                        )
-                    )
                 return failwith "Not Implemented yet"
             }
         | state, cmd ->

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -36,8 +36,6 @@ type ChannelWaitingForFundingSigned = {
         let commitments = {
             ProposedLocalChanges = List.empty
             ProposedRemoteChanges = List.empty
-            LocalChanges = LocalChanges.Zero
-            RemoteChanges = RemoteChanges.Zero
             LocalNextHTLCId = HTLCId.Zero
             RemoteNextHTLCId = HTLCId.Zero
             OriginChannels = Map.empty
@@ -57,6 +55,8 @@ type ChannelWaitingForFundingSigned = {
                     PendingHTLCSuccessTxs = []
                 }
                 RemoteCommit = self.RemoteCommit
+                LocalChanges = LocalChanges.Zero
+                RemoteChanges = RemoteChanges.Zero
             }
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
@@ -128,8 +128,6 @@ and ChannelWaitingForFundingCreated = {
         let commitments = {
             ProposedLocalChanges = List.empty
             ProposedRemoteChanges = List.empty
-            LocalChanges = LocalChanges.Zero
-            RemoteChanges = RemoteChanges.Zero
             LocalNextHTLCId = HTLCId.Zero
             RemoteNextHTLCId = HTLCId.Zero
             OriginChannels = Map.empty
@@ -171,6 +169,8 @@ and ChannelWaitingForFundingCreated = {
                     Spec = remoteSpec
                     RemotePerCommitmentPoint = self.RemoteFirstPerCommitmentPoint
                 }
+                LocalChanges = LocalChanges.Zero
+                RemoteChanges = RemoteChanges.Zero
             }
             ChannelOptions = self.ChannelOptions
             ChannelPrivKeys = self.ChannelPrivKeys
@@ -601,7 +601,7 @@ and Channel = {
                 match remoteNextCommitInfo with
                 | Waiting nextRemoteCommit -> nextRemoteCommit
                 | Revoked _info -> self.SavedChannelState.RemoteCommit
-            let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.ProposedLocalChanges) |> expectTransactionError
+            let! reduced = remoteCommit1.Spec.Reduce(self.SavedChannelState.RemoteChanges.ACKed, commitments1.ProposedLocalChanges) |> expectTransactionError
             do!
                 Validation.checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec
                     reduced
@@ -619,7 +619,7 @@ and Channel = {
         let commitments1 = self.Commitments.AddRemoteProposal(msg)
         let! reduced =
             self.SavedChannelState.LocalCommit.Spec.Reduce
-                (commitments1.LocalChanges.ACKed, commitments1.ProposedRemoteChanges)
+                (self.SavedChannelState.LocalChanges.ACKed, commitments1.ProposedRemoteChanges)
             |> expectTransactionError
         do!
             Validation.checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec
@@ -669,7 +669,7 @@ and Channel = {
                 match remoteNextCommitInfo with
                 | Waiting nextRemoteCommit -> nextRemoteCommit
                 | Revoked _info -> self.SavedChannelState.RemoteCommit
-            let! reduced = remoteCommit1.Spec.Reduce(commitments1.RemoteChanges.ACKed, commitments1.ProposedLocalChanges) |> expectTransactionError
+            let! reduced = remoteCommit1.Spec.Reduce(self.SavedChannelState.RemoteChanges.ACKed, commitments1.ProposedLocalChanges) |> expectTransactionError
             do!
                 Validation.checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec
                     reduced
@@ -697,7 +697,7 @@ and Channel = {
         }
         let! reduced =
             self.SavedChannelState.LocalCommit.Spec.Reduce (
-                commitments1.LocalChanges.ACKed,
+                self.SavedChannelState.LocalChanges.ACKed,
                 commitments1.ProposedRemoteChanges
             ) |> expectTransactionError
         do!
@@ -844,26 +844,15 @@ and Channel = {
     }
 
     member self.SignCommitment(): Result<Channel * Option<CommitmentSignedMsg>, ChannelError> = result {
-        let cm = self.Commitments
         let! remoteNextCommitInfo =
             self.RemoteNextCommitInfoIfFundingLockedNormal "SignCommit"
         match remoteNextCommitInfo with
-        | _ when (cm.LocalHasChanges() |> not) ->
+        | _ when (self.LocalHasChanges() |> not) ->
             // Ignore SignCommitment Command (nothing to sign)
             return self, None
         | RemoteNextCommitInfo.Revoked _ ->
-            let! commitmentSignedMsg, newCommitments, newRemoteCommit =
-                Commitments.sendCommit
-                    self.ChannelPrivKeys
-                    cm
-                    self.SavedChannelState
-                    remoteNextCommitInfo
-            let channel = {
-                self with
-                    Commitments = newCommitments
-                    RemoteNextCommitInfo =
-                        Some <| RemoteNextCommitInfo.Waiting newRemoteCommit
-            }
+            let! commitmentSignedMsg, channel =
+                self.sendCommit remoteNextCommitInfo
             return channel, Some commitmentSignedMsg
         | RemoteNextCommitInfo.Waiting _ ->
             // Already in the process of signing
@@ -874,17 +863,7 @@ and Channel = {
                                           : Result<Channel * RevokeAndACKMsg, ChannelError> = result {
         let! _remoteNextCommitInfo =
             self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyCommitmentSigned"
-        let! revokeAndACKMsg, newSavedChannelState, newCommitments =
-            Commitments.receiveCommit
-                self.ChannelPrivKeys
-                msg
-                self.Commitments
-                self.SavedChannelState
-        let channel = {
-            self with
-                SavedChannelState = newSavedChannelState
-                Commitments = newCommitments
-        }
+        let! revokeAndACKMsg, channel = self.receiveCommit msg
         return channel, revokeAndACKMsg
     }
 
@@ -892,7 +871,6 @@ and Channel = {
                                       : Result<Channel, ChannelError> = result {
         let! remoteNextCommitInfo =
             self.RemoteNextCommitInfoIfFundingLockedNormal "ApplyRevokeAndACK"
-        let cm = self.Commitments
         match remoteNextCommitInfo with
         | RemoteNextCommitInfo.Waiting _ when (msg.PerCommitmentSecret.PerCommitmentPoint() <> self.SavedChannelState.RemoteCommit.RemotePerCommitmentPoint) ->
             let errorMsg = sprintf "Invalid revoke_and_ack %A; must be %A" msg.PerCommitmentSecret self.SavedChannelState.RemoteCommit.RemotePerCommitmentPoint
@@ -908,27 +886,23 @@ and Channel = {
             match remotePerCommitmentSecretsOpt with
             | Error err -> return! Error <| invalidRevokeAndACK msg err.Message
             | Ok remotePerCommitmentSecrets ->
-                let commitments1 = {
-                    cm with
-                        LocalChanges = {
-                            cm.LocalChanges with
-                                Signed = [];
-                                ACKed = cm.LocalChanges.ACKed @ cm.LocalChanges.Signed
-                        }
-                        RemoteChanges = {
-                            cm.RemoteChanges with
-                                Signed = []
-                        }
-                }
                 let savedChannelState = {
                     self.SavedChannelState with
                         RemotePerCommitmentSecrets = remotePerCommitmentSecrets
                         RemoteCommit = theirNextCommit
+                        LocalChanges = {
+                            self.SavedChannelState.LocalChanges with
+                                Signed = [];
+                                ACKed = self.SavedChannelState.LocalChanges.ACKed @ self.SavedChannelState.LocalChanges.Signed
+                        }
+                        RemoteChanges = {
+                            self.SavedChannelState.RemoteChanges with
+                                Signed = []
+                        }
                 }
                 return {
                     self with
                         SavedChannelState = savedChannelState
-                        Commitments = commitments1
                         RemoteNextCommitInfo =
                             Some <| RemoteNextCommitInfo.Revoked msg.NextPerCommitmentPoint
                 }
@@ -1183,3 +1157,241 @@ and Channel = {
                 return channel, NewClosingSigned closingSignedMsg
     }
 
+    member self.LocalHasChanges() =
+        (not self.SavedChannelState.RemoteChanges.ACKed.IsEmpty)
+        || (not self.Commitments.ProposedLocalChanges.IsEmpty)
+
+    member self.RemoteHasChanges() =
+        (not self.SavedChannelState.LocalChanges.ACKed.IsEmpty)
+        || (not self.Commitments.ProposedRemoteChanges.IsEmpty)
+
+    member self.SpendableBalance (): LNMoney =
+        let remoteParams = self.SavedChannelState.StaticChannelConfig.RemoteParams
+        let remoteCommit =
+            match self.RemoteNextCommitInfo with
+            | Some (RemoteNextCommitInfo.Waiting nextRemoteCommit) -> nextRemoteCommit
+            | Some (RemoteNextCommitInfo.Revoked _info) -> self.SavedChannelState.RemoteCommit
+            // TODO: This could return a proper error, or report the full balance
+            | None -> failwith "funding is not locked"
+        let reducedRes =
+            remoteCommit.Spec.Reduce(
+                self.SavedChannelState.RemoteChanges.ACKed,
+                self.Commitments.ProposedLocalChanges
+            )
+        let reduced =
+            match reducedRes with
+            | Error err ->
+                failwithf
+                    "reducing commit failed even though we have not proposed any changes\
+                    error: %A"
+                    err
+            | Ok reduced -> reduced
+        let fees =
+            if self.SavedChannelState.StaticChannelConfig.IsFunder then
+                Transactions.commitTxFee remoteParams.DustLimitSatoshis reduced
+                |> LNMoney.FromMoney
+            else
+                LNMoney.Zero
+        let channelReserve =
+            remoteParams.ChannelReserveSatoshis
+            |> LNMoney.FromMoney
+        let totalBalance = reduced.ToRemote
+        let untrimmedSpendableBalance = totalBalance - channelReserve - fees
+        let dustLimit =
+            remoteParams.DustLimitSatoshis
+            |> LNMoney.FromMoney
+        let untrimmedMax = LNMoney.Min(untrimmedSpendableBalance, dustLimit)
+        let spendableBalance = LNMoney.Max(untrimmedMax, untrimmedSpendableBalance)
+        spendableBalance
+
+    member private self.sendCommit (remoteNextCommitInfo: RemoteNextCommitInfo)
+                                       : Result<CommitmentSignedMsg * Channel, ChannelError> =
+        let channelPrivKeys = self.ChannelPrivKeys
+        let cm = self.Commitments
+        let savedChannelState = self.SavedChannelState
+        match remoteNextCommitInfo with
+        | RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint ->
+            result {
+                // remote commitment will include all local changes + remote acked changes
+                let! spec = savedChannelState.RemoteCommit.Spec.Reduce(savedChannelState.RemoteChanges.ACKed, cm.ProposedLocalChanges) |> expectTransactionError
+                let! (remoteCommitTx, htlcTimeoutTxs, htlcSuccessTxs) =
+                    Commitments.Helpers.makeRemoteTxs savedChannelState.StaticChannelConfig
+                                          (savedChannelState.RemoteCommit.Index.NextCommitment())
+                                          (channelPrivKeys.ToChannelPubKeys())
+                                          (remoteNextPerCommitmentPoint)
+                                          (spec)
+                    |> expectTransactionErrors
+                let signature,_ = channelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
+                let sortedHTLCTXs = Commitments.Helpers.sortBothHTLCs htlcTimeoutTxs htlcSuccessTxs
+                let htlcSigs =
+                    sortedHTLCTXs
+                    |> List.map(
+                            (fun htlc -> channelPrivKeys.SignHtlcTx htlc.Value remoteNextPerCommitmentPoint)
+                            >> fst
+                            >> (fun txSig -> txSig.Signature)
+                            )
+                let msg = {
+                    CommitmentSignedMsg.ChannelId = savedChannelState.StaticChannelConfig.ChannelId()
+                    Signature = !> signature.Signature
+                    HTLCSignatures = htlcSigs |> List.map (!>)
+                }
+                let nextRemoteCommitInfo = {
+                    savedChannelState.RemoteCommit
+                    with
+                        Index = savedChannelState.RemoteCommit.Index.NextCommitment()
+                        Spec = spec
+                        RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
+                }
+                let nextCommitments = {
+                    cm with
+                        ProposedLocalChanges = []
+                }
+                let nextSavedChannelState = {
+                    self.SavedChannelState with
+                        LocalChanges = {
+                            self.SavedChannelState.LocalChanges with
+                                Signed = cm.ProposedLocalChanges
+                        }
+                        RemoteChanges = {
+                            self.SavedChannelState.RemoteChanges with
+                                ACKed = []
+                                Signed = self.SavedChannelState.RemoteChanges.ACKed
+                        }
+                }
+                let channel = {
+                    self with
+                        Commitments = nextCommitments
+                        SavedChannelState = nextSavedChannelState
+                        RemoteNextCommitInfo =
+                            Some <| RemoteNextCommitInfo.Waiting nextRemoteCommitInfo
+                }
+                return msg, channel
+            }
+        | RemoteNextCommitInfo.Waiting _ ->
+            CanNotSignBeforeRevocation |> Error
+
+    member private self.receiveCommit (msg: CommitmentSignedMsg)
+                                          : Result<RevokeAndACKMsg * Channel, ChannelError> =
+        let channelPrivKeys = self.ChannelPrivKeys
+        let cm = self.Commitments
+        let savedChannelState = self.SavedChannelState
+        if self.RemoteHasChanges() |> not then
+            ReceivedCommitmentSignedWhenWeHaveNoPendingChanges |> Error
+        else
+            let commitmentSeed = channelPrivKeys.CommitmentSeed
+            let localChannelKeys = channelPrivKeys.ToChannelPubKeys()
+            let remoteChannelKeys = savedChannelState.StaticChannelConfig.RemoteChannelPubKeys
+            let nextI = savedChannelState.LocalCommit.Index.NextCommitment()
+            result {
+                let! spec = savedChannelState.LocalCommit.Spec.Reduce(savedChannelState.LocalChanges.ACKed, cm.ProposedRemoteChanges) |> expectTransactionError
+                let localPerCommitmentPoint = commitmentSeed.DerivePerCommitmentPoint nextI
+                let! (localCommitTx, htlcTimeoutTxs, htlcSuccessTxs) =
+                    Commitments.Helpers.makeLocalTXs
+                        savedChannelState.StaticChannelConfig
+                        nextI
+                        (channelPrivKeys.ToChannelPubKeys())
+                        localPerCommitmentPoint
+                        spec
+                    |> expectTransactionErrors
+                let signature, signedCommitTx = channelPrivKeys.SignWithFundingPrivKey localCommitTx.Value
+
+                let sigPair =
+                    let localSigPair = seq [(localChannelKeys.FundingPubKey.RawPubKey(), signature)]
+                    let remoteSigPair = seq[ (remoteChannelKeys.FundingPubKey.RawPubKey(), TransactionSignature(msg.Signature.Value, SigHash.All)) ]
+                    Seq.append localSigPair remoteSigPair
+                let tmp =
+                    Transactions.checkTxFinalized signedCommitTx CommitTx.WhichInput sigPair
+                    |> expectTransactionError
+                let! finalizedCommitTx = tmp
+                let sortedHTLCTXs = Commitments.Helpers.sortBothHTLCs htlcTimeoutTxs htlcSuccessTxs
+                do! Commitments.checkSignatureCountMismatch sortedHTLCTXs msg
+                
+                let _localHTLCSigs, sortedHTLCTXs =
+                    let localHtlcSigsAndHTLCTxs =
+                        sortedHTLCTXs |> List.map(fun htlc ->
+                            channelPrivKeys.SignHtlcTx htlc.Value localPerCommitmentPoint
+                        )
+                    localHtlcSigsAndHTLCTxs |> List.map(fst), localHtlcSigsAndHTLCTxs |> List.map(snd) |> Seq.cast<IHTLCTx> |> List.ofSeq
+
+                let remoteHTLCPubKey = localPerCommitmentPoint.DeriveHtlcPubKey remoteChannelKeys.HtlcBasepoint
+
+                let checkHTLCSig (htlc: IHTLCTx, remoteECDSASig: LNECDSASignature): Result<_, _> =
+                    let remoteS = TransactionSignature(remoteECDSASig.Value, SigHash.All)
+                    match htlc with
+                    | :? HTLCTimeoutTx ->
+                        (Transactions.checkTxFinalized (htlc.Value) (0) (seq [(remoteHTLCPubKey.RawPubKey(), remoteS)]))
+                        |> Result.map(box)
+                    // we cannot check that htlc-success tx are spendable because we need the payment preimage; thus we only check the remote sig
+                    | :? HTLCSuccessTx ->
+                        (Transactions.checkSigAndAdd (htlc) (remoteS) (remoteHTLCPubKey.RawPubKey()))
+                        |> Result.map(box)
+                    | _ -> failwith "Unreachable!"
+
+                let! txList =
+                    List.zip sortedHTLCTXs msg.HTLCSignatures
+                    |> List.map(checkHTLCSig)
+                    |> List.sequenceResultA
+                    |> expectTransactionErrors
+                let successTxs =
+                    txList |> List.choose(fun o ->
+                        match o with
+                        | :? HTLCSuccessTx as tx -> Some tx
+                        | _ -> None
+                    )
+                let finalizedTxs =
+                    txList |> List.choose(fun o ->
+                        match o with
+                        | :? FinalizedTx as tx -> Some tx
+                        | _ -> None
+                    )
+                let localPerCommitmentSecret =
+                    channelPrivKeys.CommitmentSeed.DerivePerCommitmentSecret savedChannelState.LocalCommit.Index
+                let localNextPerCommitmentPoint =
+                    let perCommitmentSecret =
+                        channelPrivKeys.CommitmentSeed.DerivePerCommitmentSecret
+                            (savedChannelState.LocalCommit.Index.NextCommitment().NextCommitment())
+                    perCommitmentSecret.PerCommitmentPoint()
+
+                let nextMsg = {
+                    RevokeAndACKMsg.ChannelId = savedChannelState.StaticChannelConfig.ChannelId()
+                    PerCommitmentSecret = localPerCommitmentSecret
+                    NextPerCommitmentPoint = localNextPerCommitmentPoint
+                }
+                
+                let localCommit1 = { LocalCommit.Index = savedChannelState.LocalCommit.Index.NextCommitment()
+                                     Spec = spec
+                                     PublishableTxs = { PublishableTxs.CommitTx = finalizedCommitTx
+                                                        HTLCTxs = finalizedTxs }
+                                     PendingHTLCSuccessTxs = successTxs }
+                let nextSavedChannelState = {
+                    savedChannelState with
+                        LocalCommit = localCommit1
+                        LocalChanges = {
+                            savedChannelState.LocalChanges with
+                                ACKed = []
+                        }
+                        RemoteChanges = {
+                            savedChannelState.RemoteChanges with
+                                ACKed = (savedChannelState.RemoteChanges.ACKed @ cm.ProposedRemoteChanges)
+                        }
+                }
+                let nextCommitments =
+                    let completedOutgoingHTLCs =
+                        let t1 = savedChannelState.LocalCommit.Spec.OutgoingHTLCs
+                                 |> Map.toSeq |> Seq.map (fun (k, _) -> k) |> Set.ofSeq
+                        let t2 = localCommit1.Spec.OutgoingHTLCs
+                                 |> Map.toSeq |> Seq.map (fun (k, _) -> k) |> Set.ofSeq
+                        Set.difference t1 t2
+                    let originChannels1 = cm.OriginChannels |> Map.filter(fun k _ -> Set.contains k completedOutgoingHTLCs)
+                    {
+                        cm with
+                            ProposedRemoteChanges = []
+                            OriginChannels = originChannels1
+                    }
+                let nextChannel = {
+                    self with
+                        SavedChannelState = nextSavedChannelState
+                        Commitments = nextCommitments
+                }
+                return nextMsg, nextChannel
+            }

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -1069,100 +1069,98 @@ and Channel = {
                 return channel, Some localShutdownMsg, None
     }
 
-module Channel =
+    member self.ApplyClosingSigned (msg: ClosingSignedMsg)
+                                       : Result<Channel * ClosingSignedResponse, ChannelError> = result {
+        let! localShutdownScriptPubKey, remoteShutdownScriptPubKey =
+            match (self.NegotiatingState.LocalRequestedShutdown, self.NegotiatingState.RemoteRequestedShutdown) with
+            | (Some localShutdownScriptPubKey, Some remoteShutdownScriptPubKey) ->
+                Ok (localShutdownScriptPubKey, remoteShutdownScriptPubKey)
+            // FIXME: these should be new channel errors
+            | (Some _, None) ->
+                Error ReceivedClosingSignedBeforeReceivingShutdown
+            | (None, Some _) ->
+                Error ReceivedClosingSignedBeforeSendingShutdown
+            | (None, None) ->
+                Error ReceivedClosingSignedBeforeSendingOrReceivingShutdown
+        let cm = self.Commitments
+        let remoteChannelKeys = self.StaticChannelConfig.RemoteChannelPubKeys
+        let lastCommitFeeSatoshi =
+            self.StaticChannelConfig.FundingScriptCoin.TxOut.Value - (cm.LocalCommit.PublishableTxs.CommitTx.Value.TotalOut)
+        do! checkRemoteProposedHigherFeeThanBaseFee lastCommitFeeSatoshi msg.FeeSatoshis
+        do!
+            checkRemoteProposedFeeWithinNegotiatedRange
+                (List.tryHead self.NegotiatingState.LocalClosingFeesProposed)
+                (Option.map (fun (fee, _sig) -> fee) self.NegotiatingState.RemoteClosingFeeProposed)
+                msg.FeeSatoshis
 
-    let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
-        match command with
-        | ApplyClosingSigned msg ->
-            result {
-                let! localShutdownScriptPubKey, remoteShutdownScriptPubKey =
-                    match (cs.NegotiatingState.LocalRequestedShutdown, cs.NegotiatingState.RemoteRequestedShutdown) with
-                    | (Some localShutdownScriptPubKey, Some remoteShutdownScriptPubKey) ->
-                        Ok (localShutdownScriptPubKey, remoteShutdownScriptPubKey)
-                    // FIXME: these should be new channel errors
-                    | (Some _, None) ->
-                        Error ReceivedClosingSignedBeforeReceivingShutdown
-                    | (None, Some _) ->
-                        Error ReceivedClosingSignedBeforeSendingShutdown
-                    | (None, None) ->
-                        Error ReceivedClosingSignedBeforeSendingOrReceivingShutdown
-                let cm = cs.Commitments
-                let remoteChannelKeys = cs.StaticChannelConfig.RemoteChannelPubKeys
-                let lastCommitFeeSatoshi =
-                    cs.StaticChannelConfig.FundingScriptCoin.TxOut.Value - (cm.LocalCommit.PublishableTxs.CommitTx.Value.TotalOut)
-                do! checkRemoteProposedHigherFeeThanBaseFee lastCommitFeeSatoshi msg.FeeSatoshis
-                do!
-                    checkRemoteProposedFeeWithinNegotiatedRange
-                        (List.tryHead cs.NegotiatingState.LocalClosingFeesProposed)
-                        (Option.map (fun (fee, _sig) -> fee) cs.NegotiatingState.RemoteClosingFeeProposed)
-                        msg.FeeSatoshis
-
-                let! closingTx, _closingSignedMsg =
-                    cs.MakeClosingTx
+        let! closingTx, _closingSignedMsg =
+            self.MakeClosingTx
+                localShutdownScriptPubKey
+                remoteShutdownScriptPubKey
+                msg.FeeSatoshis
+            |> expectTransactionError
+        let! finalizedTx =
+            Transactions.checkTxFinalized
+                closingTx.Value
+                closingTx.WhichInput
+                (seq [
+                    remoteChannelKeys.FundingPubKey.RawPubKey(),
+                    TransactionSignature(msg.Signature.Value, SigHash.All)
+                ])
+            |> expectTransactionError
+        let maybeLocalFee =
+            self.NegotiatingState.LocalClosingFeesProposed
+            |> List.tryHead
+        let areWeInDeal = Some(msg.FeeSatoshis) = maybeLocalFee
+        let hasTooManyNegotiationDone =
+            (self.NegotiatingState.LocalClosingFeesProposed |> List.length) >= self.ChannelOptions.MaxClosingNegotiationIterations
+        if (areWeInDeal || hasTooManyNegotiationDone) then
+            return self, MutualClose finalizedTx
+        else
+            let lastLocalClosingFee = self.NegotiatingState.LocalClosingFeesProposed |> List.tryHead
+            let! localF = 
+                match lastLocalClosingFee with
+                | Some v -> Ok v
+                | None ->
+                    self.FirstClosingFee
                         localShutdownScriptPubKey
                         remoteShutdownScriptPubKey
-                        msg.FeeSatoshis
                     |> expectTransactionError
-                let! finalizedTx =
-                    Transactions.checkTxFinalized
-                        closingTx.Value
-                        closingTx.WhichInput
-                        (seq [
-                            remoteChannelKeys.FundingPubKey.RawPubKey(),
-                            TransactionSignature(msg.Signature.Value, SigHash.All)
-                        ])
+            let nextClosingFee =
+                Channel.NextClosingFee (localF, msg.FeeSatoshis)
+            if (Some nextClosingFee = lastLocalClosingFee) then
+                return self, MutualClose finalizedTx
+            else if (nextClosingFee = msg.FeeSatoshis) then
+                // we have reached on agreement!
+                return self, MutualClose finalizedTx
+            else
+                let! _closingTx, closingSignedMsg =
+                    self.MakeClosingTx
+                        localShutdownScriptPubKey
+                        remoteShutdownScriptPubKey
+                        nextClosingFee
                     |> expectTransactionError
-                let maybeLocalFee =
-                    cs.NegotiatingState.LocalClosingFeesProposed
-                    |> List.tryHead
-                let areWeInDeal = Some(msg.FeeSatoshis) = maybeLocalFee
-                let hasTooManyNegotiationDone =
-                    (cs.NegotiatingState.LocalClosingFeesProposed |> List.length) >= cs.ChannelOptions.MaxClosingNegotiationIterations
-                if (areWeInDeal || hasTooManyNegotiationDone) then
-                    return [ MutualClosePerformed finalizedTx ]
-                else
-                    let lastLocalClosingFee = cs.NegotiatingState.LocalClosingFeesProposed |> List.tryHead
-                    let! localF = 
-                        match lastLocalClosingFee with
-                        | Some v -> Ok v
-                        | None ->
-                            cs.FirstClosingFee
-                                localShutdownScriptPubKey
-                                remoteShutdownScriptPubKey
-                            |> expectTransactionError
-                    let nextClosingFee =
-                        Channel.NextClosingFee (localF, msg.FeeSatoshis)
-                    if (Some nextClosingFee = lastLocalClosingFee) then
-                        return [ MutualClosePerformed finalizedTx ]
-                    else if (nextClosingFee = msg.FeeSatoshis) then
-                        // we have reached on agreement!
-                        return [ MutualClosePerformed finalizedTx ]
-                    else
-                        let! _closingTx, closingSignedMsg =
-                            cs.MakeClosingTx
-                                localShutdownScriptPubKey
-                                remoteShutdownScriptPubKey
-                                nextClosingFee
-                            |> expectTransactionError
-                        let nextState = {
-                            cs.NegotiatingState with
-                                LocalClosingFeesProposed =
-                                    nextClosingFee :: cs.NegotiatingState.LocalClosingFeesProposed
-                                RemoteClosingFeeProposed = Some (msg.FeeSatoshis, msg.Signature)
-                        }
-                        return [ WeProposedNewClosingSigned(closingSignedMsg, nextState) ]
-            }
+                let nextState = {
+                    self.NegotiatingState with
+                        LocalClosingFeesProposed =
+                            nextClosingFee :: self.NegotiatingState.LocalClosingFeesProposed
+                        RemoteClosingFeeProposed = Some (msg.FeeSatoshis, msg.Signature)
+                }
+                let channel = {
+                    self with
+                        NegotiatingState = nextState
+                }
+                return channel, NewClosingSigned closingSignedMsg
+    }
+
+module Channel =
+
+    let executeCommand (_cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
+        match command with
         | _cmd ->
             failwith "not implemented"
 
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
-        // -----  closing ------
-        | MutualClosePerformed _txToPublish -> c
-        | WeProposedNewClosingSigned(_msg, nextNegotiatingState) ->
-            {
-                c with
-                    NegotiatingState = nextNegotiatingState
-            }
         // ----- else -----
         | _otherEvent -> c

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -32,7 +32,7 @@ type ChannelWaitingForFundingSigned = {
                 self.ChannelPrivKeys.SignWithFundingPrivKey self.LocalCommitTx.Value
             let remoteSigPairOfLocalTx = (theirFundingPk,  TransactionSignature(msg.Signature.Value, SigHash.All))
             let sigPairs = seq [ remoteSigPairOfLocalTx; ]
-            Transactions.checkTxFinalized signedLocalCommitTx self.LocalCommitTx.WhichInput sigPairs |> expectTransactionError
+            Transactions.checkTxFinalized signedLocalCommitTx CommitTx.WhichInput sigPairs |> expectTransactionError
         let commitments = {
             LocalCommit = {
                 Index = CommitmentNumber.FirstCommitment
@@ -110,7 +110,7 @@ and ChannelWaitingForFundingCreated = {
         let theirSigPair = (self.RemoteChannelPubKeys.FundingPubKey.RawPubKey(), remoteTxSig)
         let sigPairs = seq [ theirSigPair ]
         let! finalizedCommitTx =
-            Transactions.checkTxFinalized (signedLocalCommitTx) (localCommitTx.WhichInput) sigPairs
+            Transactions.checkTxFinalized (signedLocalCommitTx) CommitTx.WhichInput sigPairs
             |> expectTransactionError
         let localSigOfRemoteCommit, _ =
             self.ChannelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -85,7 +85,6 @@ type ChannelWaitingForFundingSigned = {
         }
         let nextState = WaitForFundingConfirmed {
             Deferred = None
-            LastSent = Choice1Of2 self.LastSent
             InitialFeeRatePerKw = self.InitialFeeRatePerKw
         }
         let channel = {
@@ -201,7 +200,6 @@ and ChannelWaitingForFundingCreated = {
         }
         let nextState = WaitForFundingConfirmed {
             Deferred = None
-            LastSent = msgToSend |> Choice2Of2
             InitialFeeRatePerKw = self.InitialFeeRatePerKw
         }
         let channel = {

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -228,7 +228,6 @@ and ChannelWaitingForFundingTx = {
     FundingSatoshis: Money
     PushMSat: LNMoney
     InitFeeRatePerKw: FeeRatePerKw
-    FundingTxFeeRatePerKw: FeeRatePerKw
     LocalParams: LocalParams
     RemoteInit: InitMsg
     ChannelFlags: uint8
@@ -238,7 +237,7 @@ and ChannelWaitingForFundingTx = {
                                     : Result<FundingCreatedMsg * ChannelWaitingForFundingSigned, ChannelError> = result {
         let remoteParams = RemoteParams.FromAcceptChannel self.RemoteInit self.LastReceived
         let localParams = self.LocalParams
-        let commitmentSpec = CommitmentSpec.Create (self.FundingSatoshis.ToLNMoney() - self.PushMSat) self.PushMSat self.FundingTxFeeRatePerKw
+        let commitmentSpec = CommitmentSpec.Create (self.FundingSatoshis.ToLNMoney() - self.PushMSat) self.PushMSat self.InitFeeRatePerKw
         let commitmentSeed = self.ChannelPrivKeys.CommitmentSeed
         let fundingTxId = fundingTx.Value.GetTxId()
         let! (_localSpec, localCommitTx, remoteSpec, remoteCommitTx) =
@@ -307,7 +306,6 @@ and ChannelWaitingForAcceptChannel = {
     FundingSatoshis: Money
     PushMSat: LNMoney
     InitFeeRatePerKw: FeeRatePerKw
-    FundingTxFeeRatePerKw: FeeRatePerKw
     LocalParams: LocalParams
     RemoteInit: InitMsg
     ChannelFlags: uint8
@@ -342,7 +340,6 @@ and ChannelWaitingForAcceptChannel = {
             FundingSatoshis = self.FundingSatoshis
             PushMSat = self.PushMSat
             InitFeeRatePerKw = self.InitFeeRatePerKw
-            FundingTxFeeRatePerKw = self.FundingTxFeeRatePerKw
             LocalParams = self.LocalParams
             RemoteInit = self.RemoteInit
             ChannelFlags = self.ChannelFlags
@@ -375,7 +372,6 @@ and Channel = {
                                   fundingSatoshis: Money,
                                   pushMSat: LNMoney,
                                   initFeeRatePerKw: FeeRatePerKw,
-                                  fundingTxFeeRatePerKw: FeeRatePerKw,
                                   localParams: LocalParams,
                                   remoteInit: InitMsg,
                                   channelFlags: uint8,
@@ -419,7 +415,6 @@ and Channel = {
                     FundingSatoshis = fundingSatoshis
                     PushMSat = pushMSat
                     InitFeeRatePerKw = initFeeRatePerKw
-                    FundingTxFeeRatePerKw = fundingTxFeeRatePerKw
                     LocalParams = localParams
                     RemoteInit = remoteInit
                     ChannelFlags = channelFlags

--- a/src/DotNetLightning.Core/Channel/Channel.fs
+++ b/src/DotNetLightning.Core/Channel/Channel.fs
@@ -902,6 +902,30 @@ and Channel = {
                 }
     }
 
+    member self.Close (localShutdownScriptPubKey: ShutdownScriptPubKey)
+                          : Result<Channel * ShutdownMsg, ChannelError> = result {
+        if self.NegotiatingState.LocalRequestedShutdown.IsSome then
+            do! Error <| cannotCloseChannel "shutdown is already in progress"
+        do!
+            Validation.checkShutdownScriptPubKeyAcceptable
+                self.StaticChannelConfig.LocalStaticShutdownScriptPubKey
+                localShutdownScriptPubKey
+        if (self.Commitments.LocalHasUnsignedOutgoingHTLCs()) then
+            do! Error <| cannotCloseChannel "Cannot close with unsigned outgoing htlcs"
+        let shutdownMsg: ShutdownMsg = {
+            ChannelId = self.StaticChannelConfig.ChannelId()
+            ScriptPubKey = localShutdownScriptPubKey
+        }
+        let channel = {
+            self with
+                NegotiatingState = {
+                    self.NegotiatingState with
+                        LocalRequestedShutdown = Some localShutdownScriptPubKey
+                }
+        }
+        return channel, shutdownMsg
+    }
+
 module Channel =
 
     let private hex = NBitcoin.DataEncoders.HexEncoder()
@@ -955,22 +979,6 @@ module Channel =
 
     let executeCommand (cs: Channel) (command: ChannelCommand): Result<ChannelEvent list, ChannelError> =
         match command with
-        | ChannelCommand.Close localShutdownScriptPubKey ->
-            result {
-                if cs.NegotiatingState.LocalRequestedShutdown.IsSome then
-                    do! Error <| cannotCloseChannel "shutdown is already in progress"
-                do!
-                    Validation.checkShutdownScriptPubKeyAcceptable
-                        cs.StaticChannelConfig.LocalStaticShutdownScriptPubKey
-                        localShutdownScriptPubKey
-                if (cs.Commitments.LocalHasUnsignedOutgoingHTLCs()) then
-                    do! Error <| cannotCloseChannel "Cannot close with unsigned outgoing htlcs"
-                let shutdownMsg: ShutdownMsg = {
-                    ChannelId = cs.StaticChannelConfig.ChannelId()
-                    ScriptPubKey = localShutdownScriptPubKey
-                }
-                return [ AcceptedOperationShutdown(shutdownMsg, localShutdownScriptPubKey) ]
-            }
         | RemoteShutdown(msg, localShutdownScriptPubKey) ->
             result {
                 let remoteShutdownScriptPubKey = msg.ScriptPubKey
@@ -1171,14 +1179,6 @@ module Channel =
     let applyEvent c (e: ChannelEvent): Channel =
         match e with
         // -----  closing ------
-        | AcceptedOperationShutdown(_msg, shutdownScriptPubKey) ->
-            {
-                c with
-                    NegotiatingState = {
-                        c.NegotiatingState with
-                            LocalRequestedShutdown = Some shutdownScriptPubKey
-                    }
-            }
         | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs remoteShutdownScriptPubKey ->
             { 
                 c with

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -38,6 +38,7 @@ type ChannelError =
     // --- case they sent unacceptable msg ---
     | InvalidOpenChannel of InvalidOpenChannelError
     | InvalidAcceptChannel of InvalidAcceptChannelError
+    | InvalidMonoHopUnidirectionalPayment of InvalidMonoHopUnidirectionalPaymentError
     | InvalidUpdateAddHTLC of InvalidUpdateAddHTLCError
     | InvalidRevokeAndACK of InvalidRevokeAndACKError
     | InvalidUpdateFee of InvalidUpdateFeeError
@@ -71,6 +72,7 @@ type ChannelError =
         | TheyCannotAffordFee (_, _, _) -> Close
         | InvalidOpenChannel _ -> DistrustPeer
         | InvalidAcceptChannel _ -> DistrustPeer
+        | InvalidMonoHopUnidirectionalPayment _ -> Close
         | InvalidUpdateAddHTLC _ -> Close
         | InvalidRevokeAndACK _ -> Close
         | InvalidUpdateFee _ -> Close
@@ -129,6 +131,8 @@ type ChannelError =
             "Received commitment signed when we have not pending changes"
         | InvalidAcceptChannel invalidAcceptChannelError ->
             sprintf "Invalid accept_channel msg: %s" invalidAcceptChannelError.Message
+        | InvalidMonoHopUnidirectionalPayment invalidMonohopUnidirectionalPaymentError ->
+            sprintf "Invalid mono hop unidrectional payment: %s" invalidMonohopUnidirectionalPaymentError.Message
         | InvalidUpdateAddHTLC invalidUpdateAddHTLCError ->
             sprintf "Invalid udpate_add_htlc msg: %s" invalidUpdateAddHTLCError.Message
         | InvalidRevokeAndACK invalidRevokeAndACKError ->
@@ -181,6 +185,18 @@ and InvalidAcceptChannelError = {
     member this.Message =
         String.concat "; " this.Errors
     
+and InvalidMonoHopUnidirectionalPaymentError = {
+    NetworkMsg: MonoHopUnidirectionalPaymentMsg
+    Errors: string list
+}
+    with
+    static member Create msg e = {
+        NetworkMsg = msg
+        Errors = e
+    }
+    member this.Message =
+        String.concat "; " this.Errors
+
 and InvalidUpdateAddHTLCError = {
     NetworkMsg: UpdateAddHTLCMsg
     Errors: string list
@@ -509,6 +525,22 @@ module internal AcceptChannelMsgValidation =
 
         (check1 |> Validation.ofResult) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7
         
+module UpdateMonoHopUnidirectionalPaymentWithContext =
+    let internal checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
+        let fees =
+            if state.LocalParams.IsFunder then
+                Transactions.commitTxFee state.RemoteParams.DustLimitSatoshis currentSpec
+            else
+                Money.Zero
+        let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
+        if missing < Money.Zero then
+            sprintf "We don't have sufficient funds to send mono-hop unidirectional payment. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"
+                    (currentSpec.ToRemote.ToMoney())
+                    state.RemoteParams.ChannelReserveSatoshis
+                    fees
+            |> Error
+        else
+            Ok()
 
 module UpdateAddHTLCValidation =
     let internal checkExpiryIsNotPast (current: BlockHeight) (expiry) =
@@ -523,7 +555,23 @@ module UpdateAddHTLCValidation =
     let internal checkAmountIsLargerThanMinimum (htlcMinimum: LNMoney) (amount) =
         check (amount) (<) (htlcMinimum) "htlc value (%A) is too small. must be greater or equal to %A"
 
-    
+module internal MonoHopUnidirectionalPaymentValidationWithContext =
+    let checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
+        let fees =
+            if state.LocalParams.IsFunder then
+                Transactions.commitTxFee state.RemoteParams.DustLimitSatoshis currentSpec
+            else
+                Money.Zero
+        let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
+        if missing < Money.Zero then
+            sprintf "We don't have sufficient funds to send mono-hop unidirectional payment. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"
+                    (currentSpec.ToRemote.ToMoney())
+                    state.RemoteParams.ChannelReserveSatoshis
+                    fees
+            |> Error
+        else
+            Ok()
+
 module internal UpdateAddHTLCValidationWithContext =
     let checkLessThanHTLCValueInFlightLimit (currentSpec: CommitmentSpec) (limit) (add: UpdateAddHTLCMsg) =
         let htlcValueInFlight = currentSpec.HTLCs |> Map.toSeq |> Seq.sumBy (fun (_, v) -> v.Add.Amount)

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -455,10 +455,10 @@ module internal OpenChannelMsgValidation =
                 "dust_limit_satoshis is greater than the user specified limit. received: %A; limit: %A"
         Validation.ofResult(check1) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7
     let checkChannelAnnouncementPreferenceAcceptable (channelHandshakeLimits: ChannelHandshakeLimits)
-                                                     (channelOptions: ChannelOptions)
+                                                     (announceChannel: bool)
                                                      (msg: OpenChannelMsg) =
         let theirAnnounce = msg.ChannelFlags.AnnounceChannel
-        if (channelHandshakeLimits.ForceChannelAnnouncementPreference) && channelOptions.AnnounceChannel <> theirAnnounce then
+        if (channelHandshakeLimits.ForceChannelAnnouncementPreference) && announceChannel <> theirAnnounce then
             "Peer tried to open channel but their announcement preference is different from ours"
             |> Error
         else
@@ -572,17 +572,17 @@ module internal AcceptChannelMsgValidation =
         (check1 |> Validation.ofResult) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7
         
 module UpdateMonoHopUnidirectionalPaymentWithContext =
-    let internal checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
+    let internal checkWeHaveSufficientFunds (staticChannelConfig: StaticChannelConfig) (currentSpec) =
         let fees =
-            if state.IsFunder then
-                Transactions.commitTxFee state.RemoteParams.DustLimitSatoshis currentSpec
+            if staticChannelConfig.IsFunder then
+                Transactions.commitTxFee staticChannelConfig.RemoteParams.DustLimitSatoshis currentSpec
             else
                 Money.Zero
-        let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
+        let missing = currentSpec.ToRemote.ToMoney() - staticChannelConfig.RemoteParams.ChannelReserveSatoshis - fees
         if missing < Money.Zero then
             sprintf "We don't have sufficient funds to send mono-hop unidirectional payment. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"
                     (currentSpec.ToRemote.ToMoney())
-                    state.RemoteParams.ChannelReserveSatoshis
+                    staticChannelConfig.RemoteParams.ChannelReserveSatoshis
                     fees
             |> Error
         else
@@ -602,17 +602,17 @@ module UpdateAddHTLCValidation =
         check (amount) (<) (htlcMinimum) "htlc value (%A) is too small. must be greater or equal to %A"
 
 module internal MonoHopUnidirectionalPaymentValidationWithContext =
-    let checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
+    let checkWeHaveSufficientFunds (staticChannelConfig: StaticChannelConfig) (currentSpec) =
         let fees =
-            if state.IsFunder then
-                Transactions.commitTxFee state.RemoteParams.DustLimitSatoshis currentSpec
+            if staticChannelConfig.IsFunder then
+                Transactions.commitTxFee staticChannelConfig.RemoteParams.DustLimitSatoshis currentSpec
             else
                 Money.Zero
-        let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
+        let missing = currentSpec.ToRemote.ToMoney() - staticChannelConfig.RemoteParams.ChannelReserveSatoshis - fees
         if missing < Money.Zero then
             sprintf "We don't have sufficient funds to send mono-hop unidirectional payment. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"
                     (currentSpec.ToRemote.ToMoney())
-                    state.RemoteParams.ChannelReserveSatoshis
+                    staticChannelConfig.RemoteParams.ChannelReserveSatoshis
                     fees
             |> Error
         else
@@ -634,13 +634,19 @@ module internal UpdateAddHTLCValidationWithContext =
         let acceptedHTLCs = currentSpec.HTLCs |> Map.toSeq |> Seq.filter (fun kv -> (snd kv).Direction = In) |> Seq.length
         check acceptedHTLCs (>) (int limit) "We have much number of HTLCs (%A). Limit specified by remote is (%A). So not going to relay"
 
-    let checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
-        let fees = if (state.IsFunder) then (Transactions.commitTxFee (state.RemoteParams.DustLimitSatoshis) currentSpec) else Money.Zero
-        let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
+    let checkWeHaveSufficientFunds (staticChannelConfig: StaticChannelConfig) (currentSpec) =
+        let fees =
+            if staticChannelConfig.IsFunder then
+                Transactions.commitTxFee
+                    staticChannelConfig.RemoteParams.DustLimitSatoshis
+                    currentSpec
+            else
+                Money.Zero
+        let missing = currentSpec.ToRemote.ToMoney() - staticChannelConfig.RemoteParams.ChannelReserveSatoshis - fees
         if (missing < Money.Zero) then
             sprintf "We don't have sufficient funds to send HTLC. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"
                     (currentSpec.ToRemote.ToMoney())
-                    (state.RemoteParams.ChannelReserveSatoshis)
+                    (staticChannelConfig.RemoteParams.ChannelReserveSatoshis)
                     (fees)
             |> Error
         else

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -36,6 +36,7 @@ type ChannelError =
     | TheyCannotAffordFee of toRemote: LNMoney * fee: Money * channelReserve: Money
     
     // --- case they sent unacceptable msg ---
+    | InvalidFundingLocked of InvalidFundingLockedError
     | InvalidOpenChannel of InvalidOpenChannelError
     | InvalidAcceptChannel of InvalidAcceptChannelError
     | InvalidMonoHopUnidirectionalPayment of InvalidMonoHopUnidirectionalPaymentError
@@ -70,6 +71,7 @@ type ChannelError =
         | ReceivedShutdownWhenRemoteHasUnsignedOutgoingHTLCs _ -> Close
         | SignatureCountMismatch (_, _) -> Close
         | TheyCannotAffordFee (_, _, _) -> Close
+        | InvalidFundingLocked _ -> DistrustPeer
         | InvalidOpenChannel _ -> DistrustPeer
         | InvalidAcceptChannel _ -> DistrustPeer
         | InvalidMonoHopUnidirectionalPayment _ -> Close
@@ -102,6 +104,8 @@ type ChannelError =
             sprintf "Number of signatures went from the remote (%A) does not match the number expected (%A)" actual expected
         | TheyCannotAffordFee (toRemote, fee, channelReserve) ->
             sprintf "they are funder but cannot afford their fee. to_remote output is: %A; actual fee is %A; channel_reserve_satoshis is: %A" toRemote fee channelReserve
+        | InvalidFundingLocked invalidFundingLockedError ->
+            sprintf "Invalid funding_locked from the peer: %s" invalidFundingLockedError.Message
         | InvalidOpenChannel invalidOpenChannelError ->
             sprintf "Invalid open_channel from the peer.: %s" invalidOpenChannelError.Message
         | OnceConfirmedFundingTxHasBecomeUnconfirmed (height, depth) ->
@@ -161,6 +165,13 @@ and ChannelConsumerAction =
     /// The error is not critical to the channel operation.
     /// But it maybe good to report the log message, or maybe lower the peer score.
     | Ignore
+and InvalidFundingLockedError ={
+    NetworkMsg: FundingLockedMsg
+}
+    with
+    member this.Message =
+        "remote peer sent a second funding_locked message which does not match their first"
+
 and InvalidOpenChannelError = {
     NetworkMsg: OpenChannelMsg
     Errors: string list
@@ -302,7 +313,7 @@ module internal ChannelError =
         Result.mapError(FundingTxNotGiven) msg
         
     let invalidRevokeAndACK msg e =
-        InvalidRevokeAndACKError.Create msg ([e]) |> InvalidRevokeAndACK |> Error
+        InvalidRevokeAndACKError.Create msg ([e]) |> InvalidRevokeAndACK
         
     let cannotCloseChannel msg =
         msg |> CannotCloseChannel|> Error

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -50,7 +50,8 @@ type ChannelError =
     | OnceConfirmedFundingTxHasBecomeUnconfirmed of height: BlockHeight * depth: BlockHeightOffset32
     | CannotCloseChannel of msg: string
     | UndefinedStateAndCmdPair of state: ChannelState * cmd: ChannelCommand
-    | RemoteProposedHigherFeeThanBefore of previous: Money * current: Money
+    | RemoteProposedHigherFeeThanBaseFee of baseFee: Money * proposedFee: Money
+    | RemoteProposedFeeOutOfNegotiatedRange of ourPreviousFee: Money * theirPreviousFee: Money * theirNextFee: Money
     // ---- invalid command ----
     | InvalidOperationAddHTLC of InvalidOperationAddHTLCError
     // -------------------------
@@ -83,7 +84,8 @@ type ChannelError =
         | CannotCloseChannel _ -> Ignore
         | UndefinedStateAndCmdPair _ -> Ignore
         | InvalidOperationAddHTLC _ -> Ignore
-        | RemoteProposedHigherFeeThanBefore(_, _) -> Close
+        | RemoteProposedHigherFeeThanBaseFee(_, _) -> Close
+        | RemoteProposedFeeOutOfNegotiatedRange(_, _, _) -> Close
     
     member this.Message =
         match this with
@@ -114,9 +116,15 @@ type ChannelError =
             sprintf "They sent shutdown msg (%A) while they have pending unsigned HTLCs, this is protocol violation" msg
         | UndefinedStateAndCmdPair (state, cmd) ->
             sprintf "DotNetLightning does not know how to handle command (%A) while in state (%A)" cmd state
-        | RemoteProposedHigherFeeThanBefore(prev, current) ->
-            "remote proposed a commitment fee higher than the last commitment fee in the course of fee negotiation"
-            + sprintf "previous fee=%A; fee remote proposed=%A;" prev current
+        | RemoteProposedHigherFeeThanBaseFee(baseFee, proposedFee) ->
+            "remote proposed a closing fee higher than commitment fee of the final commitment transaction. "
+            + sprintf "commitment fee=%A; fee remote proposed=%A;" baseFee proposedFee
+        | RemoteProposedFeeOutOfNegotiatedRange(ourPreviousFee, theirPreviousFee, theirNextFee) ->
+            "remote proposed a closing fee which was not strictly between the previous fee that \
+            we proposed and the previous fee that they proposed. "
+            + sprintf
+                "our previous fee = %A; their previous fee = %A; their next fee = %A"
+                ourPreviousFee theirPreviousFee theirNextFee
         | CryptoError cryptoError ->
             sprintf "Crypto error: %s" cryptoError.Message
         | TransactionRelatedErrors transactionErrors ->
@@ -323,11 +331,30 @@ module internal ChannelError =
     let undefinedStateAndCmdPair state cmd =
         UndefinedStateAndCmdPair (state, cmd) |> Error
         
-    let checkRemoteProposedHigherFeeThanBefore prev curr =
-        if (prev < curr) then
-            RemoteProposedHigherFeeThanBefore(prev, curr) |> Error
+    let checkRemoteProposedHigherFeeThanBaseFee baseFee proposedFee =
+        if (baseFee < proposedFee) then
+            RemoteProposedHigherFeeThanBaseFee(baseFee, proposedFee) |> Error
         else
             Ok()
+
+    let checkRemoteProposedFeeWithinNegotiatedRange (ourPreviousFeeOpt: Option<Money>)
+                                                    (theirPreviousFeeOpt: Option<Money>)
+                                                    (theirNextFee: Money) =
+        match (ourPreviousFeeOpt, theirPreviousFeeOpt) with
+        | (Some ourPreviousFee, Some theirPreviousFee) ->
+            let feeWithinRange =
+                ((theirNextFee < theirPreviousFee) && (theirNextFee > ourPreviousFee)) ||
+                ((theirNextFee < ourPreviousFee) && (theirNextFee > theirPreviousFee))
+            if feeWithinRange then
+                Ok ()
+            else
+                RemoteProposedFeeOutOfNegotiatedRange(
+                    ourPreviousFee,
+                    theirPreviousFee,
+                    theirNextFee
+                ) |> Error
+        | _ -> Ok ()
+
 module internal OpenChannelMsgValidation =
     let checkMaxAcceptedHTLCs (msg: OpenChannelMsg) =
         if (msg.MaxAcceptedHTLCs < 1us) || (msg.MaxAcceptedHTLCs > 483us) then

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -479,27 +479,31 @@ module internal AcceptChannelMsgValidation =
         else
             Ok()
 
-    let checkChannelReserveSatoshis (state: Data.WaitForAcceptChannelData) msg =
-        if msg.ChannelReserveSatoshis > state.LastSent.FundingSatoshis then
-            sprintf "bogus channel_reserve_satoshis %A . Must be larger than funding_satoshis %A" (msg.ChannelReserveSatoshis) (state.InputInitFunder.FundingSatoshis)
+    let checkChannelReserveSatoshis (fundingSatoshis: Money)
+                                    (openChannelMsg: OpenChannelMsg)
+                                    (acceptChannelMsg: AcceptChannelMsg) =
+        if acceptChannelMsg.ChannelReserveSatoshis > openChannelMsg.FundingSatoshis then
+            sprintf "bogus channel_reserve_satoshis %A . Must be larger than funding_satoshis %A" (acceptChannelMsg.ChannelReserveSatoshis) fundingSatoshis
             |> Error
-        else if msg.DustLimitSatoshis > state.LastSent.ChannelReserveSatoshis then
-            sprintf "Bogus channel_reserve and dust_limit. dust_limit: %A; channel_reserve %A" msg.DustLimitSatoshis (state.LastSent.ChannelReserveSatoshis)
+        else if acceptChannelMsg.DustLimitSatoshis > openChannelMsg.ChannelReserveSatoshis then
+            sprintf "Bogus channel_reserve and dust_limit. dust_limit: %A; channel_reserve %A" acceptChannelMsg.DustLimitSatoshis (openChannelMsg.ChannelReserveSatoshis)
             |> Error
-        else if msg.ChannelReserveSatoshis < state.LastSent.DustLimitSatoshis then
-            sprintf "Peer never wants payout outputs? channel_reserve_satoshis are %A; dust_limit_satoshis in our last sent msg is %A" msg.ChannelReserveSatoshis (state.LastSent.DustLimitSatoshis)
+        else if acceptChannelMsg.ChannelReserveSatoshis < openChannelMsg.DustLimitSatoshis then
+            sprintf "Peer never wants payout outputs? channel_reserve_satoshis are %A; dust_limit_satoshis in our last sent msg is %A" acceptChannelMsg.ChannelReserveSatoshis (openChannelMsg.DustLimitSatoshis)
             |> Error
         else
             Ok()
 
-    let checkDustLimitIsLargerThanOurChannelReserve (state: Data.WaitForAcceptChannelData) msg =
+    let checkDustLimitIsLargerThanOurChannelReserve (openChannelMsg: OpenChannelMsg)
+                                                    (acceptChannelMsg: AcceptChannelMsg) =
         check
-            msg.DustLimitSatoshis (>) state.LastSent.ChannelReserveSatoshis
+            acceptChannelMsg.DustLimitSatoshis (>) openChannelMsg.ChannelReserveSatoshis
             "dust limit (%A) is bigger than our channel reserve (%A)" 
 
-    let checkMinimumHTLCValueIsAcceptable (state: Data.WaitForAcceptChannelData) (msg: AcceptChannelMsg) =
-        if (msg.HTLCMinimumMSat.ToMoney() >= (state.LastSent.FundingSatoshis - msg.ChannelReserveSatoshis)) then
-            sprintf "Minimum HTLC value is greater than full channel value HTLCMinimum %A satoshi; funding_satoshis %A; channel_reserve: %A" (msg.HTLCMinimumMSat.ToMoney()) (state.LastSent.FundingSatoshis) (msg.ChannelReserveSatoshis)
+    let checkMinimumHTLCValueIsAcceptable (openChannelMsg: OpenChannelMsg)
+                                          (acceptChannelMsg: AcceptChannelMsg) =
+        if (acceptChannelMsg.HTLCMinimumMSat.ToMoney() >= (openChannelMsg.FundingSatoshis - acceptChannelMsg.ChannelReserveSatoshis)) then
+            sprintf "Minimum HTLC value is greater than full channel value HTLCMinimum %A satoshi; funding_satoshis %A; channel_reserve: %A" (acceptChannelMsg.HTLCMinimumMSat.ToMoney()) (openChannelMsg.FundingSatoshis) (acceptChannelMsg.ChannelReserveSatoshis)
             |> Error
         else
             Ok()

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -480,30 +480,31 @@ module internal AcceptChannelMsgValidation =
             Ok()
 
     let checkChannelReserveSatoshis (fundingSatoshis: Money)
-                                    (openChannelMsg: OpenChannelMsg)
+                                    (channelReserveSatoshis: Money)
+                                    (dustLimitSatoshis: Money)
                                     (acceptChannelMsg: AcceptChannelMsg) =
-        if acceptChannelMsg.ChannelReserveSatoshis > openChannelMsg.FundingSatoshis then
+        if acceptChannelMsg.ChannelReserveSatoshis > fundingSatoshis then
             sprintf "bogus channel_reserve_satoshis %A . Must be larger than funding_satoshis %A" (acceptChannelMsg.ChannelReserveSatoshis) fundingSatoshis
             |> Error
-        else if acceptChannelMsg.DustLimitSatoshis > openChannelMsg.ChannelReserveSatoshis then
-            sprintf "Bogus channel_reserve and dust_limit. dust_limit: %A; channel_reserve %A" acceptChannelMsg.DustLimitSatoshis (openChannelMsg.ChannelReserveSatoshis)
+        else if acceptChannelMsg.DustLimitSatoshis > channelReserveSatoshis then
+            sprintf "Bogus channel_reserve and dust_limit. dust_limit: %A; channel_reserve %A" acceptChannelMsg.DustLimitSatoshis channelReserveSatoshis
             |> Error
-        else if acceptChannelMsg.ChannelReserveSatoshis < openChannelMsg.DustLimitSatoshis then
-            sprintf "Peer never wants payout outputs? channel_reserve_satoshis are %A; dust_limit_satoshis in our last sent msg is %A" acceptChannelMsg.ChannelReserveSatoshis (openChannelMsg.DustLimitSatoshis)
+        else if acceptChannelMsg.ChannelReserveSatoshis < dustLimitSatoshis then
+            sprintf "Peer never wants payout outputs? channel_reserve_satoshis are %A; dust_limit_satoshis in our last sent msg is %A" acceptChannelMsg.ChannelReserveSatoshis dustLimitSatoshis
             |> Error
         else
             Ok()
 
-    let checkDustLimitIsLargerThanOurChannelReserve (openChannelMsg: OpenChannelMsg)
+    let checkDustLimitIsLargerThanOurChannelReserve (channelReserveSatoshis: Money)
                                                     (acceptChannelMsg: AcceptChannelMsg) =
         check
-            acceptChannelMsg.DustLimitSatoshis (>) openChannelMsg.ChannelReserveSatoshis
+            acceptChannelMsg.DustLimitSatoshis (>) channelReserveSatoshis
             "dust limit (%A) is bigger than our channel reserve (%A)" 
 
-    let checkMinimumHTLCValueIsAcceptable (openChannelMsg: OpenChannelMsg)
+    let checkMinimumHTLCValueIsAcceptable (fundingSatoshis: Money)
                                           (acceptChannelMsg: AcceptChannelMsg) =
-        if (acceptChannelMsg.HTLCMinimumMSat.ToMoney() >= (openChannelMsg.FundingSatoshis - acceptChannelMsg.ChannelReserveSatoshis)) then
-            sprintf "Minimum HTLC value is greater than full channel value HTLCMinimum %A satoshi; funding_satoshis %A; channel_reserve: %A" (acceptChannelMsg.HTLCMinimumMSat.ToMoney()) (openChannelMsg.FundingSatoshis) (acceptChannelMsg.ChannelReserveSatoshis)
+        if (acceptChannelMsg.HTLCMinimumMSat.ToMoney() >= (fundingSatoshis - acceptChannelMsg.ChannelReserveSatoshis)) then
+            sprintf "Minimum HTLC value is greater than full channel value HTLCMinimum %A satoshi; funding_satoshis %A; channel_reserve: %A" (acceptChannelMsg.HTLCMinimumMSat.ToMoney()) (fundingSatoshis) (acceptChannelMsg.ChannelReserveSatoshis)
             |> Error
         else
             Ok()

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -46,10 +46,12 @@ type ChannelError =
     // ------------------
     
     /// Consumer of the api (usually, that is wallet) failed to give an funding tx
+    | ReceivedClosingSignedBeforeReceivingShutdown
+    | ReceivedClosingSignedBeforeSendingShutdown
+    | ReceivedClosingSignedBeforeSendingOrReceivingShutdown
     | FundingTxNotGiven of msg: string
     | OnceConfirmedFundingTxHasBecomeUnconfirmed of height: BlockHeight * depth: BlockHeightOffset32
     | CannotCloseChannel of msg: string
-    | UndefinedStateAndCmdPair of state: ChannelState * cmd: ChannelCommand
     | RemoteProposedHigherFeeThanBaseFee of baseFee: Money * proposedFee: Money
     | RemoteProposedFeeOutOfNegotiatedRange of ourPreviousFee: Money * theirPreviousFee: Money * theirNextFee: Money
     // ---- invalid command ----
@@ -79,10 +81,12 @@ type ChannelError =
         | InvalidUpdateAddHTLC _ -> Close
         | InvalidRevokeAndACK _ -> Close
         | InvalidUpdateFee _ -> Close
+        | ReceivedClosingSignedBeforeReceivingShutdown -> Close
+        | ReceivedClosingSignedBeforeSendingShutdown -> Close
+        | ReceivedClosingSignedBeforeSendingOrReceivingShutdown -> Close
         | FundingTxNotGiven _ -> Ignore
         | OnceConfirmedFundingTxHasBecomeUnconfirmed _ -> Close
         | CannotCloseChannel _ -> Ignore
-        | UndefinedStateAndCmdPair _ -> Ignore
         | InvalidOperationAddHTLC _ -> Ignore
         | RemoteProposedHigherFeeThanBaseFee(_, _) -> Close
         | RemoteProposedFeeOutOfNegotiatedRange(_, _, _) -> Close
@@ -114,8 +118,6 @@ type ChannelError =
             sprintf "once confirmed funding tx has become less confirmed than threshold %A! This is probably caused by reorg. current depth is: %A " height depth
         | ReceivedShutdownWhenRemoteHasUnsignedOutgoingHTLCs msg ->
             sprintf "They sent shutdown msg (%A) while they have pending unsigned HTLCs, this is protocol violation" msg
-        | UndefinedStateAndCmdPair (state, cmd) ->
-            sprintf "DotNetLightning does not know how to handle command (%A) while in state (%A)" cmd state
         | RemoteProposedHigherFeeThanBaseFee(baseFee, proposedFee) ->
             "remote proposed a closing fee higher than commitment fee of the final commitment transaction. "
             + sprintf "commitment fee=%A; fee remote proposed=%A;" baseFee proposedFee
@@ -151,6 +153,12 @@ type ChannelError =
             sprintf "Invalid revoke_and_ack msg: %s" invalidRevokeAndACKError.Message
         | InvalidUpdateFee invalidUpdateFeeError ->
             sprintf "Invalid update_fee msg: %s" invalidUpdateFeeError.Message
+        | ReceivedClosingSignedBeforeReceivingShutdown ->
+            sprintf "received closing_signed before receiving shutdown"
+        | ReceivedClosingSignedBeforeSendingShutdown ->
+            sprintf "received closing_signed before sending shutdown"
+        | ReceivedClosingSignedBeforeSendingOrReceivingShutdown ->
+            sprintf "received closing_signed before sending or receiving shutdown"
         | FundingTxNotGiven msg ->
             sprintf "Funding tx not given: %s" msg
         | CannotCloseChannel msg ->
@@ -328,8 +336,6 @@ module internal ChannelError =
 
     let receivedShutdownWhenRemoteHasUnsignedOutgoingHTLCs msg =
         msg |> ReceivedShutdownWhenRemoteHasUnsignedOutgoingHTLCs |> Error
-    let undefinedStateAndCmdPair state cmd =
-        UndefinedStateAndCmdPair (state, cmd) |> Error
         
     let checkRemoteProposedHigherFeeThanBaseFee baseFee proposedFee =
         if (baseFee < proposedFee) then

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -54,6 +54,8 @@ type ChannelError =
     | CannotCloseChannel of msg: string
     | RemoteProposedHigherFeeThanBaseFee of baseFee: Money * proposedFee: Money
     | RemoteProposedFeeOutOfNegotiatedRange of ourPreviousFee: Money * theirPreviousFee: Money * theirNextFee: Money
+    | NoUpdatesToSign
+    | CannotSignCommitmentBeforeRevocation
     // ---- invalid command ----
     | InvalidOperationAddHTLC of InvalidOperationAddHTLCError
     // -------------------------
@@ -87,6 +89,8 @@ type ChannelError =
         | FundingTxNotGiven _ -> Ignore
         | OnceConfirmedFundingTxHasBecomeUnconfirmed _ -> Close
         | CannotCloseChannel _ -> Ignore
+        | NoUpdatesToSign -> Ignore
+        | CannotSignCommitmentBeforeRevocation -> Ignore
         | InvalidOperationAddHTLC _ -> Ignore
         | RemoteProposedHigherFeeThanBaseFee(_, _) -> Close
         | RemoteProposedFeeOutOfNegotiatedRange(_, _, _) -> Close
@@ -163,6 +167,10 @@ type ChannelError =
             sprintf "Funding tx not given: %s" msg
         | CannotCloseChannel msg ->
             sprintf "Cannot close channel: %s" msg
+        | NoUpdatesToSign ->
+            "No updates to sign"
+        | CannotSignCommitmentBeforeRevocation ->
+            "Cannot sign commitment before previous commitment is revoked"
         | InvalidOperationAddHTLC invalidOperationAddHTLCError ->
             sprintf "Invalid operation (add htlc): %s" invalidOperationAddHTLCError.Message
 

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -316,7 +316,7 @@ module internal ChannelError =
         InvalidRevokeAndACKError.Create msg ([e]) |> InvalidRevokeAndACK
         
     let cannotCloseChannel msg =
-        msg |> CannotCloseChannel|> Error
+        msg |> CannotCloseChannel
 
     let receivedShutdownWhenRemoteHasUnsignedOutgoingHTLCs msg =
         msg |> ReceivedShutdownWhenRemoteHasUnsignedOutgoingHTLCs |> Error

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -530,7 +530,7 @@ module internal AcceptChannelMsgValidation =
 module UpdateMonoHopUnidirectionalPaymentWithContext =
     let internal checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
         let fees =
-            if state.LocalParams.IsFunder then
+            if state.IsFunder then
                 Transactions.commitTxFee state.RemoteParams.DustLimitSatoshis currentSpec
             else
                 Money.Zero
@@ -560,7 +560,7 @@ module UpdateAddHTLCValidation =
 module internal MonoHopUnidirectionalPaymentValidationWithContext =
     let checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
         let fees =
-            if state.LocalParams.IsFunder then
+            if state.IsFunder then
                 Transactions.commitTxFee state.RemoteParams.DustLimitSatoshis currentSpec
             else
                 Money.Zero
@@ -591,7 +591,7 @@ module internal UpdateAddHTLCValidationWithContext =
         check acceptedHTLCs (>) (int limit) "We have much number of HTLCs (%A). Limit specified by remote is (%A). So not going to relay"
 
     let checkWeHaveSufficientFunds (state: Commitments) (currentSpec) =
-        let fees = if (state.LocalParams.IsFunder) then (Transactions.commitTxFee (state.RemoteParams.DustLimitSatoshis) currentSpec) else Money.Zero
+        let fees = if (state.IsFunder) then (Transactions.commitTxFee (state.RemoteParams.DustLimitSatoshis) currentSpec) else Money.Zero
         let missing = currentSpec.ToRemote.ToMoney() - state.RemoteParams.ChannelReserveSatoshis - fees
         if (missing < Money.Zero) then
             sprintf "We don't have sufficient funds to send HTLC. current to_remote amount is: %A. Remote Channel Reserve is: %A. and fee is %A"

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -257,11 +257,6 @@ module private ValidationHelper =
 /// Helpers to create channel error
 [<AutoOpen>]
 module internal ChannelError =
-    let feeRateMismatch (FeeRatePerKw remote, FeeRatePerKw local) =
-        let remote = float remote
-        let local = float local
-        abs (2.0 * (remote - local) / (remote + local))
-
     let inline feeDeltaTooHigh msg (actualDelta, maxAccepted) =
         InvalidUpdateFeeError.Create
             msg
@@ -368,7 +363,7 @@ module internal OpenChannelMsgValidation =
                        (maxFeeRateMismatchRatio: float) =
         let localFeeRatePerKw =
             feeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.Background)
-        let diff = feeRateMismatch(remoteFeeRatePerKw, localFeeRatePerKw)
+        let diff = remoteFeeRatePerKw.MismatchRatio localFeeRatePerKw
         if (diff > maxFeeRateMismatchRatio) then
             sprintf
                 "Peer's feerate (%A) was unacceptably far from the estimated fee rate of %A"
@@ -602,7 +597,7 @@ module internal UpdateAddHTLCValidationWithContext =
 module internal UpdateFeeValidation =
     let checkFeeDiffTooHigh (msg: UpdateFeeMsg) (localFeeRatePerKw: FeeRatePerKw) (maxFeeRateMismatchRatio) =
         let remoteFeeRatePerKw = msg.FeeRatePerKw
-        let diff = feeRateMismatch(remoteFeeRatePerKw, localFeeRatePerKw)
+        let diff = remoteFeeRatePerKw.MismatchRatio localFeeRatePerKw
         if (diff > maxFeeRateMismatchRatio) then
             (diff, maxFeeRateMismatchRatio)
             |> feeDeltaTooHigh msg

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -410,9 +410,11 @@ module internal OpenChannelMsgValidation =
                 msg.DustLimitSatoshis (>) config.MaxDustLimitSatoshis
                 "dust_limit_satoshis is greater than the user specified limit. received: %A; limit: %A"
         Validation.ofResult(check1) *^> check2 *^> check3 *^> check4 *^> check5 *^> check6 *^> check7
-    let checkChannelAnnouncementPreferenceAcceptable (config: ChannelConfig) (msg: OpenChannelMsg) =
+    let checkChannelAnnouncementPreferenceAcceptable (channelHandshakeLimits: ChannelHandshakeLimits)
+                                                     (channelOptions: ChannelOptions)
+                                                     (msg: OpenChannelMsg) =
         let theirAnnounce = (msg.ChannelFlags &&& 1uy) = 1uy
-        if (config.PeerChannelConfigLimits.ForceChannelAnnouncementPreference) && config.ChannelOptions.AnnounceChannel <> theirAnnounce then
+        if (channelHandshakeLimits.ForceChannelAnnouncementPreference) && channelOptions.AnnounceChannel <> theirAnnounce then
             "Peer tried to open channel but their announcement preference is different from ours"
             |> Error
         else

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -620,7 +620,15 @@ module internal MonoHopUnidirectionalPaymentValidationWithContext =
 
 module internal UpdateAddHTLCValidationWithContext =
     let checkLessThanHTLCValueInFlightLimit (currentSpec: CommitmentSpec) (limit) (add: UpdateAddHTLCMsg) =
-        let htlcValueInFlight = currentSpec.HTLCs |> Map.toSeq |> Seq.sumBy (fun (_, v) -> v.Add.Amount)
+        let outgoingValue =
+            currentSpec.OutgoingHTLCs
+            |> Map.toSeq
+            |> Seq.sumBy (fun (_, v) -> v.Amount)
+        let incomingValue =
+            currentSpec.IncomingHTLCs
+            |> Map.toSeq
+            |> Seq.sumBy (fun (_, v) -> v.Amount)
+        let htlcValueInFlight = outgoingValue + incomingValue
         if (htlcValueInFlight > limit) then
             sprintf "Too much HTLC value is in flight. Current: %A. Limit: %A \n Could not add new one with value: %A"
                     htlcValueInFlight
@@ -631,7 +639,7 @@ module internal UpdateAddHTLCValidationWithContext =
             Ok()
 
     let checkLessThanMaxAcceptedHTLC (currentSpec: CommitmentSpec) (limit: uint16) =
-        let acceptedHTLCs = currentSpec.HTLCs |> Map.toSeq |> Seq.filter (fun kv -> (snd kv).Direction = In) |> Seq.length
+        let acceptedHTLCs = currentSpec.IncomingHTLCs |> Map.count
         check acceptedHTLCs (>) (int limit) "We have much number of HTLCs (%A). Limit specified by remote is (%A). So not going to relay"
 
     let checkWeHaveSufficientFunds (staticChannelConfig: StaticChannelConfig) (currentSpec) =

--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -451,7 +451,7 @@ module internal OpenChannelMsgValidation =
     let checkChannelAnnouncementPreferenceAcceptable (channelHandshakeLimits: ChannelHandshakeLimits)
                                                      (channelOptions: ChannelOptions)
                                                      (msg: OpenChannelMsg) =
-        let theirAnnounce = (msg.ChannelFlags &&& 1uy) = 1uy
+        let theirAnnounce = msg.ChannelFlags.AnnounceChannel
         if (channelHandshakeLimits.ForceChannelAnnouncementPreference) && channelOptions.AnnounceChannel <> theirAnnounce then
             "Peer tried to open channel but their announcement preference is different from ours"
             |> Error

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -153,3 +153,25 @@ type ChannelCommand =
     | ForceClose
     | GetState
     | GetStateData
+
+
+/// Channel config which is static, ie. config parameters which are established
+/// during the channel handshake and persist unchagned through the lifetime of
+/// the channel.
+type StaticChannelConfig = {
+    AnnounceChannel: bool
+    RemoteNodeId: NodeId
+    Network: Network
+    FundingTxMinimumDepth: BlockHeightOffset32
+    LocalStaticShutdownScriptPubKey: Option<ShutdownScriptPubKey>
+    RemoteStaticShutdownScriptPubKey: Option<ShutdownScriptPubKey>
+    IsFunder: bool
+    FundingScriptCoin: ScriptCoin
+    LocalParams: LocalParams
+    RemoteParams: RemoteParams
+    RemoteChannelPubKeys: ChannelPubKeys
+}
+    with
+        member this.ChannelId(): ChannelId =
+            this.FundingScriptCoin.Outpoint.ToChannelId()
+

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | ApplyMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg
     | AddHTLC of OperationAddHTLC
     | ApplyUpdateAddHTLC of msg: UpdateAddHTLCMsg * currentHeight: BlockHeight
     | FulfillHTLC of OperationFulfillHTLC

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | SignCommitment
     | ApplyCommitmentSigned of CommitmentSignedMsg
     | ApplyRevokeAndACK of RevokeAndACKMsg
 

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -192,7 +192,6 @@ and InputInitFundee = {
 /// It is just an input to the state.
 type ChannelCommand =
     // open: funder
-    | CreateOutbound of InputInitFunder
     | ApplyAcceptChannel of AcceptChannelMsg
     | CreateFundingTx of fundingTx: FinalizedTx * outIndex: TxOutIndex
     | ApplyFundingSigned of FundingSignedMsg
@@ -200,7 +199,6 @@ type ChannelCommand =
     | ApplyFundingConfirmedOnBC of height: BlockHeight * txIndex: TxIndexInBlock * depth: BlockHeightOffset32
 
     // open: fundee
-    | CreateInbound of InputInitFundee
     | ApplyOpenChannel of OpenChannelMsg
     | ApplyFundingCreated of FundingCreatedMsg
 

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -63,7 +63,6 @@ type OperationUpdateFee = {
 }
 
 type LocalParams = {
-    ChannelPubKeys: ChannelPubKeys
     DustLimitSatoshis: Money
     MaxHTLCValueInFlightMSat: LNMoney
     ChannelReserveSatoshis: Money
@@ -80,18 +79,10 @@ type RemoteParams = {
     HTLCMinimumMSat: LNMoney
     ToSelfDelay: BlockHeightOffset16
     MaxAcceptedHTLCs: uint16
-    ChannelPubKeys: ChannelPubKeys
     Features: FeatureBits
 }
     with
         static member FromAcceptChannel (remoteInit: InitMsg) (msg: AcceptChannelMsg) =
-            let channelPubKeys = {
-                FundingPubKey = msg.FundingPubKey
-                RevocationBasepoint = msg.RevocationBasepoint
-                PaymentBasepoint = msg.PaymentBasepoint
-                DelayedPaymentBasepoint = msg.DelayedPaymentBasepoint
-                HtlcBasepoint = msg.HTLCBasepoint
-            }
             {
                 DustLimitSatoshis = msg.DustLimitSatoshis
                 MaxHTLCValueInFlightMSat = msg.MaxHTLCValueInFlightMsat
@@ -99,20 +90,12 @@ type RemoteParams = {
                 HTLCMinimumMSat = msg.HTLCMinimumMSat
                 ToSelfDelay = msg.ToSelfDelay
                 MaxAcceptedHTLCs = msg.MaxAcceptedHTLCs
-                ChannelPubKeys = channelPubKeys
                 Features = remoteInit.Features
             }
 
         static member FromOpenChannel (remoteInit: InitMsg)
                                       (msg: OpenChannelMsg)
                                           : RemoteParams =
-            let channelPubKeys = {
-                FundingPubKey = msg.FundingPubKey
-                RevocationBasepoint = msg.RevocationBasepoint
-                PaymentBasepoint = msg.PaymentBasepoint
-                DelayedPaymentBasepoint = msg.DelayedPaymentBasepoint
-                HtlcBasepoint = msg.HTLCBasepoint
-            }
             {
                 DustLimitSatoshis = msg.DustLimitSatoshis
                 MaxHTLCValueInFlightMSat = msg.MaxHTLCValueInFlightMsat
@@ -120,7 +103,6 @@ type RemoteParams = {
                 HTLCMinimumMSat = msg.HTLCMinimumMsat
                 ToSelfDelay = msg.ToSelfDelay
                 MaxAcceptedHTLCs = msg.MaxAcceptedHTLCs
-                ChannelPubKeys = channelPubKeys
                 Features = remoteInit.Features
             }
 

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -123,9 +123,6 @@ type ChannelCommand =
     | ApplyOpenChannel of OpenChannelMsg
     | ApplyFundingCreated of FundingCreatedMsg
 
-    // close
-    | ApplyClosingSigned of ClosingSignedMsg
-
     // else
     | ForceClose
     | GetState

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | UpdateFee of OperationUpdateFee
     | ApplyUpdateFee of UpdateFeeMsg
 
     | SignCommitment

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -62,19 +62,6 @@ type OperationUpdateFee = {
     FeeRatePerKw: FeeRatePerKw
 }
 
-type OperationClose = private { ScriptPubKey: Script option }
-    with
-    static member Zero = { ScriptPubKey = None }
-    static member Create scriptPubKey =
-        result {
-            do! Scripts.checkIsValidFinalScriptPubKey scriptPubKey
-            return  { ScriptPubKey = Some scriptPubKey }
-        }
-
-module OperationClose =
-    let value cmdClose =
-        cmdClose.ScriptPubKey
-
 type LocalParams = {
     ChannelPubKeys: ChannelPubKeys
     DustLimitSatoshis: Money
@@ -84,7 +71,6 @@ type LocalParams = {
     ToSelfDelay: BlockHeightOffset16
     MaxAcceptedHTLCs: uint16
     IsFunder: bool
-    DefaultFinalScriptPubKey: Script
     Features: FeatureBits
 }
 
@@ -222,9 +208,9 @@ type ChannelCommand =
     | ApplyRevokeAndACK of RevokeAndACKMsg
 
     // close
-    | Close of OperationClose
+    | Close of ShutdownScriptPubKey
     | ApplyClosingSigned of ClosingSignedMsg
-    | RemoteShutdown of ShutdownMsg
+    | RemoteShutdown of ShutdownMsg * ShutdownScriptPubKey
 
     // else
     | ForceClose

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -125,8 +125,6 @@ type ChannelCommand =
     | ApplyOpenChannel of OpenChannelMsg
     | ApplyFundingCreated of FundingCreatedMsg
 
-    | CreateChannelReestablish
-
     // normal
     | MonoHopUnidirectionalPayment of OperationMonoHopUnidirectionalPayment
     | ApplyMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -125,7 +125,6 @@ type ChannelCommand =
 
     // close
     | ApplyClosingSigned of ClosingSignedMsg
-    | RemoteShutdown of ShutdownMsg * ShutdownScriptPubKey
 
     // else
     | ForceClose

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | FulfillHTLC of OperationFulfillHTLC
     | ApplyUpdateFulfillHTLC of UpdateFulfillHTLCMsg
     | FailHTLC of OperationFailHTLC
     | ApplyUpdateFailHTLC of UpdateFailHTLCMsg

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | FailHTLC of OperationFailHTLC
     | ApplyUpdateFailHTLC of UpdateFailHTLCMsg
     | FailMalformedHTLC of OperationFailMalformedHTLC
     | ApplyUpdateFailMalformedHTLC of UpdateFailMalformedHTLCMsg

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,8 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | ApplyUpdateFee of UpdateFeeMsg
-
     | SignCommitment
     | ApplyCommitmentSigned of CommitmentSignedMsg
     | ApplyRevokeAndACK of RevokeAndACKMsg

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | ApplyUpdateAddHTLC of msg: UpdateAddHTLCMsg * currentHeight: BlockHeight
     | FulfillHTLC of OperationFulfillHTLC
     | ApplyUpdateFulfillHTLC of UpdateFulfillHTLCMsg
     | FailHTLC of OperationFailHTLC

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | MonoHopUnidirectionalPayment of OperationMonoHopUnidirectionalPayment
     | ApplyMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg
     | AddHTLC of OperationAddHTLC
     | ApplyUpdateAddHTLC of msg: UpdateAddHTLCMsg * currentHeight: BlockHeight

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -11,6 +11,7 @@ open DotNetLightning.Transactions
 open DotNetLightning.Serialization
 
 open NBitcoin
+open Aether
 
 open ResultUtils
 open ResultUtils.Portability
@@ -175,3 +176,19 @@ type StaticChannelConfig = {
         member this.ChannelId(): ChannelId =
             this.FundingScriptCoin.Outpoint.ToChannelId()
 
+type ChannelOptions = {
+    MaxFeeRateMismatchRatio: float
+    // Amount (in millionth of a satoshi) the channel will charge per transferred satoshi.
+    // This may be allowed to change at runtime in a later update, however doing so must result in
+    // update messages sent to notify all nodes of our updated relay fee.
+    FeeProportionalMillionths: uint32
+    /// We don't exchange more than this many signatures when negotiating the closing fee
+    MaxClosingNegotiationIterations: int32
+    FeeEstimator: IFeeEstimator
+ }
+    with
+
+    static member FeeProportionalMillionths_: Lens<_, _> =
+        (fun cc -> cc.FeeProportionalMillionths),
+        (fun v cc -> { cc with FeeProportionalMillionths = v })
+        

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -123,9 +123,6 @@ type ChannelCommand =
     | ApplyOpenChannel of OpenChannelMsg
     | ApplyFundingCreated of FundingCreatedMsg
 
-    // normal
-    | ApplyRevokeAndACK of RevokeAndACKMsg
-
     // close
     | Close of ShutdownScriptPubKey
     | ApplyClosingSigned of ClosingSignedMsg

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | ApplyUpdateFulfillHTLC of UpdateFulfillHTLCMsg
     | FailHTLC of OperationFailHTLC
     | ApplyUpdateFailHTLC of UpdateFailHTLCMsg
     | FailMalformedHTLC of OperationFailMalformedHTLC

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | ApplyUpdateFailMalformedHTLC of UpdateFailMalformedHTLCMsg
     | UpdateFee of OperationUpdateFee
     | ApplyUpdateFee of UpdateFeeMsg
 

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | ApplyUpdateFailHTLC of UpdateFailHTLCMsg
     | ApplyUpdateFailMalformedHTLC of UpdateFailMalformedHTLCMsg
     | UpdateFee of OperationUpdateFee
     | ApplyUpdateFee of UpdateFeeMsg

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | ApplyCommitmentSigned of CommitmentSignedMsg
     | ApplyRevokeAndACK of RevokeAndACKMsg
 
     // close

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -125,7 +125,6 @@ type ChannelCommand =
 
     // normal
     | ApplyUpdateFailHTLC of UpdateFailHTLCMsg
-    | FailMalformedHTLC of OperationFailMalformedHTLC
     | ApplyUpdateFailMalformedHTLC of UpdateFailMalformedHTLCMsg
     | UpdateFee of OperationUpdateFee
     | ApplyUpdateFee of UpdateFeeMsg

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -76,7 +76,6 @@ module OperationClose =
         cmdClose.ScriptPubKey
 
 type LocalParams = {
-    NodeId: NodeId
     ChannelPubKeys: ChannelPubKeys
     DustLimitSatoshis: Money
     MaxHTLCValueInFlightMSat: LNMoney

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -98,7 +98,6 @@ type RemoteParams = {
     MaxAcceptedHTLCs: uint16
     ChannelPubKeys: ChannelPubKeys
     Features: FeatureBits
-    MinimumDepth: BlockHeightOffset32
 }
     with
         static member FromAcceptChannel nodeId (remoteInit: InitMsg) (msg: AcceptChannelMsg) =
@@ -119,10 +118,12 @@ type RemoteParams = {
                 MaxAcceptedHTLCs = msg.MaxAcceptedHTLCs
                 ChannelPubKeys = channelPubKeys
                 Features = remoteInit.Features
-                MinimumDepth = msg.MinimumDepth
             }
 
-        static member FromOpenChannel (nodeId) (remoteInit: InitMsg) (msg: OpenChannelMsg) (channelHandshakeConfig: ChannelHandshakeConfig) =
+        static member FromOpenChannel (nodeId: NodeId)
+                                      (remoteInit: InitMsg)
+                                      (msg: OpenChannelMsg)
+                                          : RemoteParams =
             let channelPubKeys = {
                 FundingPubKey = msg.FundingPubKey
                 RevocationBasepoint = msg.RevocationBasepoint
@@ -140,7 +141,6 @@ type RemoteParams = {
                 MaxAcceptedHTLCs = msg.MaxAcceptedHTLCs
                 ChannelPubKeys = channelPubKeys
                 Features = remoteInit.Features
-                MinimumDepth = channelHandshakeConfig.MinimumDepth
             }
 
 type InputInitFunder = {

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // close
-    | Close of ShutdownScriptPubKey
     | ApplyClosingSigned of ClosingSignedMsg
     | RemoteShutdown of ShutdownMsg * ShutdownScriptPubKey
 

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -118,7 +118,6 @@ type ChannelCommand =
     | ApplyAcceptChannel of AcceptChannelMsg
     | CreateFundingTx of fundingTx: FinalizedTx * outIndex: TxOutIndex
     | ApplyFundingSigned of FundingSignedMsg
-    | ApplyFundingConfirmedOnBC of height: BlockHeight * txIndex: TxIndexInBlock * depth: BlockHeightOffset32
 
     // open: fundee
     | ApplyOpenChannel of OpenChannelMsg

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -107,28 +107,6 @@ type RemoteParams = {
                 Features = remoteInit.Features
             }
 
-/// possible input to the channel. Command prefixed from `Apply` is passive. i.e.
-/// it has caused by the outside world and not by the user. Mostly this is a message sent
-/// from this channel's remote peer.
-/// others are active commands which is caused by the user.
-/// However, these two kinds of command has no difference from architectural viewpoint.
-/// It is just an input to the state.
-type ChannelCommand =
-    // open: funder
-    | ApplyAcceptChannel of AcceptChannelMsg
-    | CreateFundingTx of fundingTx: FinalizedTx * outIndex: TxOutIndex
-    | ApplyFundingSigned of FundingSignedMsg
-
-    // open: fundee
-    | ApplyOpenChannel of OpenChannelMsg
-    | ApplyFundingCreated of FundingCreatedMsg
-
-    // else
-    | ForceClose
-    | GetState
-    | GetStateData
-
-
 /// Channel config which is static, ie. config parameters which are established
 /// during the channel handshake and persist unchagned through the lifetime of
 /// the channel.

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -124,7 +124,6 @@ type ChannelCommand =
     | ApplyFundingCreated of FundingCreatedMsg
 
     // normal
-    | AddHTLC of OperationAddHTLC
     | ApplyUpdateAddHTLC of msg: UpdateAddHTLCMsg * currentHeight: BlockHeight
     | FulfillHTLC of OperationFulfillHTLC
     | ApplyUpdateFulfillHTLC of UpdateFulfillHTLCMsg

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -70,12 +70,10 @@ type LocalParams = {
     HTLCMinimumMSat: LNMoney
     ToSelfDelay: BlockHeightOffset16
     MaxAcceptedHTLCs: uint16
-    IsFunder: bool
     Features: FeatureBits
 }
 
 type RemoteParams = {
-    NodeId: NodeId
     DustLimitSatoshis: Money
     MaxHTLCValueInFlightMSat: LNMoney
     ChannelReserveSatoshis: Money
@@ -86,7 +84,7 @@ type RemoteParams = {
     Features: FeatureBits
 }
     with
-        static member FromAcceptChannel nodeId (remoteInit: InitMsg) (msg: AcceptChannelMsg) =
+        static member FromAcceptChannel (remoteInit: InitMsg) (msg: AcceptChannelMsg) =
             let channelPubKeys = {
                 FundingPubKey = msg.FundingPubKey
                 RevocationBasepoint = msg.RevocationBasepoint
@@ -95,7 +93,6 @@ type RemoteParams = {
                 HtlcBasepoint = msg.HTLCBasepoint
             }
             {
-                NodeId = nodeId
                 DustLimitSatoshis = msg.DustLimitSatoshis
                 MaxHTLCValueInFlightMSat = msg.MaxHTLCValueInFlightMsat
                 ChannelReserveSatoshis = msg.ChannelReserveSatoshis
@@ -106,8 +103,7 @@ type RemoteParams = {
                 Features = remoteInit.Features
             }
 
-        static member FromOpenChannel (nodeId: NodeId)
-                                      (remoteInit: InitMsg)
+        static member FromOpenChannel (remoteInit: InitMsg)
                                       (msg: OpenChannelMsg)
                                           : RemoteParams =
             let channelPubKeys = {
@@ -118,7 +114,6 @@ type RemoteParams = {
                 HtlcBasepoint = msg.HTLCBasepoint
             }
             {
-                NodeId = nodeId
                 DustLimitSatoshis = msg.DustLimitSatoshis
                 MaxHTLCValueInFlightMSat = msg.MaxHTLCValueInFlightMsat
                 ChannelReserveSatoshis = msg.ChannelReserveSatoshis

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -129,46 +129,6 @@ type RemoteParams = {
                 Features = remoteInit.Features
             }
 
-type InputInitFunder = {
-    TemporaryChannelId: ChannelId
-    FundingSatoshis: Money
-    PushMSat: LNMoney
-    InitFeeRatePerKw: FeeRatePerKw
-    FundingTxFeeRatePerKw: FeeRatePerKw
-    LocalParams: LocalParams
-    RemoteInit: InitMsg
-    ChannelFlags: uint8
-    ChannelPrivKeys: ChannelPrivKeys
-}
-    with
-        static member FromOpenChannel (localParams) (remoteInit) (channelPrivKeys) (o: OpenChannelMsg) =
-            {
-                InputInitFunder.TemporaryChannelId = o.TemporaryChannelId
-                FundingSatoshis = o.FundingSatoshis
-                PushMSat = o.PushMSat
-                InitFeeRatePerKw = o.FeeRatePerKw
-                FundingTxFeeRatePerKw = o.FeeRatePerKw
-                LocalParams = localParams
-                RemoteInit = remoteInit
-                ChannelFlags = o.ChannelFlags
-                ChannelPrivKeys = channelPrivKeys
-            }
-
-        member this.DeriveCommitmentSpec() =
-            CommitmentSpec.Create this.ToLocal this.PushMSat this.FundingTxFeeRatePerKw
-
-        member this.ToLocal =
-            this.FundingSatoshis.ToLNMoney() - this.PushMSat
-
-and InputInitFundee = {
-    TemporaryChannelId: ChannelId
-    LocalParams: LocalParams
-    RemoteInit: InitMsg
-    ToLocal: LNMoney
-    ChannelPrivKeys: ChannelPrivKeys
-}
-
-
 /// possible input to the channel. Command prefixed from `Apply` is passive. i.e.
 /// it has caused by the outside world and not by the user. Mostly this is a message sent
 /// from this channel's remote peer.

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -118,7 +118,6 @@ type ChannelCommand =
     | ApplyAcceptChannel of AcceptChannelMsg
     | CreateFundingTx of fundingTx: FinalizedTx * outIndex: TxOutIndex
     | ApplyFundingSigned of FundingSignedMsg
-    | ApplyFundingLocked of FundingLockedMsg
     | ApplyFundingConfirmedOnBC of height: BlockHeight * txIndex: TxIndexInBlock * depth: BlockHeightOffset32
 
     // open: fundee

--- a/src/DotNetLightning.Core/Channel/ChannelOperations.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelOperations.fs
@@ -15,6 +15,10 @@ open NBitcoin
 open ResultUtils
 open ResultUtils.Portability
 
+type OperationMonoHopUnidirectionalPayment = {
+    Amount: LNMoney
+}
+
 type OperationAddHTLC = {
     Amount: LNMoney
     PaymentHash: PaymentHash
@@ -203,6 +207,8 @@ type ChannelCommand =
     | CreateChannelReestablish
 
     // normal
+    | MonoHopUnidirectionalPayment of OperationMonoHopUnidirectionalPayment
+    | ApplyMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg
     | AddHTLC of OperationAddHTLC
     | ApplyUpdateAddHTLC of msg: UpdateAddHTLCMsg * currentHeight: BlockHeight
     | FulfillHTLC of OperationFulfillHTLC

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -61,7 +61,8 @@ module Data =
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
         LocalShutdown: ShutdownScriptPubKey
         RemoteShutdown: ShutdownScriptPubKey
-        ClosingFeesProposed: List<Money>
+        LocalClosingFeesProposed: List<Money>
+        RemoteClosingFeeProposed: Option<Money * LNECDSASignature>
     }
 
     type ClosingData = {

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -46,20 +46,3 @@ type ClosingSignedResponse =
     | NewClosingSigned of ClosingSignedMsg
     | MutualClose of FinalizedTx
 
-//     8888888888 888     888 8888888888 888b    888 88888888888 .d8888b.
-//     888        888     888 888        8888b   888     888    d88P  Y88b
-//     888        888     888 888        88888b  888     888    Y88b.
-//     8888888    Y88b   d88P 8888888    888Y88b 888     888     "Y888b.
-//     888         Y88b d88P  888        888 Y88b888     888        "Y88b.
-//     888          Y88o88P   888        888  Y88888     888          "888
-//     888           Y888P    888        888   Y8888     888    Y88b  d88P
-//     8888888888     Y8P     8888888888 888    Y888     888     "Y8888P"
-
-
-/// The one that includes `Operation` in its name is the event which we are the initiator
-type ChannelEvent =
-    // --- ln events ---
-    // -------- else ---------
-    | Closed
-    | Disconnected
-

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -321,8 +321,6 @@ type ChannelStatePhase =
     | Opening
     | Normal
     | Closing
-    | Closed
-    | Abnormal
 type ChannelState =
     /// Establishing
     | WaitForFundingConfirmed of WaitForFundingConfirmedData
@@ -335,16 +333,6 @@ type ChannelState =
     | Shutdown of ShutdownData
     | Negotiating of NegotiatingData
     | Closing of ClosingData
-    | Closed of IChannelStateData
-
-    /// Abnormal
-    | Offline of IChannelStateData
-    | Syncing of IChannelStateData
-
-    /// Error
-    | ErrFundingLost of IChannelStateData
-    | ErrFundingTimeOut of IChannelStateData
-    | ErrInformationLeak of IChannelStateData
     with
         interface IState 
 
@@ -363,12 +351,6 @@ type ChannelState =
             | Shutdown data -> Some data.ChannelId
             | Negotiating data -> Some data.ChannelId
             | Closing data -> Some data.ChannelId
-            | Closed _
-            | Offline _
-            | Syncing _
-            | ErrFundingLost _
-            | ErrFundingTimeOut _
-            | ErrInformationLeak _ -> None
 
         member this.Phase =
             match this with
@@ -378,12 +360,6 @@ type ChannelState =
             | Shutdown _
             | Negotiating _
             | Closing _ -> ChannelStatePhase.Closing
-            | Closed _ -> ChannelStatePhase.Closed
-            | Offline _
-            | Syncing _
-            | ErrFundingLost _
-            | ErrFundingTimeOut _
-            | ErrInformationLeak _ -> Abnormal
 
         member this.Commitments: Option<Commitments> =
             match this with
@@ -393,10 +369,4 @@ type ChannelState =
             | Shutdown data -> Some (data :> IHasCommitments).Commitments
             | Negotiating data -> Some (data :> IHasCommitments).Commitments
             | Closing data -> Some (data :> IHasCommitments).Commitments
-            | Closed _
-            | Offline _
-            | Syncing _
-            | ErrFundingLost _
-            | ErrFundingTimeOut _
-            | ErrInformationLeak _ -> None
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -99,5 +99,4 @@ type ChannelEvent =
     | Closed
     | Disconnected
     | ChannelStateRequestedSignCommitment
-    | WeSentChannelReestablish of msg: ChannelReestablishMsg
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -59,12 +59,35 @@ module Data =
 
     type IChannelStateData = interface inherit IStateData end
 
+    type ShutdownState = {
+        ShutdownScriptPubKey: ShutdownScriptPubKey
+        HasRequestedShutdown: bool
+    } with
+        static member ForNewChannel (shutdownScriptPubKeyOpt: Option<ShutdownScriptPubKey>)
+                                        : Option<ShutdownState> =
+            match shutdownScriptPubKeyOpt with
+            | None -> None
+            | Some shutdownScriptPubKey -> Some {
+                ShutdownScriptPubKey = shutdownScriptPubKey
+                HasRequestedShutdown = false
+            }
+
     type NormalData = {
         ShortChannelId: Option<ShortChannelId>
-        LocalShutdown: Option<ShutdownScriptPubKey>
-        RemoteShutdown: Option<ShutdownScriptPubKey>
+        LocalShutdownState: Option<ShutdownState>
+        RemoteShutdownState: Option<ShutdownState>
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
-    }
+    } with
+        member self.HasEnteredShutdown(): bool =
+            let localEnteredShutdown =
+                match self.LocalShutdownState with
+                | None -> false
+                | Some shutdownState -> shutdownState.HasRequestedShutdown
+            let remoteEnteredShutdown =
+                match self.RemoteShutdownState with
+                | None -> false
+                | Some shutdownState -> shutdownState.HasRequestedShutdown
+            localEnteredShutdown || remoteEnteredShutdown
 
     type NegotiatingData = {
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
@@ -150,11 +173,11 @@ type ChannelEvent =
 
     | WeAcceptedRevokeAndACK of nextCommitments: Commitments * remoteNextPerCommitmentPoint: PerCommitmentPoint
 
-    | AcceptedOperationShutdown of msg: ShutdownMsg
-    | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdownScriptPubKey: ShutdownScriptPubKey
+    | AcceptedOperationShutdown of msg: ShutdownMsg * nextLocalShutdownState: ShutdownState
+    | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of nextRemoteShutdownState: ShutdownState
     /// We have to send closing_signed to initiate the negotiation only when if we are the funder
     | AcceptedShutdownWhenNoPendingHTLCs of msgToSend: ClosingSignedMsg option * nextState: NegotiatingData
-    | AcceptedShutdownWhenWeHavePendingHTLCs of localShutdown: ShutdownMsg * remoteShutdownScriptPubKey: ShutdownScriptPubKey
+    | AcceptedShutdownWhenWeHavePendingHTLCs of localShutdown: ShutdownMsg * nextState: NormalData
 
     // ------ closing ------
     | MutualClosePerformed of txToPublish: FinalizedTx * nextState : ClosingData
@@ -201,7 +224,7 @@ type ChannelState =
         member this.Phase =
             match this with
             | Normal normalData ->
-                if normalData.LocalShutdown.IsSome && normalData.RemoteShutdown.IsSome then
+                if normalData.HasEnteredShutdown() then
                     ChannelStatePhase.Closing
                 else
                     if normalData.ShortChannelId.IsNone || normalData.RemoteNextCommitInfo.IsNone then

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,8 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedMonoHopUnidirectionalPayment of newCommitments: Commitments
-
     | WeAcceptedOperationAddHTLC of msg: UpdateAddHTLCMsg * newCommitments: Commitments
     | WeAcceptedUpdateAddHTLC of newCommitments: Commitments
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,8 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedFulfillHTLC of msg: UpdateFulfillHTLCMsg * origin: HTLCSource * htlc: UpdateAddHTLCMsg * newCommitments: Commitments
-
     | WeAcceptedOperationFailHTLC of msg: UpdateFailHTLCMsg * newCommitments: Commitments
     | WeAcceptedFailHTLC of origin: HTLCSource * msg: UpdateAddHTLCMsg * nextCommitments: Commitments
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -69,7 +69,6 @@ module Data =
 
     type NormalData = {
         ShortChannelId: ShortChannelId
-        ChannelUpdate: ChannelUpdateMsg
         LocalShutdown: Option<ShutdownMsg>
         RemoteShutdown: Option<ShutdownMsg>
         RemoteNextCommitInfo: RemoteNextCommitInfo

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -59,61 +59,6 @@ module Data =
 
     type IChannelStateData = interface inherit IStateData end
 
-    type WaitForAcceptChannelData = {
-            InputInitFunder: InputInitFunder
-            LastSent: OpenChannelMsg
-    } with
-        interface IChannelStateData
-
-    type WaitForFundingTxData = {
-        InputInitFunder: InputInitFunder
-        LastSent: OpenChannelMsg
-        LastReceived: AcceptChannelMsg
-    }
-
-    type WaitForFundingCreatedData = {
-        TemporaryFailure: ChannelId
-        LocalParams: LocalParams
-        RemoteParams: RemoteParams
-        FundingSatoshis: Money
-        PushMSat: LNMoney
-        InitialFeeRatePerKw: FeeRatePerKw
-        RemoteFirstPerCommitmentPoint: PerCommitmentPoint
-        ChannelFlags: uint8
-        LastSent: AcceptChannelMsg
-    } with
-        interface IChannelStateData
-
-        static member Create (localParams: LocalParams)
-                             (remoteParams: RemoteParams)
-                             (msg: OpenChannelMsg)
-                             (acceptChannelMsg: AcceptChannelMsg)
-                                 : WaitForFundingCreatedData = {
-            ChannelFlags = msg.ChannelFlags
-            TemporaryFailure = msg.TemporaryChannelId
-            LocalParams = localParams
-            RemoteParams = remoteParams
-            FundingSatoshis = msg.FundingSatoshis
-            PushMSat = msg.PushMSat
-            InitialFeeRatePerKw = msg.FeeRatePerKw
-            RemoteFirstPerCommitmentPoint = msg.FirstPerCommitmentPoint
-            LastSent = acceptChannelMsg
-        }
-
-    type WaitForFundingSignedData = {
-        ChannelId: ChannelId
-        LocalParams: LocalParams
-        RemoteParams: RemoteParams
-        FundingTx: FinalizedTx
-        LocalSpec: CommitmentSpec
-        LocalCommitTx: CommitTx
-        RemoteCommit: RemoteCommit
-        ChannelFlags: uint8
-        LastSent: FundingCreatedMsg
-        InitialFeeRatePerKw: FeeRatePerKw
-    } with
-        interface IChannelStateData
-
     type WaitForFundingConfirmedData = {
         Deferred: Option<FundingLockedMsg>
         LastSent: Choice<FundingCreatedMsg, FundingSignedMsg>

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -66,12 +66,6 @@ module Data =
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
     }
 
-    type ShutdownData = {
-        RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
-        LocalShutdown: ShutdownMsg
-        RemoteShutdown: ShutdownMsg
-    }
-
     type NegotiatingData = {
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
         LocalShutdown: ShutdownMsg
@@ -160,7 +154,7 @@ type ChannelEvent =
     | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdown: ShutdownMsg
     /// We have to send closing_signed to initiate the negotiation only when if we are the funder
     | AcceptedShutdownWhenNoPendingHTLCs of msgToSend: ClosingSignedMsg option * nextState: NegotiatingData
-    | AcceptedShutdownWhenWeHavePendingHTLCs of nextState: ShutdownData
+    | AcceptedShutdownWhenWeHavePendingHTLCs of localShutdown: ShutdownMsg * remoteShutdown: ShutdownMsg
 
     // ------ closing ------
     | MutualClosePerformed of txToPublish: FinalizedTx * nextState : ClosingData
@@ -192,7 +186,6 @@ type ChannelState =
     | Normal of NormalData
 
     /// Closing
-    | Shutdown of ShutdownData
     | Negotiating of NegotiatingData
     | Closing of ClosingData
     with
@@ -208,11 +201,13 @@ type ChannelState =
         member this.Phase =
             match this with
             | Normal normalData ->
-                if normalData.ShortChannelId.IsNone || normalData.RemoteNextCommitInfo.IsNone then
-                    ChannelStatePhase.Opening
+                if normalData.LocalShutdown.IsSome && normalData.RemoteShutdown.IsSome then
+                    ChannelStatePhase.Closing
                 else
-                    ChannelStatePhase.Normal
-            | Shutdown _
+                    if normalData.ShortChannelId.IsNone || normalData.RemoteNextCommitInfo.IsNone then
+                        ChannelStatePhase.Opening
+                    else
+                        ChannelStatePhase.Normal
             | Negotiating _
             | Closing _ -> ChannelStatePhase.Closing
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -41,7 +41,6 @@ module Data =
             }
 
     type NormalData = {
-        ShortChannelId: Option<ShortChannelId>
         LocalShutdownState: Option<ShutdownState>
         RemoteShutdownState: Option<ShutdownState>
     } with

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -65,10 +65,10 @@ module Data =
 
 
     type WaitForAcceptChannelData = {
-            InputInitFunder: InputInitFunder;
+            InputInitFunder: InputInitFunder
             LastSent: OpenChannelMsg
-        }
-        with interface IChannelStateData
+    } with
+        interface IChannelStateData
 
     type WaitForFundingTxData = {
         InputInitFunder: InputInitFunder
@@ -77,148 +77,162 @@ module Data =
     }
 
     type WaitForFundingCreatedData = {
-                                            TemporaryFailure: ChannelId
-                                            LocalParams: LocalParams
-                                            RemoteParams: RemoteParams
-                                            FundingSatoshis: Money
-                                            PushMSat: LNMoney
-                                            InitialFeeRatePerKw: FeeRatePerKw
-                                            RemoteFirstPerCommitmentPoint: PerCommitmentPoint
-                                            ChannelFlags: uint8
-                                            LastSent: AcceptChannelMsg
-                                      }
-        with
-            interface IChannelStateData
-            static member Create (localParams) (remoteParams) (msg: OpenChannelMsg) acceptChannelMsg =
-                { ChannelFlags = msg.ChannelFlags
-                  TemporaryFailure = msg.TemporaryChannelId
-                  LocalParams = localParams
-                  RemoteParams = remoteParams
-                  FundingSatoshis = msg.FundingSatoshis
-                  PushMSat = msg.PushMSat
-                  InitialFeeRatePerKw = msg.FeeRatePerKw
-                  RemoteFirstPerCommitmentPoint = msg.FirstPerCommitmentPoint
-                  LastSent = acceptChannelMsg }
+        TemporaryFailure: ChannelId
+        LocalParams: LocalParams
+        RemoteParams: RemoteParams
+        FundingSatoshis: Money
+        PushMSat: LNMoney
+        InitialFeeRatePerKw: FeeRatePerKw
+        RemoteFirstPerCommitmentPoint: PerCommitmentPoint
+        ChannelFlags: uint8
+        LastSent: AcceptChannelMsg
+    } with
+        interface IChannelStateData
+
+        static member Create (localParams: LocalParams)
+                             (remoteParams: RemoteParams)
+                             (msg: OpenChannelMsg)
+                             (acceptChannelMsg: AcceptChannelMsg)
+                                 : WaitForFundingCreatedData = {
+            ChannelFlags = msg.ChannelFlags
+            TemporaryFailure = msg.TemporaryChannelId
+            LocalParams = localParams
+            RemoteParams = remoteParams
+            FundingSatoshis = msg.FundingSatoshis
+            PushMSat = msg.PushMSat
+            InitialFeeRatePerKw = msg.FeeRatePerKw
+            RemoteFirstPerCommitmentPoint = msg.FirstPerCommitmentPoint
+            LastSent = acceptChannelMsg
+        }
+
     type WaitForFundingSignedData = {
-                                            ChannelId: ChannelId
-                                            LocalParams: LocalParams
-                                            RemoteParams: RemoteParams
-                                            FundingTx: FinalizedTx
-                                            LocalSpec: CommitmentSpec
-                                            LocalCommitTx: CommitTx
-                                            RemoteCommit: RemoteCommit
-                                            ChannelFlags: uint8
-                                            LastSent: FundingCreatedMsg
-                                            InitialFeeRatePerKw: FeeRatePerKw
-                                       }
-        with interface IChannelStateData
+        ChannelId: ChannelId
+        LocalParams: LocalParams
+        RemoteParams: RemoteParams
+        FundingTx: FinalizedTx
+        LocalSpec: CommitmentSpec
+        LocalCommitTx: CommitTx
+        RemoteCommit: RemoteCommit
+        ChannelFlags: uint8
+        LastSent: FundingCreatedMsg
+        InitialFeeRatePerKw: FeeRatePerKw
+    } with
+        interface IChannelStateData
 
     type WaitForFundingConfirmedData = {
-                                            Commitments: Commitments
-                                            Deferred: FundingLockedMsg option
-                                            LastSent: Choice<FundingCreatedMsg, FundingSignedMsg>
-                                            InitialFeeRatePerKw: FeeRatePerKw
-                                            ChannelId: ChannelId
-                                          }
-        with
-            interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+        Commitments: Commitments
+        Deferred: Option<FundingLockedMsg>
+        LastSent: Choice<FundingCreatedMsg, FundingSignedMsg>
+        InitialFeeRatePerKw: FeeRatePerKw
+        ChannelId: ChannelId
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
+    type WaitForFundingLockedData = {
+        Commitments: Commitments
+        ShortChannelId: ShortChannelId
+        OurMessage: FundingLockedMsg
+        TheirMessage: Option<FundingLockedMsg>
+        InitialFeeRatePerKw: FeeRatePerKw
+        HaveWeSentFundingLocked: bool
+        ChannelId: ChannelId
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
-    type WaitForFundingLockedData = { Commitments: Commitments;
-                                      ShortChannelId: ShortChannelId;
-                                      OurMessage: FundingLockedMsg
-                                      TheirMessage: FundingLockedMsg option
-                                      InitialFeeRatePerKw: FeeRatePerKw
-                                      HaveWeSentFundingLocked:bool
-                                      ChannelId: ChannelId }
-        with interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+    type NormalData = {
+        Commitments: Commitments
+        ShortChannelId: ShortChannelId
+        Buried: bool
+        ChannelAnnouncement: Option<ChannelAnnouncementMsg>
+        ChannelUpdate: ChannelUpdateMsg
+        LocalShutdown: Option<ShutdownMsg>
+        RemoteShutdown: Option<ShutdownMsg>
+        ChannelId: ChannelId
+    } with
+        static member Commitments_: Lens<_, _> =
+            (fun nd -> nd.Commitments), (fun v nd -> { nd with Commitments = v })
 
-    type NormalData =   {
-                            Commitments: Commitments;
-                            ShortChannelId: ShortChannelId;
-                            Buried: bool;
-                            ChannelAnnouncement: ChannelAnnouncementMsg option
-                            ChannelUpdate: ChannelUpdateMsg
-                            LocalShutdown: ShutdownMsg option
-                            RemoteShutdown: ShutdownMsg option
-                            ChannelId: ChannelId
-                        }
-        with
-            static member Commitments_: Lens<_, _> =
-                (fun nd -> nd.Commitments), (fun v nd -> { nd with Commitments = v })
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
-            interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
-
-    type ShutdownData = { Commitments: Commitments; LocalShutdown: ShutdownMsg; RemoteShutdown: ShutdownMsg; ChannelId: ChannelId }
-        with interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+    type ShutdownData = {
+        Commitments: Commitments
+        LocalShutdown: ShutdownMsg
+        RemoteShutdown: ShutdownMsg
+        ChannelId: ChannelId
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
     type NegotiatingData = {
-                            Commitments: Commitments;
-                            LocalShutdown: ShutdownMsg;
-                            RemoteShutdown: ShutdownMsg;
-                            ClosingTxProposed: ClosingTxProposed list list
-                            MaybeBestUnpublishedTx: FinalizedTx option
-                            ChannelId: ChannelId
-                          }
-        with
-            interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+        Commitments: Commitments
+        LocalShutdown: ShutdownMsg
+        RemoteShutdown: ShutdownMsg
+        ClosingTxProposed: List<List<ClosingTxProposed>>
+        MaybeBestUnpublishedTx: Option<FinalizedTx>
+        ChannelId: ChannelId
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
 
     type ClosingData = {
-                        ChannelId: ChannelId
-                        Commitments: Commitments
-                        MaybeFundingTx: Transaction option
-                        WaitingSince: System.DateTime
-                        MutualCloseProposed: ClosingTx list
-                        MutualClosePublished: FinalizedTx
-                        LocalCommitPublished: LocalCommitPublished option
-                        RemoteCommitPublished: RemoteCommitPublished option
-                        NextRemoteCommitPublished: RemoteCommitPublished option
-                        FutureRemoteCommitPublished: RemoteCommitPublished option
-                        RevokedCommitPublished: RevokedCommitPublished list
-                      }
-        with
-            interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
+        ChannelId: ChannelId
+        Commitments: Commitments
+        MaybeFundingTx: Option<Transaction>
+        WaitingSince: System.DateTime
+        MutualCloseProposed: List<ClosingTx>
+        MutualClosePublished: FinalizedTx
+        LocalCommitPublished: Option<LocalCommitPublished>
+        RemoteCommitPublished: Option<RemoteCommitPublished>
+        NextRemoteCommitPublished: Option<RemoteCommitPublished>
+        FutureRemoteCommitPublished: Option<RemoteCommitPublished>
+        RevokedCommitPublished: List<RevokedCommitPublished>
+    } with
+        interface IHasCommitments with
+            member this.ChannelId: ChannelId = 
+                this.ChannelId
+            member this.Commitments: Commitments = 
+                this.Commitments
                     
-            member this.FinalizedTx =
-                this.MutualClosePublished
-            static member Create(channelId, commitments, maybeFundingTx, waitingSince, mutualCloseProposed, mutualClosePublished) =
-                {
-                    ChannelId = channelId
-                    Commitments = commitments
-                    MaybeFundingTx = maybeFundingTx
-                    WaitingSince = waitingSince
-                    MutualCloseProposed = mutualCloseProposed
-                    MutualClosePublished = mutualClosePublished
-                    LocalCommitPublished = None
-                    RemoteCommitPublished = None
-                    NextRemoteCommitPublished = None
-                    FutureRemoteCommitPublished = None
-                    RevokedCommitPublished = []
-                }
+        member this.FinalizedTx =
+            this.MutualClosePublished
+        
+        static member Create (channelId: ChannelId)
+                             (commitments: Commitments)
+                             (maybeFundingTx: Option<Transaction>)
+                             (waitingSince: System.DateTime)
+                             (mutualCloseProposed: List<ClosingTx>)
+                             (mutualClosePublished: FinalizedTx)
+                                 : ClosingData = {
+            ChannelId = channelId
+            Commitments = commitments
+            MaybeFundingTx = maybeFundingTx
+            WaitingSince = waitingSince
+            MutualCloseProposed = mutualCloseProposed
+            MutualClosePublished = mutualClosePublished
+            LocalCommitPublished = None
+            RemoteCommitPublished = None
+            NextRemoteCommitPublished = None
+            FutureRemoteCommitPublished = None
+            RevokedCommitPublished = []
+        }
 
 //     8888888888 888     888 8888888888 888b    888 88888888888 .d8888b.
 //     888        888     888 888        8888b   888     888    d88P  Y88b

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -65,7 +65,6 @@ module Data =
 
     type WaitForFundingLockedData = {
         ShortChannelId: ShortChannelId
-        OurMessage: FundingLockedMsg
         TheirMessage: Option<FundingLockedMsg>
         HaveWeSentFundingLocked: bool
     }

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -60,7 +60,7 @@ module Data =
     type IChannelStateData = interface inherit IStateData end
 
     type WaitForFundingConfirmedData = {
-        Deferred: Option<FundingLockedMsg>
+        RemoteNextPerCommitmentPointOpt: Option<PerCommitmentPoint>
     }
 
     type WaitForFundingLockedData = {
@@ -139,7 +139,7 @@ type ChannelEvent =
     /// -------- init both -----
     | FundingConfirmed of FundingLockedMsg * nextState: Data.WaitForFundingLockedData
     | TheySentFundingLocked of msg: FundingLockedMsg
-    | WeResumedDelayedFundingLocked of msg: FundingLockedMsg
+    | WeResumedDelayedFundingLocked of remoteNextPerCommitmentPoint: PerCommitmentPoint
     | BothFundingLocked of nextState: Data.NormalData
 
     // -------- normal operation ------

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,8 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedFailHTLC of origin: HTLCSource * msg: UpdateAddHTLCMsg * nextCommitments: Commitments
-
     | WeAcceptedFailMalformedHTLC of origin: HTLCSource * msg: UpdateAddHTLCMsg * newCommitments: Commitments
 
     | WeAcceptedOperationUpdateFee of msg: UpdateFeeMsg  * nextCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -292,7 +292,7 @@ type ChannelEvent =
     | WeAcceptedFailMalformedHTLC of origin: HTLCSource * msg: UpdateAddHTLCMsg * newCommitments: Commitments
 
     | WeAcceptedOperationUpdateFee of msg: UpdateFeeMsg  * nextCommitments: Commitments
-    | WeAcceptedUpdateFee of msg: UpdateFeeMsg 
+    | WeAcceptedUpdateFee of msg: UpdateFeeMsg * newCommitments: Commitments
 
     | WeAcceptedOperationSign of msg: CommitmentSignedMsg * nextCommitments: Commitments
     | WeAcceptedCommitmentSigned of msg: RevokeAndACKMsg * nextCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -70,7 +70,7 @@ module Data =
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
         LocalShutdown: ShutdownScriptPubKey
         RemoteShutdown: ShutdownScriptPubKey
-        ClosingTxProposed: List<Option<ClosingTxProposed>>
+        ClosingTxProposed: List<ClosingTxProposed>
         MaybeBestUnpublishedTx: Option<FinalizedTx>
     }
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,7 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedOperationFailHTLC of msg: UpdateFailHTLCMsg * newCommitments: Commitments
     | WeAcceptedFailHTLC of origin: HTLCSource * msg: UpdateAddHTLCMsg * nextCommitments: Commitments
 
     | WeAcceptedOperationFailMalformedHTLC of msg: UpdateFailMalformedHTLCMsg * newCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,7 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedOperationMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg * newCommitments: Commitments
     | WeAcceptedMonoHopUnidirectionalPayment of newCommitments: Commitments
 
     | WeAcceptedOperationAddHTLC of msg: UpdateAddHTLCMsg * newCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,7 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedOperationUpdateFee of msg: UpdateFeeMsg  * nextCommitments: Commitments
     | WeAcceptedUpdateFee of msg: UpdateFeeMsg * newCommitments: Commitments
 
     | WeAcceptedOperationSign of msg: CommitmentSignedMsg * nextCommitments: Commitments * nextRemoteCommit: RemoteCommit

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -56,10 +56,6 @@ module Data =
 /// The one that includes `Operation` in its name is the event which we are the initiator
 type ChannelEvent =
     // --- ln events ---
-    /// -------- init both -----
-    | FundingConfirmed of FundingLockedMsg * shortChannelId: ShortChannelId
-    | WeResumedDelayedFundingLocked of remoteNextPerCommitmentPoint: PerCommitmentPoint
-
     // -------- normal operation ------
     | WeAcceptedOperationMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg * newCommitments: Commitments
     | WeAcceptedMonoHopUnidirectionalPayment of newCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -58,11 +58,6 @@ module Data =
     }
 
     type IChannelStateData = interface inherit IStateData end
-    type IHasCommitments =
-        inherit IChannelStateData
-        abstract member ChannelId: ChannelId
-        abstract member Commitments: Commitments
-
 
     type WaitForAcceptChannelData = {
             InputInitFunder: InputInitFunder
@@ -120,81 +115,41 @@ module Data =
         interface IChannelStateData
 
     type WaitForFundingConfirmedData = {
-        Commitments: Commitments
         Deferred: Option<FundingLockedMsg>
         LastSent: Choice<FundingCreatedMsg, FundingSignedMsg>
         InitialFeeRatePerKw: FeeRatePerKw
-        ChannelId: ChannelId
-    } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type WaitForFundingLockedData = {
-        Commitments: Commitments
         ShortChannelId: ShortChannelId
         OurMessage: FundingLockedMsg
         TheirMessage: Option<FundingLockedMsg>
         InitialFeeRatePerKw: FeeRatePerKw
         HaveWeSentFundingLocked: bool
-        ChannelId: ChannelId
-    } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type NormalData = {
-        Commitments: Commitments
         ShortChannelId: ShortChannelId
         Buried: bool
         ChannelAnnouncement: Option<ChannelAnnouncementMsg>
         ChannelUpdate: ChannelUpdateMsg
         LocalShutdown: Option<ShutdownMsg>
         RemoteShutdown: Option<ShutdownMsg>
-        ChannelId: ChannelId
-    } with
-        static member Commitments_: Lens<_, _> =
-            (fun nd -> nd.Commitments), (fun v nd -> { nd with Commitments = v })
-
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type ShutdownData = {
-        Commitments: Commitments
         LocalShutdown: ShutdownMsg
         RemoteShutdown: ShutdownMsg
-        ChannelId: ChannelId
-    } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type NegotiatingData = {
-        Commitments: Commitments
         LocalShutdown: ShutdownMsg
         RemoteShutdown: ShutdownMsg
         ClosingTxProposed: List<List<ClosingTxProposed>>
         MaybeBestUnpublishedTx: Option<FinalizedTx>
-        ChannelId: ChannelId
-    } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
+    }
 
     type ClosingData = {
-        ChannelId: ChannelId
-        Commitments: Commitments
         MaybeFundingTx: Option<Transaction>
         WaitingSince: System.DateTime
         MutualCloseProposed: List<ClosingTx>
@@ -205,24 +160,14 @@ module Data =
         FutureRemoteCommitPublished: Option<RemoteCommitPublished>
         RevokedCommitPublished: List<RevokedCommitPublished>
     } with
-        interface IHasCommitments with
-            member this.ChannelId: ChannelId = 
-                this.ChannelId
-            member this.Commitments: Commitments = 
-                this.Commitments
-                    
         member this.FinalizedTx =
             this.MutualClosePublished
         
-        static member Create (channelId: ChannelId)
-                             (commitments: Commitments)
-                             (maybeFundingTx: Option<Transaction>)
+        static member Create (maybeFundingTx: Option<Transaction>)
                              (waitingSince: System.DateTime)
                              (mutualCloseProposed: List<ClosingTx>)
                              (mutualClosePublished: FinalizedTx)
                                  : ClosingData = {
-            ChannelId = channelId
-            Commitments = commitments
             MaybeFundingTx = maybeFundingTx
             WaitingSince = waitingSince
             MutualCloseProposed = mutualCloseProposed
@@ -252,7 +197,7 @@ type ChannelEvent =
     | TheySentFundingLocked of msg: FundingLockedMsg
     | WeSentFundingLocked of msg: FundingLockedMsg
     | WeResumedDelayedFundingLocked of msg: FundingLockedMsg
-    | BothFundingLocked of nextState: Data.NormalData
+    | BothFundingLocked of nextState: Data.NormalData * nextCommitments: Commitments
 
     // -------- normal operation ------
     | WeAcceptedOperationMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg * newCommitments: Commitments
@@ -331,15 +276,6 @@ type ChannelState =
             (fun v cc -> match cc with
                          | Normal _ -> Normal v
                          | _ -> cc )
-        member this.ChannelId: ChannelId =
-            match this with
-            | WaitForFundingConfirmed data -> data.ChannelId
-            | WaitForFundingLocked data -> data.ChannelId
-            | Normal data -> data.ChannelId
-            | Shutdown data -> data.ChannelId
-            | Negotiating data -> data.ChannelId
-            | Closing data -> data.ChannelId
-
         member this.Phase =
             match this with
             | WaitForFundingConfirmed _
@@ -348,13 +284,4 @@ type ChannelState =
             | Shutdown _
             | Negotiating _
             | Closing _ -> ChannelStatePhase.Closing
-
-        member this.Commitments: Commitments =
-            match this with
-            | WaitForFundingConfirmed data -> (data :> IHasCommitments).Commitments
-            | WaitForFundingLocked data -> (data :> IHasCommitments).Commitments
-            | Normal data -> (data :> IHasCommitments).Commitments
-            | Shutdown data -> (data :> IHasCommitments).Commitments
-            | Negotiating data -> (data :> IHasCommitments).Commitments
-            | Closing data -> (data :> IHasCommitments).Commitments
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -1,5 +1,6 @@
 namespace DotNetLightning.Channel
 
+open DotNetLightning.Chain
 open DotNetLightning.Utils
 open DotNetLightning.Utils.Aether
 open DotNetLightning.DomainUtils.Types
@@ -7,6 +8,7 @@ open DotNetLightning.Serialization.Msgs
 open DotNetLightning.Transactions
 open DotNetLightning.Crypto
 open NBitcoin
+
 
 (*
     based on eclair's channel state management
@@ -257,17 +259,6 @@ module Data =
 /// The one that includes `Operation` in its name is the event which we are the initiator
 type ChannelEvent =
     // --- ln events ---
-    // --------- init fundee --------
-    | NewInboundChannelStarted of nextState: Data.WaitForOpenChannelData
-    | WeAcceptedOpenChannel of nextMsg: AcceptChannelMsg * nextState: Data.WaitForFundingCreatedData
-    | WeAcceptedFundingCreated of nextMsg: FundingSignedMsg * nextState: Data.WaitForFundingConfirmedData
-
-    // --------- init fender --------
-    | NewOutboundChannelStarted of nextMsg: OpenChannelMsg * nextState: Data.WaitForAcceptChannelData
-    | WeAcceptedAcceptChannel of fundingDestination: IDestination * fundingAmount: Money * nextState: Data.WaitForFundingTxData
-    | WeCreatedFundingTx of nextMsg: FundingCreatedMsg * nextState: Data.WaitForFundingSignedData
-    | WeAcceptedFundingSigned of txToPublish: FinalizedTx * nextState: Data.WaitForFundingConfirmedData
-
     /// -------- init both -----
     | FundingConfirmed of nextState: Data.WaitForFundingLockedData
     | TheySentFundingLocked of msg: FundingLockedMsg
@@ -334,12 +325,6 @@ type ChannelStatePhase =
     | Abnormal
 type ChannelState =
     /// Establishing
-    | WaitForInitInternal
-    | WaitForOpenChannel of WaitForOpenChannelData
-    | WaitForAcceptChannel of WaitForAcceptChannelData
-    | WaitForFundingTx of WaitForFundingTxData
-    | WaitForFundingCreated of WaitForFundingCreatedData
-    | WaitForFundingSigned of WaitForFundingSignedData
     | WaitForFundingConfirmed of WaitForFundingConfirmedData
     | WaitForFundingLocked of WaitForFundingLockedData
 
@@ -363,7 +348,6 @@ type ChannelState =
     with
         interface IState 
 
-        static member Zero = WaitForInitInternal
         static member Normal_: Prism<_, _> =
             (fun cc -> match cc with
                        | Normal s -> Some s
@@ -373,12 +357,6 @@ type ChannelState =
                          | _ -> cc )
         member this.ChannelId: Option<ChannelId> =
             match this with
-            | WaitForInitInternal
-            | WaitForOpenChannel _
-            | WaitForAcceptChannel _
-            | WaitForFundingTx _
-            | WaitForFundingCreated _ -> None
-            | WaitForFundingSigned data -> Some data.ChannelId
             | WaitForFundingConfirmed data -> Some data.ChannelId
             | WaitForFundingLocked data -> Some data.ChannelId
             | Normal data -> Some data.ChannelId
@@ -394,12 +372,6 @@ type ChannelState =
 
         member this.Phase =
             match this with
-            | WaitForInitInternal
-            | WaitForOpenChannel _ 
-            | WaitForAcceptChannel _
-            | WaitForFundingTx _
-            | WaitForFundingCreated _
-            | WaitForFundingSigned _
             | WaitForFundingConfirmed _
             | WaitForFundingLocked _ -> Opening
             | Normal _ -> ChannelStatePhase.Normal
@@ -415,12 +387,6 @@ type ChannelState =
 
         member this.Commitments: Option<Commitments> =
             match this with
-            | WaitForInitInternal
-            | WaitForOpenChannel _
-            | WaitForAcceptChannel _
-            | WaitForFundingTx _
-            | WaitForFundingCreated _
-            | WaitForFundingSigned _ -> None
             | WaitForFundingConfirmed data -> Some (data :> IHasCommitments).Commitments
             | WaitForFundingLocked data -> Some (data :> IHasCommitments).Commitments
             | Normal data -> Some (data :> IHasCommitments).Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -65,7 +65,6 @@ module Data =
 
     type WaitForFundingLockedData = {
         ShortChannelId: ShortChannelId
-        TheirMessage: Option<FundingLockedMsg>
         HaveWeSentFundingLocked: bool
     }
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -58,9 +58,7 @@ type ChannelEvent =
     // --- ln events ---
     /// -------- init both -----
     | FundingConfirmed of FundingLockedMsg * shortChannelId: ShortChannelId
-    | TheySentFundingLocked of msg: FundingLockedMsg
     | WeResumedDelayedFundingLocked of remoteNextPerCommitmentPoint: PerCommitmentPoint
-    | BothFundingLocked of remoteNextPerCommitmentPoint: PerCommitmentPoint
 
     // -------- normal operation ------
     | WeAcceptedOperationMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg * newCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -56,17 +56,10 @@ module Data =
 /// The one that includes `Operation` in its name is the event which we are the initiator
 type ChannelEvent =
     // --- ln events ---
-    // -------- normal operation ------
-    | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdownScriptPubKey: ShutdownScriptPubKey
-    /// We have to send closing_signed to initiate the negotiation only when if we are the funder
-    | AcceptedShutdownWhenNoPendingHTLCs of msgToSend: ClosingSignedMsg option * nextState: NegotiatingState
-    | AcceptedShutdownWhenWeHavePendingHTLCs of localShutdown: ShutdownMsg * localShutdownScript: ShutdownScriptPubKey * remoteShutdownScript: ShutdownScriptPubKey
-
     // ------ closing ------
     | MutualClosePerformed of txToPublish: FinalizedTx
     | WeProposedNewClosingSigned of msgToSend: ClosingSignedMsg * nextState: NegotiatingState
     // -------- else ---------
     | Closed
     | Disconnected
-    | ChannelStateRequestedSignCommitment
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -49,5 +49,6 @@ type ClosingSignedResponse =
 type SavedChannelState = {
     StaticChannelConfig: StaticChannelConfig
     RemotePerCommitmentSecrets: PerCommitmentSecretStore
+    ShortChannelId: Option<ShortChannelId>
 }
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,7 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | AcceptedOperationShutdown of msg: ShutdownMsg * localShutdownScriptPubKey: ShutdownScriptPubKey
     | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdownScriptPubKey: ShutdownScriptPubKey
     /// We have to send closing_signed to initiate the negotiation only when if we are the funder
     | AcceptedShutdownWhenNoPendingHTLCs of msgToSend: ClosingSignedMsg option * nextState: NegotiatingState

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -52,6 +52,8 @@ type SavedChannelState = {
     ShortChannelId: Option<ShortChannelId>
     LocalCommit: LocalCommit
     RemoteCommit: RemoteCommit
+    LocalChanges: LocalChanges
+    RemoteChanges: RemoteChanges
 } with
     member internal this.HasNoPendingHTLCs (remoteNextCommitInfo: RemoteNextCommitInfo) =
         this.LocalCommit.Spec.OutgoingHTLCs.IsEmpty

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -157,7 +157,7 @@ type ChannelEvent =
     | WeAcceptedRevokeAndACK of nextCommitments: Commitments * remoteNextPerCommitmentPoint: PerCommitmentPoint
 
     | AcceptedOperationShutdown of msg: ShutdownMsg
-    | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdown: ShutdownMsg * nextCommitments: Commitments
+    | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdown: ShutdownMsg
     /// We have to send closing_signed to initiate the negotiation only when if we are the funder
     | AcceptedShutdownWhenNoPendingHTLCs of msgToSend: ClosingSignedMsg option * nextState: NegotiatingData
     | AcceptedShutdownWhenWeHavePendingHTLCs of nextState: ShutdownData

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -71,7 +71,6 @@ module Data =
         LocalShutdown: ShutdownScriptPubKey
         RemoteShutdown: ShutdownScriptPubKey
         ClosingTxProposed: List<ClosingTxProposed>
-        MaybeBestUnpublishedTx: Option<FinalizedTx>
     }
 
     type ClosingData = {

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -25,15 +25,6 @@ open NBitcoin
 
 [<AutoOpen>]
 module Data =
-    type ClosingTxProposed = {
-        UnsignedTx: ClosingTx
-        LocalClosingSigned: ClosingSignedMsg
-    }
-    with
-        static member LocalClosingSigned_: Lens<_ ,_> =
-            (fun p -> p.LocalClosingSigned),
-            (fun v p -> { p with LocalClosingSigned = v })
-
     type IChannelStateData = interface inherit IStateData end
 
     type ShutdownState = {
@@ -70,7 +61,7 @@ module Data =
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
         LocalShutdown: ShutdownScriptPubKey
         RemoteShutdown: ShutdownScriptPubKey
-        ClosingTxProposed: List<ClosingTxProposed>
+        ClosingFeesProposed: List<Money>
     }
 
     type ClosingData = {

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -59,29 +59,21 @@ module Data =
 
     type IChannelStateData = interface inherit IStateData end
 
-    type WaitForFundingConfirmedData = {
-        RemoteNextPerCommitmentPointOpt: Option<PerCommitmentPoint>
-    }
-
-    type WaitForFundingLockedData = {
-        ShortChannelId: ShortChannelId
-    }
-
     type NormalData = {
-        ShortChannelId: ShortChannelId
+        ShortChannelId: Option<ShortChannelId>
         LocalShutdown: Option<ShutdownMsg>
         RemoteShutdown: Option<ShutdownMsg>
-        RemoteNextCommitInfo: RemoteNextCommitInfo
+        RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
     }
 
     type ShutdownData = {
-        RemoteNextCommitInfo: RemoteNextCommitInfo
+        RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
         LocalShutdown: ShutdownMsg
         RemoteShutdown: ShutdownMsg
     }
 
     type NegotiatingData = {
-        RemoteNextCommitInfo: RemoteNextCommitInfo
+        RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
         LocalShutdown: ShutdownMsg
         RemoteShutdown: ShutdownMsg
         ClosingTxProposed: List<List<ClosingTxProposed>>
@@ -89,7 +81,7 @@ module Data =
     }
 
     type ClosingData = {
-        RemoteNextCommitInfo: RemoteNextCommitInfo
+        RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
         MaybeFundingTx: Option<Transaction>
         WaitingSince: System.DateTime
         MutualCloseProposed: List<ClosingTx>
@@ -107,9 +99,9 @@ module Data =
                              (waitingSince: System.DateTime)
                              (mutualCloseProposed: List<ClosingTx>)
                              (mutualClosePublished: FinalizedTx)
-                             (remoteNextCommitInfo: RemoteNextCommitInfo)
+                             (remoteNextCommitInfo: Option<RemoteNextCommitInfo>)
                                  : ClosingData = {
-            RemoteNextCommitInfo = remoteNextCommitInfo
+            RemoteNextCommitInfo= remoteNextCommitInfo
             MaybeFundingTx = maybeFundingTx
             WaitingSince = waitingSince
             MutualCloseProposed = mutualCloseProposed
@@ -135,7 +127,7 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     /// -------- init both -----
-    | FundingConfirmed of FundingLockedMsg * nextState: Data.WaitForFundingLockedData
+    | FundingConfirmed of FundingLockedMsg * shortChannelId: ShortChannelId
     | TheySentFundingLocked of msg: FundingLockedMsg
     | WeResumedDelayedFundingLocked of remoteNextPerCommitmentPoint: PerCommitmentPoint
     | BothFundingLocked of nextState: Data.NormalData
@@ -196,10 +188,6 @@ type ChannelStatePhase =
     | Normal
     | Closing
 type ChannelState =
-    /// Establishing
-    | WaitForFundingConfirmed of WaitForFundingConfirmedData
-    | WaitForFundingLocked of WaitForFundingLockedData
-
     /// normal
     | Normal of NormalData
 
@@ -219,9 +207,11 @@ type ChannelState =
                          | _ -> cc )
         member this.Phase =
             match this with
-            | WaitForFundingConfirmed _
-            | WaitForFundingLocked _ -> Opening
-            | Normal _ -> ChannelStatePhase.Normal
+            | Normal normalData ->
+                if normalData.ShortChannelId.IsNone || normalData.RemoteNextCommitInfo.IsNone then
+                    ChannelStatePhase.Opening
+                else
+                    ChannelStatePhase.Normal
             | Shutdown _
             | Negotiating _
             | Closing _ -> ChannelStatePhase.Closing

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,8 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedUpdateAddHTLC of newCommitments: Commitments
-
     | WeAcceptedOperationFulfillHTLC of msg: UpdateFulfillHTLCMsg * newCommitments: Commitments
     | WeAcceptedFulfillHTLC of msg: UpdateFulfillHTLCMsg * origin: HTLCSource * htlc: UpdateAddHTLCMsg * newCommitments: Commitments
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -27,40 +27,21 @@ open NBitcoin
 module Data =
     type IChannelStateData = interface inherit IStateData end
 
-    type ShutdownState = {
-        ShutdownScriptPubKey: ShutdownScriptPubKey
-        HasRequestedShutdown: bool
-    } with
-        static member ForNewChannel (shutdownScriptPubKeyOpt: Option<ShutdownScriptPubKey>)
-                                        : Option<ShutdownState> =
-            match shutdownScriptPubKeyOpt with
-            | None -> None
-            | Some shutdownScriptPubKey -> Some {
-                ShutdownScriptPubKey = shutdownScriptPubKey
-                HasRequestedShutdown = false
-            }
-
-    type NormalData = {
-        LocalShutdownState: Option<ShutdownState>
-        RemoteShutdownState: Option<ShutdownState>
-    } with
-        member self.HasEnteredShutdown(): bool =
-            let localEnteredShutdown =
-                match self.LocalShutdownState with
-                | None -> false
-                | Some shutdownState -> shutdownState.HasRequestedShutdown
-            let remoteEnteredShutdown =
-                match self.RemoteShutdownState with
-                | None -> false
-                | Some shutdownState -> shutdownState.HasRequestedShutdown
-            localEnteredShutdown || remoteEnteredShutdown
-
-    type NegotiatingData = {
-        LocalShutdown: ShutdownScriptPubKey
-        RemoteShutdown: ShutdownScriptPubKey
+    type NegotiatingState = {
+        LocalRequestedShutdown: Option<ShutdownScriptPubKey>
+        RemoteRequestedShutdown: Option<ShutdownScriptPubKey>
         LocalClosingFeesProposed: List<Money>
         RemoteClosingFeeProposed: Option<Money * LNECDSASignature>
-    }
+    } with
+        static member New(): NegotiatingState = {
+            LocalRequestedShutdown = None
+            RemoteRequestedShutdown = None
+            LocalClosingFeesProposed = List.empty
+            RemoteClosingFeeProposed = None
+        }
+        member self.HasEnteredShutdown(): bool =
+            self.LocalRequestedShutdown.IsSome && self.RemoteRequestedShutdown.IsSome
+
 
 //     8888888888 888     888 8888888888 888b    888 88888888888 .d8888b.
 //     888        888     888 888        8888b   888     888    d88P  Y88b
@@ -105,52 +86,18 @@ type ChannelEvent =
 
     | WeAcceptedRevokeAndACK of nextCommitments: Commitments * remoteNextPerCommitmentPoint: PerCommitmentPoint
 
-    | AcceptedOperationShutdown of msg: ShutdownMsg * nextLocalShutdownState: ShutdownState
-    | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of nextRemoteShutdownState: ShutdownState
+    | AcceptedOperationShutdown of msg: ShutdownMsg * localShutdownScriptPubKey: ShutdownScriptPubKey
+    | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdownScriptPubKey: ShutdownScriptPubKey
     /// We have to send closing_signed to initiate the negotiation only when if we are the funder
-    | AcceptedShutdownWhenNoPendingHTLCs of msgToSend: ClosingSignedMsg option * nextState: NegotiatingData
-    | AcceptedShutdownWhenWeHavePendingHTLCs of localShutdown: ShutdownMsg * nextState: NormalData
+    | AcceptedShutdownWhenNoPendingHTLCs of msgToSend: ClosingSignedMsg option * nextState: NegotiatingState
+    | AcceptedShutdownWhenWeHavePendingHTLCs of localShutdown: ShutdownMsg * localShutdownScript: ShutdownScriptPubKey * remoteShutdownScript: ShutdownScriptPubKey
 
     // ------ closing ------
     | MutualClosePerformed of txToPublish: FinalizedTx
-    | WeProposedNewClosingSigned of msgToSend: ClosingSignedMsg * nextState: NegotiatingData
+    | WeProposedNewClosingSigned of msgToSend: ClosingSignedMsg * nextState: NegotiatingState
     // -------- else ---------
     | Closed
     | Disconnected
     | ChannelStateRequestedSignCommitment
     | WeSentChannelReestablish of msg: ChannelReestablishMsg
-
-
-//      .d8888b. 88888888888     d8888 88888888888 8888888888 .d8888b.
-//     d88P  Y88b    888        d88888     888     888       d88P  Y88b
-//     Y88b.         888       d88P888     888     888       Y88b.
-//      "Y888b.      888      d88P 888     888     8888888    "Y888b.
-//         "Y88b.    888     d88P  888     888     888           "Y88b.
-//           "888    888    d88P   888     888     888             "888
-//     Y88b  d88P    888   d8888888888     888     888       Y88b  d88P
-//      "Y8888P"     888  d88P     888     888     8888888888 "Y8888P"
-    // --- setup ---
-
-open Data
-type ChannelStatePhase =
-    | Opening
-    | Normal
-    | Closing
-type ChannelState =
-    /// normal
-    | Normal of NormalData
-
-    /// Closing
-    | Negotiating of NegotiatingData
-    | Closing
-    with
-        interface IState 
-
-        static member Normal_: Prism<_, _> =
-            (fun cc -> match cc with
-                       | Normal s -> Some s
-                       | _ -> None ),
-            (fun v cc -> match cc with
-                         | Normal _ -> Normal v
-                         | _ -> cc )
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -69,7 +69,6 @@ module Data =
 
     type NormalData = {
         ShortChannelId: ShortChannelId
-        ChannelAnnouncement: Option<ChannelAnnouncementMsg>
         ChannelUpdate: ChannelUpdateMsg
         LocalShutdown: Option<ShutdownMsg>
         RemoteShutdown: Option<ShutdownMsg>

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,7 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedOperationAddHTLC of msg: UpdateAddHTLCMsg * newCommitments: Commitments
     | WeAcceptedUpdateAddHTLC of newCommitments: Commitments
 
     | WeAcceptedOperationFulfillHTLC of msg: UpdateFulfillHTLCMsg * newCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -71,7 +71,6 @@ module Data =
 
     type NormalData = {
         ShortChannelId: ShortChannelId
-        Buried: bool
         ChannelAnnouncement: Option<ChannelAnnouncementMsg>
         ChannelUpdate: ChannelUpdateMsg
         LocalShutdown: Option<ShutdownMsg>

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -3,7 +3,6 @@ namespace DotNetLightning.Channel
 open DotNetLightning.Chain
 open DotNetLightning.Utils
 open DotNetLightning.Utils.Aether
-open DotNetLightning.DomainUtils.Types
 open DotNetLightning.Serialization.Msgs
 open DotNetLightning.Transactions
 open DotNetLightning.Crypto
@@ -25,8 +24,6 @@ open NBitcoin
 
 [<AutoOpen>]
 module Data =
-    type IChannelStateData = interface inherit IStateData end
-
     type NegotiatingState = {
         LocalRequestedShutdown: Option<ShutdownScriptPubKey>
         RemoteRequestedShutdown: Option<ShutdownScriptPubKey>

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,8 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedFailMalformedHTLC of origin: HTLCSource * msg: UpdateAddHTLCMsg * newCommitments: Commitments
-
     | WeAcceptedOperationUpdateFee of msg: UpdateFeeMsg  * nextCommitments: Commitments
     | WeAcceptedUpdateFee of msg: UpdateFeeMsg * newCommitments: Commitments
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -34,29 +34,6 @@ module Data =
             (fun p -> p.LocalClosingSigned),
             (fun v p -> { p with LocalClosingSigned = v })
 
-    type LocalCommitPublished = {
-        CommitTx: CommitTx
-        ClaimMainDelayedOutputTx: ClaimDelayedOutputTx option
-        HTLCSuccessTxs: HTLCSuccessTx list
-        HTLCTimeoutTxs: HTLCTimeoutTx list
-    }
-
-    type RemoteCommitPublished = {
-        CommitTx: CommitTx
-        ClaimMainOutputTx: ClaimP2WPKHOutputTx
-        ClaimHTLCSuccessTxs: ClaimHTLCSuccessTx list
-        ClaimHTLCTimeoutTxs: ClaimHTLCTimeoutTx list
-    }
-
-    type RevokedCommitPublished = {
-        CommitTx: CommitTx
-        ClaimMainOutputTx: ClaimP2WPKHOutputTx option
-        MainPenaltyTx: MainPenaltyTx option
-        ClaimHTLCTimeoutTxs: ClaimHTLCTimeoutTx list
-        HTLCTimeoutTxs: HTLCTimeoutTx list
-        HTLCPenaltyTxs: HTLCPenaltyTx list
-    }
-
     type IChannelStateData = interface inherit IStateData end
 
     type ShutdownState = {
@@ -99,35 +76,10 @@ module Data =
 
     type ClosingData = {
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
-        MaybeFundingTx: Option<Transaction>
-        WaitingSince: System.DateTime
-        MutualCloseProposed: List<ClosingTx>
-        MutualClosePublished: FinalizedTx
-        LocalCommitPublished: Option<LocalCommitPublished>
-        RemoteCommitPublished: Option<RemoteCommitPublished>
-        NextRemoteCommitPublished: Option<RemoteCommitPublished>
-        FutureRemoteCommitPublished: Option<RemoteCommitPublished>
-        RevokedCommitPublished: List<RevokedCommitPublished>
     } with
-        member this.FinalizedTx =
-            this.MutualClosePublished
-        
-        static member Create (maybeFundingTx: Option<Transaction>)
-                             (waitingSince: System.DateTime)
-                             (mutualCloseProposed: List<ClosingTx>)
-                             (mutualClosePublished: FinalizedTx)
-                             (remoteNextCommitInfo: Option<RemoteNextCommitInfo>)
+        static member Create (remoteNextCommitInfo: Option<RemoteNextCommitInfo>)
                                  : ClosingData = {
-            RemoteNextCommitInfo= remoteNextCommitInfo
-            MaybeFundingTx = maybeFundingTx
-            WaitingSince = waitingSince
-            MutualCloseProposed = mutualCloseProposed
-            MutualClosePublished = mutualClosePublished
-            LocalCommitPublished = None
-            RemoteCommitPublished = None
-            NextRemoteCommitPublished = None
-            FutureRemoteCommitPublished = None
-            RevokedCommitPublished = []
+            RemoteNextCommitInfo = remoteNextCommitInfo
         }
 
 //     8888888888 888     888 8888888888 888b    888 88888888888 .d8888b.

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -343,14 +343,14 @@ type ChannelState =
             (fun v cc -> match cc with
                          | Normal _ -> Normal v
                          | _ -> cc )
-        member this.ChannelId: Option<ChannelId> =
+        member this.ChannelId: ChannelId =
             match this with
-            | WaitForFundingConfirmed data -> Some data.ChannelId
-            | WaitForFundingLocked data -> Some data.ChannelId
-            | Normal data -> Some data.ChannelId
-            | Shutdown data -> Some data.ChannelId
-            | Negotiating data -> Some data.ChannelId
-            | Closing data -> Some data.ChannelId
+            | WaitForFundingConfirmed data -> data.ChannelId
+            | WaitForFundingLocked data -> data.ChannelId
+            | Normal data -> data.ChannelId
+            | Shutdown data -> data.ChannelId
+            | Negotiating data -> data.ChannelId
+            | Closing data -> data.ChannelId
 
         member this.Phase =
             match this with
@@ -361,12 +361,12 @@ type ChannelState =
             | Negotiating _
             | Closing _ -> ChannelStatePhase.Closing
 
-        member this.Commitments: Option<Commitments> =
+        member this.Commitments: Commitments =
             match this with
-            | WaitForFundingConfirmed data -> Some (data :> IHasCommitments).Commitments
-            | WaitForFundingLocked data -> Some (data :> IHasCommitments).Commitments
-            | Normal data -> Some (data :> IHasCommitments).Commitments
-            | Shutdown data -> Some (data :> IHasCommitments).Commitments
-            | Negotiating data -> Some (data :> IHasCommitments).Commitments
-            | Closing data -> Some (data :> IHasCommitments).Commitments
+            | WaitForFundingConfirmed data -> (data :> IHasCommitments).Commitments
+            | WaitForFundingLocked data -> (data :> IHasCommitments).Commitments
+            | Normal data -> (data :> IHasCommitments).Commitments
+            | Shutdown data -> (data :> IHasCommitments).Commitments
+            | Negotiating data -> (data :> IHasCommitments).Commitments
+            | Closing data -> (data :> IHasCommitments).Commitments
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -61,15 +61,15 @@ module Data =
 
     type NormalData = {
         ShortChannelId: Option<ShortChannelId>
-        LocalShutdown: Option<ShutdownMsg>
-        RemoteShutdown: Option<ShutdownMsg>
+        LocalShutdown: Option<ShutdownScriptPubKey>
+        RemoteShutdown: Option<ShutdownScriptPubKey>
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
     }
 
     type NegotiatingData = {
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
-        LocalShutdown: ShutdownMsg
-        RemoteShutdown: ShutdownMsg
+        LocalShutdown: ShutdownScriptPubKey
+        RemoteShutdown: ShutdownScriptPubKey
         ClosingTxProposed: List<List<ClosingTxProposed>>
         MaybeBestUnpublishedTx: Option<FinalizedTx>
     }
@@ -151,10 +151,10 @@ type ChannelEvent =
     | WeAcceptedRevokeAndACK of nextCommitments: Commitments * remoteNextPerCommitmentPoint: PerCommitmentPoint
 
     | AcceptedOperationShutdown of msg: ShutdownMsg
-    | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdown: ShutdownMsg
+    | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdownScriptPubKey: ShutdownScriptPubKey
     /// We have to send closing_signed to initiate the negotiation only when if we are the funder
     | AcceptedShutdownWhenNoPendingHTLCs of msgToSend: ClosingSignedMsg option * nextState: NegotiatingData
-    | AcceptedShutdownWhenWeHavePendingHTLCs of localShutdown: ShutdownMsg * remoteShutdown: ShutdownMsg
+    | AcceptedShutdownWhenWeHavePendingHTLCs of localShutdown: ShutdownMsg * remoteShutdownScriptPubKey: ShutdownScriptPubKey
 
     // ------ closing ------
     | MutualClosePerformed of txToPublish: FinalizedTx * nextState : ClosingData

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,8 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedCommitmentSigned of msg: RevokeAndACKMsg * nextCommitments: Commitments
-
     | WeAcceptedRevokeAndACK of nextCommitments: Commitments * remoteNextPerCommitmentPoint: PerCommitmentPoint
 
     | AcceptedOperationShutdown of msg: ShutdownMsg * localShutdownScriptPubKey: ShutdownScriptPubKey

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -65,7 +65,6 @@ module Data =
 
     type WaitForFundingLockedData = {
         ShortChannelId: ShortChannelId
-        HaveWeSentFundingLocked: bool
     }
 
     type NormalData = {
@@ -132,9 +131,8 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     /// -------- init both -----
-    | FundingConfirmed of nextState: Data.WaitForFundingLockedData
+    | FundingConfirmed of FundingLockedMsg * nextState: Data.WaitForFundingLockedData
     | TheySentFundingLocked of msg: FundingLockedMsg
-    | WeSentFundingLocked of msg: FundingLockedMsg
     | WeResumedDelayedFundingLocked of msg: FundingLockedMsg
     | BothFundingLocked of nextState: Data.NormalData * nextCommitments: Commitments
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -46,3 +46,7 @@ type ClosingSignedResponse =
     | NewClosingSigned of ClosingSignedMsg
     | MutualClose of FinalizedTx
 
+type SavedChannelState = {
+    StaticChannelConfig: StaticChannelConfig
+}
+

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -61,14 +61,12 @@ module Data =
 
     type WaitForFundingConfirmedData = {
         Deferred: Option<FundingLockedMsg>
-        InitialFeeRatePerKw: FeeRatePerKw
     }
 
     type WaitForFundingLockedData = {
         ShortChannelId: ShortChannelId
         OurMessage: FundingLockedMsg
         TheirMessage: Option<FundingLockedMsg>
-        InitialFeeRatePerKw: FeeRatePerKw
         HaveWeSentFundingLocked: bool
     }
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -44,7 +44,6 @@ module Data =
         ShortChannelId: Option<ShortChannelId>
         LocalShutdownState: Option<ShutdownState>
         RemoteShutdownState: Option<ShutdownState>
-        RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
     } with
         member self.HasEnteredShutdown(): bool =
             let localEnteredShutdown =
@@ -58,20 +57,11 @@ module Data =
             localEnteredShutdown || remoteEnteredShutdown
 
     type NegotiatingData = {
-        RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
         LocalShutdown: ShutdownScriptPubKey
         RemoteShutdown: ShutdownScriptPubKey
         LocalClosingFeesProposed: List<Money>
         RemoteClosingFeeProposed: Option<Money * LNECDSASignature>
     }
-
-    type ClosingData = {
-        RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
-    } with
-        static member Create (remoteNextCommitInfo: Option<RemoteNextCommitInfo>)
-                                 : ClosingData = {
-            RemoteNextCommitInfo = remoteNextCommitInfo
-        }
 
 //     8888888888 888     888 8888888888 888b    888 88888888888 .d8888b.
 //     888        888     888 888        8888b   888     888    d88P  Y88b
@@ -90,7 +80,7 @@ type ChannelEvent =
     | FundingConfirmed of FundingLockedMsg * shortChannelId: ShortChannelId
     | TheySentFundingLocked of msg: FundingLockedMsg
     | WeResumedDelayedFundingLocked of remoteNextPerCommitmentPoint: PerCommitmentPoint
-    | BothFundingLocked of nextState: Data.NormalData
+    | BothFundingLocked of remoteNextPerCommitmentPoint: PerCommitmentPoint
 
     // -------- normal operation ------
     | WeAcceptedOperationMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg * newCommitments: Commitments
@@ -123,7 +113,7 @@ type ChannelEvent =
     | AcceptedShutdownWhenWeHavePendingHTLCs of localShutdown: ShutdownMsg * nextState: NormalData
 
     // ------ closing ------
-    | MutualClosePerformed of txToPublish: FinalizedTx * nextState : ClosingData
+    | MutualClosePerformed of txToPublish: FinalizedTx
     | WeProposedNewClosingSigned of msgToSend: ClosingSignedMsg * nextState: NegotiatingData
     // -------- else ---------
     | Closed
@@ -153,7 +143,7 @@ type ChannelState =
 
     /// Closing
     | Negotiating of NegotiatingData
-    | Closing of ClosingData
+    | Closing
     with
         interface IState 
 
@@ -164,16 +154,4 @@ type ChannelState =
             (fun v cc -> match cc with
                          | Normal _ -> Normal v
                          | _ -> cc )
-        member this.Phase =
-            match this with
-            | Normal normalData ->
-                if normalData.HasEnteredShutdown() then
-                    ChannelStatePhase.Closing
-                else
-                    if normalData.ShortChannelId.IsNone || normalData.RemoteNextCommitInfo.IsNone then
-                        ChannelStatePhase.Opening
-                    else
-                        ChannelStatePhase.Normal
-            | Negotiating _
-            | Closing _ -> ChannelStatePhase.Closing
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,8 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedUpdateFee of msg: UpdateFeeMsg * newCommitments: Commitments
-
     | WeAcceptedOperationSign of msg: CommitmentSignedMsg * nextCommitments: Commitments * nextRemoteCommit: RemoteCommit
     | WeAcceptedCommitmentSigned of msg: RevokeAndACKMsg * nextCommitments: Commitments
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -73,14 +73,17 @@ module Data =
         ChannelUpdate: ChannelUpdateMsg
         LocalShutdown: Option<ShutdownMsg>
         RemoteShutdown: Option<ShutdownMsg>
+        RemoteNextCommitInfo: RemoteNextCommitInfo
     }
 
     type ShutdownData = {
+        RemoteNextCommitInfo: RemoteNextCommitInfo
         LocalShutdown: ShutdownMsg
         RemoteShutdown: ShutdownMsg
     }
 
     type NegotiatingData = {
+        RemoteNextCommitInfo: RemoteNextCommitInfo
         LocalShutdown: ShutdownMsg
         RemoteShutdown: ShutdownMsg
         ClosingTxProposed: List<List<ClosingTxProposed>>
@@ -88,6 +91,7 @@ module Data =
     }
 
     type ClosingData = {
+        RemoteNextCommitInfo: RemoteNextCommitInfo
         MaybeFundingTx: Option<Transaction>
         WaitingSince: System.DateTime
         MutualCloseProposed: List<ClosingTx>
@@ -105,7 +109,9 @@ module Data =
                              (waitingSince: System.DateTime)
                              (mutualCloseProposed: List<ClosingTx>)
                              (mutualClosePublished: FinalizedTx)
+                             (remoteNextCommitInfo: RemoteNextCommitInfo)
                                  : ClosingData = {
+            RemoteNextCommitInfo = remoteNextCommitInfo
             MaybeFundingTx = maybeFundingTx
             WaitingSince = waitingSince
             MutualCloseProposed = mutualCloseProposed
@@ -134,7 +140,7 @@ type ChannelEvent =
     | FundingConfirmed of FundingLockedMsg * nextState: Data.WaitForFundingLockedData
     | TheySentFundingLocked of msg: FundingLockedMsg
     | WeResumedDelayedFundingLocked of msg: FundingLockedMsg
-    | BothFundingLocked of nextState: Data.NormalData * nextCommitments: Commitments
+    | BothFundingLocked of nextState: Data.NormalData
 
     // -------- normal operation ------
     | WeAcceptedOperationMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg * newCommitments: Commitments
@@ -155,10 +161,10 @@ type ChannelEvent =
     | WeAcceptedOperationUpdateFee of msg: UpdateFeeMsg  * nextCommitments: Commitments
     | WeAcceptedUpdateFee of msg: UpdateFeeMsg * newCommitments: Commitments
 
-    | WeAcceptedOperationSign of msg: CommitmentSignedMsg * nextCommitments: Commitments
+    | WeAcceptedOperationSign of msg: CommitmentSignedMsg * nextCommitments: Commitments * WaitingForRevocation
     | WeAcceptedCommitmentSigned of msg: RevokeAndACKMsg * nextCommitments: Commitments
 
-    | WeAcceptedRevokeAndACK of nextCommitments: Commitments
+    | WeAcceptedRevokeAndACK of nextCommitments: Commitments * remoteNextPerCommitmentPoint: PerCommitmentPoint
 
     | AcceptedOperationShutdown of msg: ShutdownMsg
     | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdown: ShutdownMsg * nextCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,7 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedOperationSign of msg: CommitmentSignedMsg * nextCommitments: Commitments * nextRemoteCommit: RemoteCommit
     | WeAcceptedCommitmentSigned of msg: RevokeAndACKMsg * nextCommitments: Commitments
 
     | WeAcceptedRevokeAndACK of nextCommitments: Commitments * remoteNextPerCommitmentPoint: PerCommitmentPoint

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -48,5 +48,6 @@ type ClosingSignedResponse =
 
 type SavedChannelState = {
     StaticChannelConfig: StaticChannelConfig
+    RemotePerCommitmentSecrets: PerCommitmentSecretStore
 }
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -64,9 +64,6 @@ module Data =
         abstract member Commitments: Commitments
 
 
-    type WaitForOpenChannelData = { InitFundee: InputInitFundee }
-        with interface IChannelStateData
-
     type WaitForAcceptChannelData = {
             InputInitFunder: InputInitFunder;
             LastSent: OpenChannelMsg
@@ -78,18 +75,6 @@ module Data =
         LastSent: OpenChannelMsg
         LastReceived: AcceptChannelMsg
     }
-
-    type WaitForFundingInternalData = {
-                                            TemporaryChannelId: ChannelId
-                                            LocalParams: LocalParams
-                                            RemoteParams:RemoteParams
-                                            FundingSatoshis: Money
-                                            PushMsat: LNMoney
-                                            InitialFeeRatePerKw: FeeRatePerKw
-                                            RemoteFirstPerCommitmentPoint: PerCommitmentPoint
-                                            LastSent: OpenChannelMsg
-                                        }
-        with interface IChannelStateData
 
     type WaitForFundingCreatedData = {
                                             TemporaryFailure: ChannelId
@@ -234,17 +219,6 @@ module Data =
                     FutureRemoteCommitPublished = None
                     RevokedCommitPublished = []
                 }
-
-    type WaitForRemotePublishFutureCommitmentData = {
-                                                    Commitments: Commitments;
-                                                    RemoteChannelReestablish: ChannelReestablishMsg
-                                                    ChannelId: ChannelId
-                                                   }
-        with interface IHasCommitments with
-                member this.ChannelId: ChannelId = 
-                    this.ChannelId
-                member this.Commitments: Commitments = 
-                    this.Commitments
 
 //     8888888888 888     888 8888888888 888b    888 88888888888 .d8888b.
 //     888        888     888 888        8888b   888     888    d88P  Y88b

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,7 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedOperationFulfillHTLC of msg: UpdateFulfillHTLCMsg * newCommitments: Commitments
     | WeAcceptedFulfillHTLC of msg: UpdateFulfillHTLCMsg * origin: HTLCSource * htlc: UpdateAddHTLCMsg * newCommitments: Commitments
 
     | WeAcceptedOperationFailHTLC of msg: UpdateFailHTLCMsg * newCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -70,7 +70,7 @@ module Data =
         RemoteNextCommitInfo: Option<RemoteNextCommitInfo>
         LocalShutdown: ShutdownScriptPubKey
         RemoteShutdown: ShutdownScriptPubKey
-        ClosingTxProposed: List<List<ClosingTxProposed>>
+        ClosingTxProposed: List<Option<ClosingTxProposed>>
         MaybeBestUnpublishedTx: Option<FinalizedTx>
     }
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -161,7 +161,7 @@ type ChannelEvent =
     | WeAcceptedOperationUpdateFee of msg: UpdateFeeMsg  * nextCommitments: Commitments
     | WeAcceptedUpdateFee of msg: UpdateFeeMsg * newCommitments: Commitments
 
-    | WeAcceptedOperationSign of msg: CommitmentSignedMsg * nextCommitments: Commitments * WaitingForRevocation
+    | WeAcceptedOperationSign of msg: CommitmentSignedMsg * nextCommitments: Commitments * nextRemoteCommit: RemoteCommit
     | WeAcceptedCommitmentSigned of msg: RevokeAndACKMsg * nextCommitments: Commitments
 
     | WeAcceptedRevokeAndACK of nextCommitments: Commitments * remoteNextPerCommitmentPoint: PerCommitmentPoint

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -42,6 +42,9 @@ module Data =
         member self.HasEnteredShutdown(): bool =
             self.LocalRequestedShutdown.IsSome && self.RemoteRequestedShutdown.IsSome
 
+type ClosingSignedResponse =
+    | NewClosingSigned of ClosingSignedMsg
+    | MutualClose of FinalizedTx
 
 //     8888888888 888     888 8888888888 888b    888 88888888888 .d8888b.
 //     888        888     888 888        8888b   888     888    d88P  Y88b
@@ -56,9 +59,6 @@ module Data =
 /// The one that includes `Operation` in its name is the event which we are the initiator
 type ChannelEvent =
     // --- ln events ---
-    // ------ closing ------
-    | MutualClosePerformed of txToPublish: FinalizedTx
-    | WeProposedNewClosingSigned of msgToSend: ClosingSignedMsg * nextState: NegotiatingState
     // -------- else ---------
     | Closed
     | Disconnected

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -59,7 +59,6 @@ type ChannelEvent =
     // -------- normal operation ------
     | WeAcceptedFailHTLC of origin: HTLCSource * msg: UpdateAddHTLCMsg * nextCommitments: Commitments
 
-    | WeAcceptedOperationFailMalformedHTLC of msg: UpdateFailMalformedHTLCMsg * newCommitments: Commitments
     | WeAcceptedFailMalformedHTLC of origin: HTLCSource * msg: UpdateAddHTLCMsg * newCommitments: Commitments
 
     | WeAcceptedOperationUpdateFee of msg: UpdateFeeMsg  * nextCommitments: Commitments

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -276,6 +276,9 @@ type ChannelEvent =
     | BothFundingLocked of nextState: Data.NormalData
 
     // -------- normal operation ------
+    | WeAcceptedOperationMonoHopUnidirectionalPayment of msg: MonoHopUnidirectionalPaymentMsg * newCommitments: Commitments
+    | WeAcceptedMonoHopUnidirectionalPayment of newCommitments: Commitments
+
     | WeAcceptedOperationAddHTLC of msg: UpdateAddHTLCMsg * newCommitments: Commitments
     | WeAcceptedUpdateAddHTLC of newCommitments: Commitments
 
@@ -368,6 +371,27 @@ type ChannelState =
             (fun v cc -> match cc with
                          | Normal _ -> Normal v
                          | _ -> cc )
+        member this.ChannelId: Option<ChannelId> =
+            match this with
+            | WaitForInitInternal
+            | WaitForOpenChannel _
+            | WaitForAcceptChannel _
+            | WaitForFundingTx _
+            | WaitForFundingCreated _ -> None
+            | WaitForFundingSigned data -> Some data.ChannelId
+            | WaitForFundingConfirmed data -> Some data.ChannelId
+            | WaitForFundingLocked data -> Some data.ChannelId
+            | Normal data -> Some data.ChannelId
+            | Shutdown data -> Some data.ChannelId
+            | Negotiating data -> Some data.ChannelId
+            | Closing data -> Some data.ChannelId
+            | Closed _
+            | Offline _
+            | Syncing _
+            | ErrFundingLost _
+            | ErrFundingTimeOut _
+            | ErrInformationLeak _ -> None
+
         member this.Phase =
             match this with
             | WaitForInitInternal
@@ -388,3 +412,25 @@ type ChannelState =
             | ErrFundingLost _
             | ErrFundingTimeOut _
             | ErrInformationLeak _ -> Abnormal
+
+        member this.Commitments: Option<Commitments> =
+            match this with
+            | WaitForInitInternal
+            | WaitForOpenChannel _
+            | WaitForAcceptChannel _
+            | WaitForFundingTx _
+            | WaitForFundingCreated _
+            | WaitForFundingSigned _ -> None
+            | WaitForFundingConfirmed data -> Some (data :> IHasCommitments).Commitments
+            | WaitForFundingLocked data -> Some (data :> IHasCommitments).Commitments
+            | Normal data -> Some (data :> IHasCommitments).Commitments
+            | Shutdown data -> Some (data :> IHasCommitments).Commitments
+            | Negotiating data -> Some (data :> IHasCommitments).Commitments
+            | Closing data -> Some (data :> IHasCommitments).Commitments
+            | Closed _
+            | Offline _
+            | Syncing _
+            | ErrFundingLost _
+            | ErrFundingTimeOut _
+            | ErrInformationLeak _ -> None
+

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -61,7 +61,6 @@ module Data =
 
     type WaitForFundingConfirmedData = {
         Deferred: Option<FundingLockedMsg>
-        LastSent: Choice<FundingCreatedMsg, FundingSignedMsg>
         InitialFeeRatePerKw: FeeRatePerKw
     }
 

--- a/src/DotNetLightning.Core/Channel/ChannelTypes.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelTypes.fs
@@ -57,8 +57,6 @@ module Data =
 type ChannelEvent =
     // --- ln events ---
     // -------- normal operation ------
-    | WeAcceptedRevokeAndACK of nextCommitments: Commitments * remoteNextPerCommitmentPoint: PerCommitmentPoint
-
     | AcceptedOperationShutdown of msg: ShutdownMsg * localShutdownScriptPubKey: ShutdownScriptPubKey
     | AcceptedShutdownWhileWeHaveUnsignedOutgoingHTLCs of remoteShutdownScriptPubKey: ShutdownScriptPubKey
     /// We have to send closing_signed to initiate the negotiation only when if we are the funder

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -161,7 +161,7 @@ module internal ChannelHelpers =
 module internal Validation =
 
     open DotNetLightning.Channel
-    let checkOurOpenChannelMsgAcceptable (_conf: ChannelConfig) (msg: OpenChannelMsg) =
+    let checkOurOpenChannelMsgAcceptable (msg: OpenChannelMsg) =
         Validation.ofResult(OpenChannelMsgValidation.checkFundingSatoshisLessThanMax msg)
         *^> OpenChannelMsgValidation.checkChannelReserveSatohisLessThanFundingSatoshis msg
         *^> OpenChannelMsgValidation.checkPushMSatLesserThanFundingValue msg
@@ -170,23 +170,28 @@ module internal Validation =
         *^> OpenChannelMsgValidation.checkFunderCanAffordFee (msg.FeeRatePerKw) msg
         |> Result.mapError((@)["open_channel msg is invalid"] >> InvalidOpenChannelError.Create msg >> InvalidOpenChannel)
 
-    let internal checkOpenChannelMsgAcceptable (feeEstimator: IFeeEstimator) (conf: ChannelConfig) (msg: OpenChannelMsg) =
+    let internal checkOpenChannelMsgAcceptable (feeEstimator: IFeeEstimator)
+                                               (channelHandshakeLimits: ChannelHandshakeLimits)
+                                               (channelOptions: ChannelOptions)
+                                               (msg: OpenChannelMsg) =
         let feeRate = feeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.Background)
         Validation.ofResult(OpenChannelMsgValidation.checkFundingSatoshisLessThanMax msg)
         *^> OpenChannelMsgValidation.checkChannelReserveSatohisLessThanFundingSatoshis msg
         *^> OpenChannelMsgValidation.checkPushMSatLesserThanFundingValue msg
         *^> OpenChannelMsgValidation.checkFundingSatoshisLessThanDustLimitSatoshis msg
-        *^> OpenChannelMsgValidation.checkRemoteFee feeEstimator msg.FeeRatePerKw conf.ChannelOptions.MaxFeeRateMismatchRatio
+        *^> OpenChannelMsgValidation.checkRemoteFee feeEstimator msg.FeeRatePerKw channelOptions.MaxFeeRateMismatchRatio
         *^> OpenChannelMsgValidation.checkToSelfDelayIsInAcceptableRange msg
         *^> OpenChannelMsgValidation.checkMaxAcceptedHTLCs msg
-        *> OpenChannelMsgValidation.checkConfigPermits conf.PeerChannelConfigLimits msg
-        *^> OpenChannelMsgValidation.checkChannelAnnouncementPreferenceAcceptable conf msg
+        *> OpenChannelMsgValidation.checkConfigPermits channelHandshakeLimits msg
+        *^> OpenChannelMsgValidation.checkChannelAnnouncementPreferenceAcceptable channelHandshakeLimits channelOptions msg
         *> OpenChannelMsgValidation.checkIsAcceptableByCurrentFeeRate feeEstimator msg
         *^> OpenChannelMsgValidation.checkFunderCanAffordFee feeRate msg
         |> Result.mapError((@)["rejected received open_channel msg"] >> InvalidOpenChannelError.Create msg >> InvalidOpenChannel)
 
 
-    let internal checkAcceptChannelMsgAcceptable (conf: ChannelConfig) (state) (msg: AcceptChannelMsg) =
+    let internal checkAcceptChannelMsgAcceptable (channelHandshakeLimits: ChannelHandshakeLimits)
+                                                 (state: WaitForAcceptChannelData)
+                                                 (msg: AcceptChannelMsg) =
         Validation.ofResult(AcceptChannelMsgValidation.checkMaxAcceptedHTLCs msg)
         *^> AcceptChannelMsgValidation.checkDustLimit msg
         *^> (AcceptChannelMsgValidation.checkChannelReserveSatoshis state msg)
@@ -194,7 +199,7 @@ module internal Validation =
         *^> AcceptChannelMsgValidation.checkDustLimitIsLargerThanOurChannelReserve state msg
         *^> AcceptChannelMsgValidation.checkMinimumHTLCValueIsAcceptable state msg
         *^> AcceptChannelMsgValidation.checkToSelfDelayIsAcceptable msg
-        *> AcceptChannelMsgValidation.checkConfigPermits conf.PeerChannelConfigLimits msg
+        *> AcceptChannelMsgValidation.checkConfigPermits channelHandshakeLimits msg
         |> Result.mapError(InvalidAcceptChannelError.Create msg >> InvalidAcceptChannel)
 
     let checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -239,20 +239,13 @@ module internal Validation =
         *^> UpdateAddHTLCValidationWithContext.checkWeHaveSufficientFunds state currentSpec
         |> Result.mapError(InvalidUpdateAddHTLCError.Create add >> InvalidUpdateAddHTLC)
 
-    let checkShutdownScriptPubKeyAcceptable (shutdownStateOpt: Option<ShutdownState>)
+    let checkShutdownScriptPubKeyAcceptable (staticShutdownScriptPubKey: Option<ShutdownScriptPubKey>)
                                             (requestedShutdownScriptPubKey: ShutdownScriptPubKey)
-                                                : Result<ShutdownState, ChannelError> = result {
-            match shutdownStateOpt with
-            | None -> ()
-            | Some shutdownState ->
-                if shutdownState.ShutdownScriptPubKey <> requestedShutdownScriptPubKey then
-                    do!
-                        Error <|
-                            cannotCloseChannel
-                                "requested shutdown script does not match shutdown \
-                                script in open/accept channel"
-            return {
-                ShutdownScriptPubKey = requestedShutdownScriptPubKey
-                HasRequestedShutdown = true
-            }
-        }
+                                                : Result<unit, ChannelError> =
+        match staticShutdownScriptPubKey with
+        | Some scriptPubKey when scriptPubKey <> requestedShutdownScriptPubKey ->
+            Error <|
+                cannotCloseChannel
+                    "requested shutdown script does not match shutdown \
+                    script in open/accept channel"
+        | _ -> Ok ()

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -190,17 +190,17 @@ module internal Validation =
 
 
     let internal checkAcceptChannelMsgAcceptable (channelHandshakeLimits: ChannelHandshakeLimits)
-                                                 (state: WaitForAcceptChannelData)
-                                                 (msg: AcceptChannelMsg) =
-        Validation.ofResult(AcceptChannelMsgValidation.checkMaxAcceptedHTLCs msg)
-        *^> AcceptChannelMsgValidation.checkDustLimit msg
-        *^> (AcceptChannelMsgValidation.checkChannelReserveSatoshis state msg)
-        *^> AcceptChannelMsgValidation.checkChannelReserveSatoshis state msg
-        *^> AcceptChannelMsgValidation.checkDustLimitIsLargerThanOurChannelReserve state msg
-        *^> AcceptChannelMsgValidation.checkMinimumHTLCValueIsAcceptable state msg
-        *^> AcceptChannelMsgValidation.checkToSelfDelayIsAcceptable msg
-        *> AcceptChannelMsgValidation.checkConfigPermits channelHandshakeLimits msg
-        |> Result.mapError(InvalidAcceptChannelError.Create msg >> InvalidAcceptChannel)
+                                                 (fundingSatoshis: Money)
+                                                 (openChannelMsg: OpenChannelMsg)
+                                                 (acceptChannelMsg: AcceptChannelMsg) =
+        Validation.ofResult(AcceptChannelMsgValidation.checkMaxAcceptedHTLCs acceptChannelMsg)
+        *^> AcceptChannelMsgValidation.checkDustLimit acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkChannelReserveSatoshis fundingSatoshis openChannelMsg acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkDustLimitIsLargerThanOurChannelReserve openChannelMsg acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkMinimumHTLCValueIsAcceptable openChannelMsg acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkToSelfDelayIsAcceptable acceptChannelMsg
+        *> AcceptChannelMsgValidation.checkConfigPermits channelHandshakeLimits acceptChannelMsg
+        |> Result.mapError(InvalidAcceptChannelError.Create acceptChannelMsg >> InvalidAcceptChannel)
 
     let checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =
         Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -210,10 +210,10 @@ module internal Validation =
         Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
         |> Result.mapError(fun errs -> InvalidMonoHopUnidirectionalPayment { NetworkMsg = payment; Errors = errs })
 
-    let checkOperationAddHTLC (state: NormalData) (op: OperationAddHTLC) =
+    let checkOperationAddHTLC (commitments: Commitments) (op: OperationAddHTLC) =
         Validation.ofResult(UpdateAddHTLCValidation.checkExpiryIsNotPast op.CurrentHeight op.Expiry)
         *> UpdateAddHTLCValidation.checkExpiryIsInAcceptableRange op.CurrentHeight op.Expiry
-        *^> UpdateAddHTLCValidation.checkAmountIsLargerThanMinimum state.Commitments.RemoteParams.HTLCMinimumMSat op.Amount
+        *^> UpdateAddHTLCValidation.checkAmountIsLargerThanMinimum commitments.RemoteParams.HTLCMinimumMSat op.Amount
         |> Result.mapError(InvalidOperationAddHTLCError.Create op >> InvalidOperationAddHTLC)
 
     let checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (add: UpdateAddHTLCMsg) =

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -191,13 +191,14 @@ module internal Validation =
 
     let internal checkAcceptChannelMsgAcceptable (channelHandshakeLimits: ChannelHandshakeLimits)
                                                  (fundingSatoshis: Money)
-                                                 (openChannelMsg: OpenChannelMsg)
+                                                 (channelReserveSatoshis: Money)
+                                                 (dustLimitSatoshis: Money)
                                                  (acceptChannelMsg: AcceptChannelMsg) =
         Validation.ofResult(AcceptChannelMsgValidation.checkMaxAcceptedHTLCs acceptChannelMsg)
         *^> AcceptChannelMsgValidation.checkDustLimit acceptChannelMsg
-        *^> AcceptChannelMsgValidation.checkChannelReserveSatoshis fundingSatoshis openChannelMsg acceptChannelMsg
-        *^> AcceptChannelMsgValidation.checkDustLimitIsLargerThanOurChannelReserve openChannelMsg acceptChannelMsg
-        *^> AcceptChannelMsgValidation.checkMinimumHTLCValueIsAcceptable openChannelMsg acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkChannelReserveSatoshis fundingSatoshis channelReserveSatoshis dustLimitSatoshis acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkDustLimitIsLargerThanOurChannelReserve channelReserveSatoshis acceptChannelMsg
+        *^> AcceptChannelMsgValidation.checkMinimumHTLCValueIsAcceptable fundingSatoshis acceptChannelMsg
         *^> AcceptChannelMsgValidation.checkToSelfDelayIsAcceptable acceptChannelMsg
         *> AcceptChannelMsgValidation.checkConfigPermits channelHandshakeLimits acceptChannelMsg
         |> Result.mapError(InvalidAcceptChannelError.Create acceptChannelMsg >> InvalidAcceptChannel)

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -176,6 +176,7 @@ module internal Validation =
     let internal checkOpenChannelMsgAcceptable (feeEstimator: IFeeEstimator)
                                                (channelHandshakeLimits: ChannelHandshakeLimits)
                                                (channelOptions: ChannelOptions)
+                                               (announceChannel: bool)
                                                (msg: OpenChannelMsg) =
         let feeRate = feeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.Background)
         Validation.ofResult(OpenChannelMsgValidation.checkFundingSatoshisLessThanMax msg)
@@ -186,7 +187,7 @@ module internal Validation =
         *^> OpenChannelMsgValidation.checkToSelfDelayIsInAcceptableRange msg
         *^> OpenChannelMsgValidation.checkMaxAcceptedHTLCs msg
         *> OpenChannelMsgValidation.checkConfigPermits channelHandshakeLimits msg
-        *^> OpenChannelMsgValidation.checkChannelAnnouncementPreferenceAcceptable channelHandshakeLimits channelOptions msg
+        *^> OpenChannelMsgValidation.checkChannelAnnouncementPreferenceAcceptable channelHandshakeLimits announceChannel msg
         *> OpenChannelMsgValidation.checkIsAcceptableByCurrentFeeRate feeEstimator msg
         *^> OpenChannelMsgValidation.checkFunderCanAffordFee feeRate msg
         |> Result.mapError((@)["rejected received open_channel msg"] >> InvalidOpenChannelError.Create msg >> InvalidOpenChannel)
@@ -206,37 +207,59 @@ module internal Validation =
         *> AcceptChannelMsgValidation.checkConfigPermits channelHandshakeLimits acceptChannelMsg
         |> Result.mapError(InvalidAcceptChannelError.Create acceptChannelMsg >> InvalidAcceptChannel)
 
-    let checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =
-        Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+    let checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec)
+                                                                        (staticChannelConfig: StaticChannelConfig)
+                                                                        (payment: MonoHopUnidirectionalPaymentMsg) =
+        MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds
+            staticChannelConfig
+            currentSpec
+        |> Validation.ofResult
         |> Result.mapError(fun errs -> InvalidMonoHopUnidirectionalPayment { NetworkMsg = payment; Errors = errs })
 
-    let checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =
-        Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+    let checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec)
+                                                                          (staticChannelConfig: StaticChannelConfig)
+                                                                          (payment: MonoHopUnidirectionalPaymentMsg) =
+        MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds
+            staticChannelConfig
+            currentSpec
+        |> Validation.ofResult
         |> Result.mapError(fun errs -> InvalidMonoHopUnidirectionalPayment { NetworkMsg = payment; Errors = errs })
 
-    let checkOperationAddHTLC (commitments: Commitments) (op: OperationAddHTLC) =
+    let checkOperationAddHTLC (remoteParams: RemoteParams) (op: OperationAddHTLC) =
         Validation.ofResult(UpdateAddHTLCValidation.checkExpiryIsNotPast op.CurrentHeight op.Expiry)
         *> UpdateAddHTLCValidation.checkExpiryIsInAcceptableRange op.CurrentHeight op.Expiry
-        *^> UpdateAddHTLCValidation.checkAmountIsLargerThanMinimum commitments.RemoteParams.HTLCMinimumMSat op.Amount
+        *^> UpdateAddHTLCValidation.checkAmountIsLargerThanMinimum remoteParams.HTLCMinimumMSat op.Amount
         |> Result.mapError(InvalidOperationAddHTLCError.Create op >> InvalidOperationAddHTLC)
 
-    let checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (add: UpdateAddHTLCMsg) =
-        Validation.ofResult(UpdateAddHTLCValidationWithContext.checkLessThanHTLCValueInFlightLimit currentSpec state.RemoteParams.MaxHTLCValueInFlightMSat add)
-        *^> UpdateAddHTLCValidationWithContext.checkLessThanMaxAcceptedHTLC currentSpec state.RemoteParams.MaxAcceptedHTLCs
-        *^> UpdateAddHTLCValidationWithContext.checkWeHaveSufficientFunds state currentSpec
+    let checkOurUpdateAddHTLCIsAcceptableWithCurrentSpec (currentSpec)
+                                                         (staticChannelConfig: StaticChannelConfig)
+                                                         (add: UpdateAddHTLCMsg) =
+        Validation.ofResult(
+            UpdateAddHTLCValidationWithContext.checkLessThanHTLCValueInFlightLimit
+                currentSpec
+                staticChannelConfig.RemoteParams.MaxHTLCValueInFlightMSat
+                add
+        )
+        *^> UpdateAddHTLCValidationWithContext.checkLessThanMaxAcceptedHTLC currentSpec staticChannelConfig.RemoteParams.MaxAcceptedHTLCs
+        *^> UpdateAddHTLCValidationWithContext.checkWeHaveSufficientFunds staticChannelConfig currentSpec
         |> Result.mapError(InvalidUpdateAddHTLCError.Create add >> InvalidUpdateAddHTLC)
 
-    let checkTheirUpdateAddHTLCIsAcceptable (state: Commitments) (add: UpdateAddHTLCMsg) (currentHeight: BlockHeight) =
+    let checkTheirUpdateAddHTLCIsAcceptable (state: Commitments)
+                                            (localParams: LocalParams)
+                                            (add: UpdateAddHTLCMsg)
+                                            (currentHeight: BlockHeight) =
         Validation.ofResult(ValidationHelper.check add.HTLCId (<>) state.RemoteNextHTLCId "Received Unexpected HTLCId (%A). Must be (%A)")
             *^> UpdateAddHTLCValidation.checkExpiryIsNotPast currentHeight add.CLTVExpiry
             *> UpdateAddHTLCValidation.checkExpiryIsInAcceptableRange currentHeight add.CLTVExpiry
-            *^> UpdateAddHTLCValidation.checkAmountIsLargerThanMinimum state.LocalParams.HTLCMinimumMSat add.Amount
+            *^> UpdateAddHTLCValidation.checkAmountIsLargerThanMinimum localParams.HTLCMinimumMSat add.Amount
             |> Result.mapError(InvalidUpdateAddHTLCError.Create add >> InvalidUpdateAddHTLC)
 
-    let checkTheirUpdateAddHTLCIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (add: UpdateAddHTLCMsg) =
-        Validation.ofResult(UpdateAddHTLCValidationWithContext.checkLessThanHTLCValueInFlightLimit currentSpec state.LocalParams.MaxHTLCValueInFlightMSat add)
-        *^> UpdateAddHTLCValidationWithContext.checkLessThanMaxAcceptedHTLC currentSpec state.LocalParams.MaxAcceptedHTLCs
-        *^> UpdateAddHTLCValidationWithContext.checkWeHaveSufficientFunds state currentSpec
+    let checkTheirUpdateAddHTLCIsAcceptableWithCurrentSpec (currentSpec)
+                                                           (staticChannelConfig: StaticChannelConfig)
+                                                           (add: UpdateAddHTLCMsg) =
+        Validation.ofResult(UpdateAddHTLCValidationWithContext.checkLessThanHTLCValueInFlightLimit currentSpec staticChannelConfig.LocalParams.MaxHTLCValueInFlightMSat add)
+        *^> UpdateAddHTLCValidationWithContext.checkLessThanMaxAcceptedHTLC currentSpec staticChannelConfig.LocalParams.MaxAcceptedHTLCs
+        *^> UpdateAddHTLCValidationWithContext.checkWeHaveSufficientFunds staticChannelConfig currentSpec
         |> Result.mapError(InvalidUpdateAddHTLCError.Create add >> InvalidUpdateAddHTLC)
 
     let checkShutdownScriptPubKeyAcceptable (staticShutdownScriptPubKey: Option<ShutdownScriptPubKey>)

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -173,22 +173,21 @@ module internal Validation =
         *^> OpenChannelMsgValidation.checkFunderCanAffordFee (msg.FeeRatePerKw) msg
         |> Result.mapError((@)["open_channel msg is invalid"] >> InvalidOpenChannelError.Create msg >> InvalidOpenChannel)
 
-    let internal checkOpenChannelMsgAcceptable (feeEstimator: IFeeEstimator)
-                                               (channelHandshakeLimits: ChannelHandshakeLimits)
+    let internal checkOpenChannelMsgAcceptable (channelHandshakeLimits: ChannelHandshakeLimits)
                                                (channelOptions: ChannelOptions)
                                                (announceChannel: bool)
                                                (msg: OpenChannelMsg) =
-        let feeRate = feeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.Background)
+        let feeRate = channelOptions.FeeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.Background)
         Validation.ofResult(OpenChannelMsgValidation.checkFundingSatoshisLessThanMax msg)
         *^> OpenChannelMsgValidation.checkChannelReserveSatohisLessThanFundingSatoshis msg
         *^> OpenChannelMsgValidation.checkPushMSatLesserThanFundingValue msg
         *^> OpenChannelMsgValidation.checkFundingSatoshisLessThanDustLimitSatoshis msg
-        *^> OpenChannelMsgValidation.checkRemoteFee feeEstimator msg.FeeRatePerKw channelOptions.MaxFeeRateMismatchRatio
+        *^> OpenChannelMsgValidation.checkRemoteFee channelOptions.FeeEstimator msg.FeeRatePerKw channelOptions.MaxFeeRateMismatchRatio
         *^> OpenChannelMsgValidation.checkToSelfDelayIsInAcceptableRange msg
         *^> OpenChannelMsgValidation.checkMaxAcceptedHTLCs msg
         *> OpenChannelMsgValidation.checkConfigPermits channelHandshakeLimits msg
         *^> OpenChannelMsgValidation.checkChannelAnnouncementPreferenceAcceptable channelHandshakeLimits announceChannel msg
-        *> OpenChannelMsgValidation.checkIsAcceptableByCurrentFeeRate feeEstimator msg
+        *> OpenChannelMsgValidation.checkIsAcceptableByCurrentFeeRate channelOptions.FeeEstimator msg
         *^> OpenChannelMsgValidation.checkFunderCanAffordFee feeRate msg
         |> Result.mapError((@)["rejected received open_channel msg"] >> InvalidOpenChannelError.Create msg >> InvalidOpenChannel)
 

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -238,3 +238,21 @@ module internal Validation =
         *^> UpdateAddHTLCValidationWithContext.checkLessThanMaxAcceptedHTLC currentSpec state.LocalParams.MaxAcceptedHTLCs
         *^> UpdateAddHTLCValidationWithContext.checkWeHaveSufficientFunds state currentSpec
         |> Result.mapError(InvalidUpdateAddHTLCError.Create add >> InvalidUpdateAddHTLC)
+
+    let checkShutdownScriptPubKeyAcceptable (shutdownStateOpt: Option<ShutdownState>)
+                                            (requestedShutdownScriptPubKey: ShutdownScriptPubKey)
+                                                : Result<ShutdownState, ChannelError> = result {
+            match shutdownStateOpt with
+            | None -> ()
+            | Some shutdownState ->
+                if shutdownState.ShutdownScriptPubKey <> requestedShutdownScriptPubKey then
+                    do!
+                        Error <|
+                            cannotCloseChannel
+                                "requested shutdown script does not match shutdown \
+                                script in open/accept channel"
+            return {
+                ShutdownScriptPubKey = requestedShutdownScriptPubKey
+                HasRequestedShutdown = true
+            }
+        }

--- a/src/DotNetLightning.Core/Channel/ChannelValidation.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelValidation.fs
@@ -197,6 +197,13 @@ module internal Validation =
         *> AcceptChannelMsgValidation.checkConfigPermits conf.PeerChannelConfigLimits msg
         |> Result.mapError(InvalidAcceptChannelError.Create msg >> InvalidAcceptChannel)
 
+    let checkOurMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =
+        Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+        |> Result.mapError(fun errs -> InvalidMonoHopUnidirectionalPayment { NetworkMsg = payment; Errors = errs })
+
+    let checkTheirMonoHopUnidirectionalPaymentIsAcceptableWithCurrentSpec (currentSpec) (state: Commitments) (payment: MonoHopUnidirectionalPaymentMsg) =
+        Validation.ofResult(MonoHopUnidirectionalPaymentValidationWithContext.checkWeHaveSufficientFunds state currentSpec)
+        |> Result.mapError(fun errs -> InvalidMonoHopUnidirectionalPayment { NetworkMsg = payment; Errors = errs })
 
     let checkOperationAddHTLC (state: NormalData) (op: OperationAddHTLC) =
         Validation.ofResult(UpdateAddHTLCValidation.checkExpiryIsNotPast op.CurrentHeight op.Expiry)

--- a/src/DotNetLightning.Core/Channel/CommitmentToLocalExtension.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentToLocalExtension.fs
@@ -1,0 +1,127 @@
+namespace DotNetLightning.Channel
+
+open NBitcoin
+open NBitcoin.BuilderExtensions
+open DotNetLightning.Utils
+open DotNetLightning.Utils.SeqConsumer
+open DotNetLightning.Crypto
+
+type CommitmentToLocalParameters = {
+    RevocationPubKey: RevocationPubKey
+    ToSelfDelay: BlockHeightOffset16
+    LocalDelayedPubKey: DelayedPaymentPubKey
+}
+    with
+    static member TryExtractParameters (scriptPubKey: Script): Option<CommitmentToLocalParameters> =
+        let ops =
+            scriptPubKey.ToOps()
+            // we have to collect it into a list and convert back to a seq
+            // because the IEnumerable that NBitcoin gives us is internally
+            // mutable.
+            |> List.ofSeq
+            |> Seq.ofList
+        let checkOpCode(opcodeType: OpcodeType) = seqConsumer<Op> {
+            let! op = NextInSeq()
+            if op.Code = opcodeType then
+                return ()
+            else
+                return! AbortSeqConsumer()
+        }
+        let consumeAllResult =
+            SeqConsumer.ConsumeAll ops <| seqConsumer {
+                do! checkOpCode OpcodeType.OP_IF
+                let! opRevocationPubKey = NextInSeq()
+                let! revocationPubKey = seqConsumer {
+                    match opRevocationPubKey.PushData with
+                    | null -> return! AbortSeqConsumer()
+                    | bytes -> return RevocationPubKey.FromBytes bytes      // FIXME: catch exception
+                }
+                do! checkOpCode OpcodeType.OP_ELSE
+                let! opToSelfDelay = NextInSeq()
+                let! toSelfDelay = seqConsumer {
+                    let nullableToSelfDelay = opToSelfDelay.GetLong()
+                    if nullableToSelfDelay.HasValue then
+                        // FIXME: catch exception
+                        return BlockHeightOffset16 (uint16 nullableToSelfDelay.Value)
+                    else
+                        return! AbortSeqConsumer()
+                }
+                do! checkOpCode OpcodeType.OP_CHECKSEQUENCEVERIFY
+                do! checkOpCode OpcodeType.OP_DROP
+                let! opLocalDelayedPubKey = NextInSeq()
+                let! localDelayedPubKey = seqConsumer {
+                    match opLocalDelayedPubKey.PushData with
+                    | null -> return! AbortSeqConsumer()
+                    | bytes -> return DelayedPaymentPubKey.FromBytes bytes  // FIXME: catch exception
+                }
+                do! checkOpCode OpcodeType.OP_ENDIF
+                do! checkOpCode OpcodeType.OP_CHECKSIG
+                return {
+                    RevocationPubKey = revocationPubKey
+                    ToSelfDelay = toSelfDelay
+                    LocalDelayedPubKey = localDelayedPubKey
+                }
+            }
+        match consumeAllResult with
+        | Ok data -> Some data
+        | Error _consumeAllError -> None
+
+type internal CommitmentToLocalExtension() =
+    inherit BuilderExtension()
+        override self.CanGenerateScriptSig (scriptPubKey: Script): bool =
+            (CommitmentToLocalParameters.TryExtractParameters scriptPubKey).IsSome
+
+        override self.GenerateScriptSig(scriptPubKey: Script, keyRepo: IKeyRepository, signer: ISigner): Script =
+            let parameters =
+                match (CommitmentToLocalParameters.TryExtractParameters scriptPubKey) with
+                | Some parameters -> parameters
+                | None ->
+                    failwith
+                        "NBitcoin should not call this unless CanGenerateScriptSig returns true"
+            let pubKey = keyRepo.FindKey scriptPubKey
+            // FindKey will return null if it can't find a key for
+            // scriptPubKey. If we can't find a valid key then this method
+            // should return null, indicating to NBitcoin that the sigScript
+            // could not be generated.
+            match pubKey with
+            | null -> null
+            | _ when pubKey = parameters.RevocationPubKey.RawPubKey() ->
+                let revocationSig = signer.Sign (parameters.RevocationPubKey.RawPubKey())
+                Script [
+                    Op.GetPushOp (revocationSig.ToBytes())
+                    Op.op_Implicit OpcodeType.OP_TRUE
+                ]
+            | _ when pubKey = parameters.LocalDelayedPubKey.RawPubKey() ->
+                let localDelayedSig = signer.Sign (parameters.LocalDelayedPubKey.RawPubKey())
+                Script [
+                    Op.GetPushOp (localDelayedSig.ToBytes())
+                    Op.op_Implicit OpcodeType.OP_FALSE
+                ]
+            | _ -> null
+
+        override self.CanDeduceScriptPubKey(_scriptSig: Script): bool =
+            false
+
+        override self.DeduceScriptPubKey(_scriptSig: Script): Script =
+            raise <| System.NotSupportedException()
+
+        override self.CanEstimateScriptSigSize(_scriptPubKey: Script): bool =
+            false
+
+        override self.EstimateScriptSigSize(_scriptPubKey: Script): int =
+            raise <| System.NotSupportedException()
+
+        override self.CanCombineScriptSig(_scriptPubKey: Script, _a: Script, _b: Script): bool = 
+            false
+
+        override self.CombineScriptSig(_scriptPubKey: Script, _a: Script, _b: Script): Script =
+            raise <| System.NotSupportedException()
+
+        override self.IsCompatibleKey(pubKey: PubKey, scriptPubKey: Script): bool =
+            match CommitmentToLocalParameters.TryExtractParameters scriptPubKey with
+            | None -> false
+            | Some parameters ->
+                parameters.RevocationPubKey.RawPubKey() = pubKey
+                || parameters.LocalDelayedPubKey.RawPubKey() = pubKey
+
+

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -72,22 +72,14 @@ type RemoteCommit = {
     RemotePerCommitmentPoint: PerCommitmentPoint
 }
 
-type WaitingForRevocation = {
-    NextRemoteCommit: RemoteCommit
-}
-    with
-        static member NextRemoteCommit_: Lens<_,_> =
-            (fun w -> w.NextRemoteCommit),
-            (fun v w -> { w with NextRemoteCommit = v})
-
 type RemoteNextCommitInfo =
-    | Waiting of WaitingForRevocation
+    | Waiting of RemoteCommit
     | Revoked of PerCommitmentPoint
     with
-        static member Waiting_: Prism<RemoteNextCommitInfo, WaitingForRevocation> =
+        static member Waiting_: Prism<RemoteNextCommitInfo, RemoteCommit> =
             (fun remoteNextCommitInfo ->
                 match remoteNextCommitInfo with
-                | Waiting waitingForRevocation -> Some waitingForRevocation
+                | Waiting remoteCommit -> Some remoteCommit
                 | Revoked _ -> None),
             (fun waitingForRevocation remoteNextCommitInfo ->
                 match remoteNextCommitInfo with
@@ -175,8 +167,7 @@ type Commitments = {
                 let remoteCommit =
                     match remoteNextCommitInfo with
                     | Revoked _ -> this.RemoteCommit
-                    | Waiting waitingForRevocation ->
-                        waitingForRevocation.NextRemoteCommit
+                    | Waiting nextRemoteCommit -> nextRemoteCommit
                 remoteCommit.Spec.HTLCs
                 |> Map.tryPick(fun _k v ->
                     if v.Direction = directionRelativeToLocal.Opposite && v.Add.HTLCId = htlcId then
@@ -192,7 +183,7 @@ type Commitments = {
         member this.SpendableBalance (remoteNextCommitInfo: RemoteNextCommitInfo): LNMoney =
             let remoteCommit =
                 match remoteNextCommitInfo with
-                | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
+                | RemoteNextCommitInfo.Waiting nextRemoteCommit -> nextRemoteCommit
                 | RemoteNextCommitInfo.Revoked _info -> this.RemoteCommit
             let reducedRes =
                 remoteCommit.Spec.Reduce(

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -78,7 +78,6 @@ type RemoteCommit = {
 
 type WaitingForRevocation = {
     NextRemoteCommit: RemoteCommit
-    SentAfterLocalCommitmentIndex: CommitmentNumber
     ReSignASAP: bool
 }
     with

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -103,7 +103,7 @@ type RemoteNextCommitInfo =
 type Commitments = {
     LocalParams: LocalParams
     RemoteParams: RemoteParams
-    ChannelFlags: uint8
+    ChannelFlags: ChannelFlags
     FundingScriptCoin: ScriptCoin
     IsFunder: bool
     LocalCommit: LocalCommit

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -108,7 +108,6 @@ type Commitments = {
     LocalNextHTLCId: HTLCId
     RemoteNextHTLCId: HTLCId
     OriginChannels: Map<HTLCId, HTLCSource>
-    RemotePerCommitmentSecrets: PerCommitmentSecretStore
 }
     with
         static member LocalChanges_: Lens<_, _> =

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -53,10 +53,6 @@ type RemoteChanges = {
             (fun v lc -> { lc with ACKed = v })
 
 
-type Changes =
-    | Local of LocalChanges
-    | Remote of RemoteChanges
-
 type PublishableTxs = {
     CommitTx: FinalizedTx
     HTLCTxs: FinalizedTx list

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -78,7 +78,6 @@ type RemoteCommit = {
 
 type WaitingForRevocation = {
     NextRemoteCommit: RemoteCommit
-    Sent: CommitmentSignedMsg
     SentAfterLocalCommitmentIndex: CommitmentNumber
     ReSignASAP: bool
 }

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -101,8 +101,6 @@ type RemoteNextCommitInfo =
             | Revoked perCommitmentPoint -> perCommitmentPoint
 
 type Commitments = {
-    LocalCommit: LocalCommit
-    RemoteCommit: RemoteCommit
     LocalChanges: LocalChanges
     RemoteChanges: RemoteChanges
     LocalNextHTLCId: HTLCId
@@ -140,51 +138,15 @@ type Commitments = {
         member internal this.RemoteHasUnsignedOutgoingHTLCs() =
             this.RemoteChanges.Proposed |> List.exists(fun p -> match p with | :? UpdateAddHTLCMsg -> true | _ -> false)
 
-        member internal this.HasNoPendingHTLCs (remoteNextCommitInfo: RemoteNextCommitInfo) =
-            this.LocalCommit.Spec.OutgoingHTLCs.IsEmpty
-            && this.LocalCommit.Spec.IncomingHTLCs.IsEmpty
-            && this.RemoteCommit.Spec.OutgoingHTLCs.IsEmpty
-            && this.RemoteCommit.Spec.IncomingHTLCs.IsEmpty
-            && (remoteNextCommitInfo |> function Waiting _ -> false | Revoked _ -> true)
-
-        member internal this.GetOutgoingHTLCCrossSigned (remoteNextCommitInfo: RemoteNextCommitInfo)
-                                                        (htlcId: HTLCId)
-                                                            : Option<UpdateAddHTLCMsg> =
-            let remoteSigned =
-                Map.tryFind htlcId this.LocalCommit.Spec.OutgoingHTLCs
-            let localSigned =
-                let remoteCommit =
-                    match remoteNextCommitInfo with
-                    | Revoked _ -> this.RemoteCommit
-                    | Waiting nextRemoteCommit -> nextRemoteCommit
-                Map.tryFind htlcId remoteCommit.Spec.IncomingHTLCs
-            match remoteSigned, localSigned with
-            | Some _, Some htlcIn -> htlcIn |> Some
-            | _ -> None
-
-        member internal this.GetIncomingHTLCCrossSigned (remoteNextCommitInfo: RemoteNextCommitInfo)
-                                                        (htlcId: HTLCId)
-                                                            : Option<UpdateAddHTLCMsg> =
-            let remoteSigned =
-                Map.tryFind htlcId this.LocalCommit.Spec.IncomingHTLCs
-            let localSigned =
-                let remoteCommit =
-                    match remoteNextCommitInfo with
-                    | Revoked _ -> this.RemoteCommit
-                    | Waiting nextRemoteCommit -> nextRemoteCommit
-                Map.tryFind htlcId remoteCommit.Spec.OutgoingHTLCs
-            match remoteSigned, localSigned with
-            | Some _, Some htlcIn -> htlcIn |> Some
-            | _ -> None
-
         member this.SpendableBalance (localIsFunder: bool)
                                      (remoteParams: RemoteParams)
+                                     (remoteCommit: RemoteCommit)
                                      (remoteNextCommitInfo: RemoteNextCommitInfo)
                                          : LNMoney =
             let remoteCommit =
                 match remoteNextCommitInfo with
                 | RemoteNextCommitInfo.Waiting nextRemoteCommit -> nextRemoteCommit
-                | RemoteNextCommitInfo.Revoked _info -> this.RemoteCommit
+                | RemoteNextCommitInfo.Revoked _info -> remoteCommit
             let reducedRes =
                 remoteCommit.Spec.Reduce(
                     this.RemoteChanges.ACKed,

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -28,15 +28,12 @@ type LocalChanges = {
             (fun v lc -> { lc with ACKed = v })
 
 type RemoteChanges = { 
-    Proposed: IUpdateMsg list
     Signed: IUpdateMsg list
     ACKed: IUpdateMsg list
 }
     with
-        static member Zero = { Proposed = []; Signed = []; ACKed = [] }
-        static member Proposed_: Lens<_, _> =
-            (fun lc -> lc.Proposed),
-            (fun ps lc -> { lc with Proposed = ps })
+        static member Zero = { Signed = []; ACKed = [] }
+
         static member Signed_: Lens<_, _> =
             (fun lc -> lc.Signed),
             (fun v lc -> { lc with Signed = v })
@@ -95,6 +92,7 @@ type RemoteNextCommitInfo =
 
 type Commitments = {
     ProposedLocalChanges: list<IUpdateMsg>
+    ProposedRemoteChanges: list<IUpdateMsg>
     LocalChanges: LocalChanges
     RemoteChanges: RemoteChanges
     LocalNextHTLCId: HTLCId
@@ -116,8 +114,10 @@ type Commitments = {
             }
 
         member this.AddRemoteProposal(proposal: IUpdateMsg) =
-            let lens = Commitments.RemoteChanges_ >-> RemoteChanges.Proposed_
-            Optic.map lens (fun proposalList -> proposal :: proposalList) this
+            {
+                this with
+                    ProposedRemoteChanges = proposal :: this.ProposedRemoteChanges
+            }
 
         member this.IncrLocalHTLCId() = { this with LocalNextHTLCId = this.LocalNextHTLCId + 1UL }
         member this.IncrRemoteHTLCId() = { this with RemoteNextHTLCId = this.RemoteNextHTLCId + 1UL }
@@ -126,13 +126,13 @@ type Commitments = {
             (not this.RemoteChanges.ACKed.IsEmpty) || (not this.ProposedLocalChanges.IsEmpty)
 
         member this.RemoteHasChanges() =
-            (not this.LocalChanges.ACKed.IsEmpty) || (not this.RemoteChanges.Proposed.IsEmpty)
+            (not this.LocalChanges.ACKed.IsEmpty) || (not this.ProposedRemoteChanges.IsEmpty)
 
         member internal this.LocalHasUnsignedOutgoingHTLCs() =
             this.ProposedLocalChanges |> List.exists(fun p -> match p with | :? UpdateAddHTLCMsg -> true | _ -> false)
 
         member internal this.RemoteHasUnsignedOutgoingHTLCs() =
-            this.RemoteChanges.Proposed |> List.exists(fun p -> match p with | :? UpdateAddHTLCMsg -> true | _ -> false)
+            this.ProposedRemoteChanges |> List.exists(fun p -> match p with | :? UpdateAddHTLCMsg -> true | _ -> false)
 
         member this.SpendableBalance (localIsFunder: bool)
                                      (remoteParams: RemoteParams)

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -78,16 +78,11 @@ type RemoteCommit = {
 
 type WaitingForRevocation = {
     NextRemoteCommit: RemoteCommit
-    ReSignASAP: bool
 }
     with
         static member NextRemoteCommit_: Lens<_,_> =
             (fun w -> w.NextRemoteCommit),
             (fun v w -> { w with NextRemoteCommit = v})
-
-        static member ReSignASAP_: Lens<_,_> =
-            (fun w -> w.ReSignASAP),
-            (fun v w -> { w with ReSignASAP = v })
 
 type RemoteNextCommitInfo =
     | Waiting of WaitingForRevocation

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -142,37 +142,40 @@ type Commitments = {
             this.RemoteChanges.Proposed |> List.exists(fun p -> match p with | :? UpdateAddHTLCMsg -> true | _ -> false)
 
         member internal this.HasNoPendingHTLCs (remoteNextCommitInfo: RemoteNextCommitInfo) =
-            this.LocalCommit.Spec.HTLCs.IsEmpty
-            && this.RemoteCommit.Spec.HTLCs.IsEmpty
+            this.LocalCommit.Spec.OutgoingHTLCs.IsEmpty
+            && this.LocalCommit.Spec.IncomingHTLCs.IsEmpty
+            && this.RemoteCommit.Spec.OutgoingHTLCs.IsEmpty
+            && this.RemoteCommit.Spec.IncomingHTLCs.IsEmpty
             && (remoteNextCommitInfo |> function Waiting _ -> false | Revoked _ -> true)
 
-        member internal this.GetHTLCCrossSigned (remoteNextCommitInfo: RemoteNextCommitInfo)
-                                                (directionRelativeToLocal: Direction)
-                                                (htlcId: HTLCId)
-                                                    : Option<UpdateAddHTLCMsg> =
+        member internal this.GetOutgoingHTLCCrossSigned (remoteNextCommitInfo: RemoteNextCommitInfo)
+                                                        (htlcId: HTLCId)
+                                                            : Option<UpdateAddHTLCMsg> =
             let remoteSigned =
-                this.LocalCommit.Spec.HTLCs
-                |> Map.tryPick (fun _k v ->
-                    if v.Direction = directionRelativeToLocal && v.Add.HTLCId = htlcId then
-                        Some v
-                    else None
-                )
-
+                Map.tryFind htlcId this.LocalCommit.Spec.OutgoingHTLCs
             let localSigned =
                 let remoteCommit =
                     match remoteNextCommitInfo with
                     | Revoked _ -> this.RemoteCommit
                     | Waiting nextRemoteCommit -> nextRemoteCommit
-                remoteCommit.Spec.HTLCs
-                |> Map.tryPick(fun _k v ->
-                    if v.Direction = directionRelativeToLocal.Opposite && v.Add.HTLCId = htlcId then
-                        Some v
-                    else
-                        None
-                )
-
+                Map.tryFind htlcId remoteCommit.Spec.IncomingHTLCs
             match remoteSigned, localSigned with
-            | Some _, Some htlcIn -> htlcIn.Add |> Some
+            | Some _, Some htlcIn -> htlcIn |> Some
+            | _ -> None
+
+        member internal this.GetIncomingHTLCCrossSigned (remoteNextCommitInfo: RemoteNextCommitInfo)
+                                                        (htlcId: HTLCId)
+                                                            : Option<UpdateAddHTLCMsg> =
+            let remoteSigned =
+                Map.tryFind htlcId this.LocalCommit.Spec.IncomingHTLCs
+            let localSigned =
+                let remoteCommit =
+                    match remoteNextCommitInfo with
+                    | Revoked _ -> this.RemoteCommit
+                    | Waiting nextRemoteCommit -> nextRemoteCommit
+                Map.tryFind htlcId remoteCommit.Spec.OutgoingHTLCs
+            match remoteSigned, localSigned with
+            | Some _, Some htlcIn -> htlcIn |> Some
             | _ -> None
 
         member this.SpendableBalance (localIsFunder: bool)

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -128,6 +128,7 @@ type Commitments = {
     LocalNextHTLCId: HTLCId
     RemoteNextHTLCId: HTLCId
     OriginChannels: Map<HTLCId, HTLCSource>
+    RemoteChannelPubKeys: ChannelPubKeys
     RemoteNextCommitInfo: RemoteNextCommitInfo
     RemotePerCommitmentSecrets: PerCommitmentSecretStore
 }

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -118,7 +118,6 @@ type Commitments = {
     RemoteNextHTLCId: HTLCId
     OriginChannels: Map<HTLCId, HTLCSource>
     RemoteChannelPubKeys: ChannelPubKeys
-    RemoteNextCommitInfo: RemoteNextCommitInfo
     RemotePerCommitmentSecrets: PerCommitmentSecretStore
 }
     with
@@ -128,9 +127,6 @@ type Commitments = {
         static member RemoteChanges_: Lens<_, _> =
             (fun c -> c.RemoteChanges),
             (fun v c -> { c with RemoteChanges = v })
-        static member RemoteNextCommitInfo_: Lens<_, _> =
-            (fun c -> c.RemoteNextCommitInfo),
-            (fun v c -> { c with RemoteNextCommitInfo = v })
 
         member this.ChannelId(): ChannelId =
             this.FundingScriptCoin.Outpoint.ToChannelId()
@@ -158,30 +154,44 @@ type Commitments = {
         member internal this.RemoteHasUnsignedOutgoingHTLCs() =
             this.RemoteChanges.Proposed |> List.exists(fun p -> match p with | :? UpdateAddHTLCMsg -> true | _ -> false)
 
-        member internal this.HasNoPendingHTLCs() =
-            this.LocalCommit.Spec.HTLCs.IsEmpty && this.RemoteCommit.Spec.HTLCs.IsEmpty && (this.RemoteNextCommitInfo |> function Waiting _ -> false | Revoked _ -> true)
+        member internal this.HasNoPendingHTLCs (remoteNextCommitInfo: RemoteNextCommitInfo) =
+            this.LocalCommit.Spec.HTLCs.IsEmpty
+            && this.RemoteCommit.Spec.HTLCs.IsEmpty
+            && (remoteNextCommitInfo |> function Waiting _ -> false | Revoked _ -> true)
 
-        member internal this.GetHTLCCrossSigned(directionRelativeToLocal: Direction, htlcId: HTLCId): UpdateAddHTLCMsg option =
+        member internal this.GetHTLCCrossSigned (remoteNextCommitInfo: RemoteNextCommitInfo)
+                                                (directionRelativeToLocal: Direction)
+                                                (htlcId: HTLCId)
+                                                    : Option<UpdateAddHTLCMsg> =
             let remoteSigned =
                 this.LocalCommit.Spec.HTLCs
-                |> Map.tryPick (fun _k v -> if v.Direction = directionRelativeToLocal && v.Add.HTLCId = htlcId then Some v else None)
+                |> Map.tryPick (fun _k v ->
+                    if v.Direction = directionRelativeToLocal && v.Add.HTLCId = htlcId then
+                        Some v
+                    else None
+                )
 
             let localSigned =
-                let lens =
-                    Commitments.RemoteNextCommitInfo_
-                    >-> RemoteNextCommitInfo.Waiting_
-                    >?> WaitingForRevocation.NextRemoteCommit_
-                match Optic.get lens this with
-                | Some v -> v
-                | None -> this.RemoteCommit
-                |> fun v -> v.Spec.HTLCs |> Map.tryPick(fun _k v -> if v.Direction = directionRelativeToLocal.Opposite && v.Add.HTLCId = htlcId then Some v else None)
+                let remoteCommit =
+                    match remoteNextCommitInfo with
+                    | Revoked _ -> this.RemoteCommit
+                    | Waiting waitingForRevocation ->
+                        waitingForRevocation.NextRemoteCommit
+                remoteCommit.Spec.HTLCs
+                |> Map.tryPick(fun _k v ->
+                    if v.Direction = directionRelativeToLocal.Opposite && v.Add.HTLCId = htlcId then
+                        Some v
+                    else
+                        None
+                )
+
             match remoteSigned, localSigned with
             | Some _, Some htlcIn -> htlcIn.Add |> Some
             | _ -> None
 
-        member this.SpendableBalance(): LNMoney =
+        member this.SpendableBalance (remoteNextCommitInfo: RemoteNextCommitInfo): LNMoney =
             let remoteCommit =
-                match this.RemoteNextCommitInfo with
+                match remoteNextCommitInfo with
                 | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
                 | RemoteNextCommitInfo.Revoked _info -> this.RemoteCommit
             let reducedRes =

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -96,6 +96,11 @@ type RemoteNextCommitInfo =
                 | Waiting _ -> remoteNextCommitInfo
                 | Revoked _ -> Revoked commitmentPubKey)
 
+        member self.PerCommitmentPoint(): PerCommitmentPoint =
+            match self with
+            | Waiting remoteCommit -> remoteCommit.RemotePerCommitmentPoint
+            | Revoked perCommitmentPoint -> perCommitmentPoint
+
 type Commitments = {
     LocalParams: LocalParams
     RemoteParams: RemoteParams

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -120,6 +120,7 @@ type Commitments = {
     RemoteParams: RemoteParams
     ChannelFlags: uint8
     FundingScriptCoin: ScriptCoin
+    IsFunder: bool
     LocalCommit: LocalCommit
     RemoteCommit: RemoteCommit
     LocalChanges: LocalChanges
@@ -207,7 +208,7 @@ type Commitments = {
                         err
                 | Ok reduced -> reduced
             let fees =
-                if this.LocalParams.IsFunder then
+                if this.IsFunder then
                     Transactions.commitTxFee this.RemoteParams.DustLimitSatoshis reduced
                     |> LNMoney.FromMoney
                 else

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -129,7 +129,6 @@ type Commitments = {
     OriginChannels: Map<HTLCId, HTLCSource>
     RemoteNextCommitInfo: RemoteNextCommitInfo
     RemotePerCommitmentSecrets: PerCommitmentSecretStore
-    ChannelId: ChannelId
 }
     with
         static member LocalChanges_: Lens<_, _> =
@@ -142,6 +141,8 @@ type Commitments = {
             (fun c -> c.RemoteNextCommitInfo),
             (fun v c -> { c with RemoteNextCommitInfo = v })
 
+        member this.ChannelId(): ChannelId =
+            this.FundingScriptCoin.Outpoint.ToChannelId()
 
         member this.AddLocalProposal(proposal: IUpdateMsg) =
             let lens = Commitments.LocalChanges_ >-> LocalChanges.Proposed_

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -186,3 +186,39 @@ type Commitments = {
             match remoteSigned, localSigned with
             | Some _, Some htlcIn -> htlcIn.Add |> Some
             | _ -> None
+
+        member this.SpendableBalance(): LNMoney =
+            let remoteCommit =
+                match this.RemoteNextCommitInfo with
+                | RemoteNextCommitInfo.Waiting info -> info.NextRemoteCommit
+                | RemoteNextCommitInfo.Revoked _info -> this.RemoteCommit
+            let reducedRes =
+                remoteCommit.Spec.Reduce(
+                    this.RemoteChanges.ACKed,
+                    this.LocalChanges.Proposed
+                )
+            let reduced =
+                match reducedRes with
+                | Error err ->
+                    failwithf
+                        "reducing commit failed even though we have not proposed any changes\
+                        error: %A"
+                        err
+                | Ok reduced -> reduced
+            let fees =
+                if this.LocalParams.IsFunder then
+                    Transactions.commitTxFee this.RemoteParams.DustLimitSatoshis reduced
+                    |> LNMoney.FromMoney
+                else
+                    LNMoney.Zero
+            let channelReserve =
+                this.RemoteParams.ChannelReserveSatoshis
+                |> LNMoney.FromMoney
+            let totalBalance = reduced.ToRemote
+            let untrimmedSpendableBalance = totalBalance - channelReserve - fees
+            let dustLimit =
+                this.RemoteParams.DustLimitSatoshis
+                |> LNMoney.FromMoney
+            let untrimmedMax = LNMoney.Min(untrimmedSpendableBalance, dustLimit)
+            let spendableBalance = LNMoney.Max(untrimmedMax, untrimmedSpendableBalance)
+            spendableBalance

--- a/src/DotNetLightning.Core/Channel/Commitments.fs
+++ b/src/DotNetLightning.Core/Channel/Commitments.fs
@@ -68,7 +68,6 @@ type LocalCommit = {
 type RemoteCommit = {
     Index: CommitmentNumber
     Spec: CommitmentSpec
-    TxId: TxId
     RemotePerCommitmentPoint: PerCommitmentPoint
 }
 

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -180,15 +180,15 @@ module internal Commitments =
                     (cm: Commitments)
                     (remoteNextCommitInfo: RemoteNextCommitInfo) =
         match cm.GetHTLCCrossSigned remoteNextCommitInfo Direction.Out msg.HTLCId with
-        | Some htlc ->
+        | Some _htlc ->
             result {
-                let! o =
+                let! _origin =
                     match cm.OriginChannels.TryGetValue(msg.HTLCId) with
                     | true, origin -> Ok origin
                     | false, _ ->
                         msg.HTLCId |> htlcOriginNowKnown
                 let nextC = cm.AddRemoteProposal(msg)
-                return [WeAcceptedFailHTLC(o, htlc, nextC)]
+                return nextC
             }
         | None ->
             msg.HTLCId |> unknownHTLCId

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -288,8 +288,7 @@ module internal Commitments =
                         (staticChannelConfig.LocalParams.ChannelReserveSatoshis, fees,  (-1 * missing))
                         |> cannotAffordFee
                 else
-                    return
-                        [ WeAcceptedUpdateFee(msg, nextCommitments) ]
+                    return nextCommitments
             }
 
     let sendCommit (channelPrivKeys: ChannelPrivKeys)

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -335,7 +335,6 @@ module internal Commitments =
                         Index = cm.RemoteCommit.Index.NextCommitment()
                         Spec = spec
                         RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
-                        TxId = remoteCommitTx.GetTxId()
                 }
                 let nextCommitments = {
                     cm with

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -281,7 +281,7 @@ module internal Commitments =
                 let! reduced =
                     savedChannelState.LocalCommit.Spec.Reduce(
                         nextCommitments.LocalChanges.ACKed,
-                        nextCommitments.RemoteChanges.Proposed
+                        nextCommitments.ProposedRemoteChanges
                     ) |> expectTransactionError
                 
                 let fees = Transactions.commitTxFee(savedChannelState.StaticChannelConfig.RemoteParams.DustLimitSatoshis) reduced
@@ -368,7 +368,7 @@ module internal Commitments =
             let remoteChannelKeys = savedChannelState.StaticChannelConfig.RemoteChannelPubKeys
             let nextI = savedChannelState.LocalCommit.Index.NextCommitment()
             result {
-                let! spec = savedChannelState.LocalCommit.Spec.Reduce(cm.LocalChanges.ACKed, cm.RemoteChanges.Proposed) |> expectTransactionError
+                let! spec = savedChannelState.LocalCommit.Spec.Reduce(cm.LocalChanges.ACKed, cm.ProposedRemoteChanges) |> expectTransactionError
                 let localPerCommitmentPoint = commitmentSeed.DerivePerCommitmentPoint nextI
                 let! (localCommitTx, htlcTimeoutTxs, htlcSuccessTxs) =
                     Helpers.makeLocalTXs
@@ -454,7 +454,7 @@ module internal Commitments =
                 }
                 let nextCommitments =
                     let ourChanges1 = { cm.LocalChanges with ACKed = []}
-                    let theirChanges1 = { cm.RemoteChanges with Proposed = []; ACKed = (cm.RemoteChanges.ACKed @ cm.RemoteChanges.Proposed) }
+                    let theirChanges1 = { cm.RemoteChanges with ACKed = (cm.RemoteChanges.ACKed @ cm.ProposedRemoteChanges) }
                     let completedOutgoingHTLCs =
                         let t1 = savedChannelState.LocalCommit.Spec.OutgoingHTLCs
                                  |> Map.toSeq |> Seq.map (fun (k, _) -> k) |> Set.ofSeq
@@ -465,6 +465,7 @@ module internal Commitments =
                     {
                         cm with
                             LocalChanges = ourChanges1
+                            ProposedRemoteChanges = []
                             RemoteChanges = theirChanges1
                             OriginChannels = originChannels1
                     }

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -13,7 +13,7 @@ open ResultUtils.Portability
 
 [<RequireQualifiedAccess; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module internal Commitments =
-    module private Helpers =
+    module Helpers =
         let isAlreadySent (htlc: UpdateAddHTLCMsg) (proposed: IUpdateMsg list) =
             proposed
             |> List.exists(fun p -> match p with
@@ -253,7 +253,7 @@ module internal Commitments =
                 let c1 = cm.AddLocalProposal(fee)
                 result {
                     let! reduced =
-                        savedChannelState.RemoteCommit.Spec.Reduce(c1.RemoteChanges.ACKed, c1.ProposedLocalChanges) |> expectTransactionError
+                        savedChannelState.RemoteCommit.Spec.Reduce(savedChannelState.RemoteChanges.ACKed, c1.ProposedLocalChanges) |> expectTransactionError
                     // A node cannot spend pending incoming htlcs, and need to keep funds above the reserve required by
                     // the counter party, after paying the fee, we look from remote's point of view, so if local is funder
                     // remote doesn't pay the fees.
@@ -280,7 +280,7 @@ module internal Commitments =
                 let nextCommitments = cm.AddRemoteProposal(msg)
                 let! reduced =
                     savedChannelState.LocalCommit.Spec.Reduce(
-                        nextCommitments.LocalChanges.ACKed,
+                        savedChannelState.LocalChanges.ACKed,
                         nextCommitments.ProposedRemoteChanges
                     ) |> expectTransactionError
                 
@@ -294,183 +294,12 @@ module internal Commitments =
                     return nextCommitments
             }
 
-    let sendCommit (channelPrivKeys: ChannelPrivKeys)
-                   (cm: Commitments)
-                   (savedChannelState: SavedChannelState)
-                   (remoteNextCommitInfo: RemoteNextCommitInfo) =
-        match remoteNextCommitInfo with
-        | RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint ->
-            result {
-                // remote commitment will include all local changes + remote acked changes
-                let! spec = savedChannelState.RemoteCommit.Spec.Reduce(cm.RemoteChanges.ACKed, cm.ProposedLocalChanges) |> expectTransactionError
-                let! (remoteCommitTx, htlcTimeoutTxs, htlcSuccessTxs) =
-                    Helpers.makeRemoteTxs savedChannelState.StaticChannelConfig
-                                          (savedChannelState.RemoteCommit.Index.NextCommitment())
-                                          (channelPrivKeys.ToChannelPubKeys())
-                                          (remoteNextPerCommitmentPoint)
-                                          (spec)
-                    |> expectTransactionErrors
-                let signature,_ = channelPrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
-                let sortedHTLCTXs = Helpers.sortBothHTLCs htlcTimeoutTxs htlcSuccessTxs
-                let htlcSigs =
-                    sortedHTLCTXs
-                    |> List.map(
-                            (fun htlc -> channelPrivKeys.SignHtlcTx htlc.Value remoteNextPerCommitmentPoint)
-                            >> fst
-                            >> (fun txSig -> txSig.Signature)
-                            )
-                let msg = {
-                    CommitmentSignedMsg.ChannelId = savedChannelState.StaticChannelConfig.ChannelId()
-                    Signature = !> signature.Signature
-                    HTLCSignatures = htlcSigs |> List.map (!>)
-                }
-                let nextRemoteCommitInfo = {
-                    savedChannelState.RemoteCommit
-                    with
-                        Index = savedChannelState.RemoteCommit.Index.NextCommitment()
-                        Spec = spec
-                        RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
-                }
-                let nextCommitments = {
-                    cm with
-                        ProposedLocalChanges = []
-                        LocalChanges = {
-                            cm.LocalChanges with
-                                Signed = cm.ProposedLocalChanges
-                        }
-                        RemoteChanges = {
-                            cm.RemoteChanges with
-                                ACKed = []
-                                Signed = cm.RemoteChanges.ACKed
-                        }
-                }
-                return msg, nextCommitments, nextRemoteCommitInfo
-            }
-        | RemoteNextCommitInfo.Waiting _ ->
-            CanNotSignBeforeRevocation |> Error
-
-    let private checkSignatureCountMismatch(sortedHTLCTXs: IHTLCTx list) (msg) =
+    let checkSignatureCountMismatch(sortedHTLCTXs: IHTLCTx list) (msg) =
         if (sortedHTLCTXs.Length <> msg.HTLCSignatures.Length) then
             signatureCountMismatch (sortedHTLCTXs.Length, msg.HTLCSignatures.Length)
         else
             Ok()
 
-    let receiveCommit (channelPrivKeys: ChannelPrivKeys)
-                      (msg: CommitmentSignedMsg)
-                      (cm: Commitments)
-                      (savedChannelState: SavedChannelState)
-                          : Result<RevokeAndACKMsg * SavedChannelState * Commitments, ChannelError> =
-        if cm.RemoteHasChanges() |> not then
-            ReceivedCommitmentSignedWhenWeHaveNoPendingChanges |> Error
-        else
-            let commitmentSeed = channelPrivKeys.CommitmentSeed
-            let localChannelKeys = channelPrivKeys.ToChannelPubKeys()
-            let remoteChannelKeys = savedChannelState.StaticChannelConfig.RemoteChannelPubKeys
-            let nextI = savedChannelState.LocalCommit.Index.NextCommitment()
-            result {
-                let! spec = savedChannelState.LocalCommit.Spec.Reduce(cm.LocalChanges.ACKed, cm.ProposedRemoteChanges) |> expectTransactionError
-                let localPerCommitmentPoint = commitmentSeed.DerivePerCommitmentPoint nextI
-                let! (localCommitTx, htlcTimeoutTxs, htlcSuccessTxs) =
-                    Helpers.makeLocalTXs
-                        savedChannelState.StaticChannelConfig
-                        nextI
-                        (channelPrivKeys.ToChannelPubKeys())
-                        localPerCommitmentPoint
-                        spec
-                    |> expectTransactionErrors
-                let signature, signedCommitTx = channelPrivKeys.SignWithFundingPrivKey localCommitTx.Value
-
-                let sigPair =
-                    let localSigPair = seq [(localChannelKeys.FundingPubKey.RawPubKey(), signature)]
-                    let remoteSigPair = seq[ (remoteChannelKeys.FundingPubKey.RawPubKey(), TransactionSignature(msg.Signature.Value, SigHash.All)) ]
-                    Seq.append localSigPair remoteSigPair
-                let tmp =
-                    Transactions.checkTxFinalized signedCommitTx CommitTx.WhichInput sigPair
-                    |> expectTransactionError
-                let! finalizedCommitTx = tmp
-                let sortedHTLCTXs = Helpers.sortBothHTLCs htlcTimeoutTxs htlcSuccessTxs
-                do! checkSignatureCountMismatch sortedHTLCTXs msg
-                
-                let _localHTLCSigs, sortedHTLCTXs =
-                    let localHtlcSigsAndHTLCTxs =
-                        sortedHTLCTXs |> List.map(fun htlc ->
-                            channelPrivKeys.SignHtlcTx htlc.Value localPerCommitmentPoint
-                        )
-                    localHtlcSigsAndHTLCTxs |> List.map(fst), localHtlcSigsAndHTLCTxs |> List.map(snd) |> Seq.cast<IHTLCTx> |> List.ofSeq
-
-                let remoteHTLCPubKey = localPerCommitmentPoint.DeriveHtlcPubKey remoteChannelKeys.HtlcBasepoint
-
-                let checkHTLCSig (htlc: IHTLCTx, remoteECDSASig: LNECDSASignature): Result<_, _> =
-                    let remoteS = TransactionSignature(remoteECDSASig.Value, SigHash.All)
-                    match htlc with
-                    | :? HTLCTimeoutTx ->
-                        (Transactions.checkTxFinalized (htlc.Value) (0) (seq [(remoteHTLCPubKey.RawPubKey(), remoteS)]))
-                        |> Result.map(box)
-                    // we cannot check that htlc-success tx are spendable because we need the payment preimage; thus we only check the remote sig
-                    | :? HTLCSuccessTx ->
-                        (Transactions.checkSigAndAdd (htlc) (remoteS) (remoteHTLCPubKey.RawPubKey()))
-                        |> Result.map(box)
-                    | _ -> failwith "Unreachable!"
-
-                let! txList =
-                    List.zip sortedHTLCTXs msg.HTLCSignatures
-                    |> List.map(checkHTLCSig)
-                    |> List.sequenceResultA
-                    |> expectTransactionErrors
-                let successTxs =
-                    txList |> List.choose(fun o ->
-                        match o with
-                        | :? HTLCSuccessTx as tx -> Some tx
-                        | _ -> None
-                    )
-                let finalizedTxs =
-                    txList |> List.choose(fun o ->
-                        match o with
-                        | :? FinalizedTx as tx -> Some tx
-                        | _ -> None
-                    )
-                let localPerCommitmentSecret =
-                    channelPrivKeys.CommitmentSeed.DerivePerCommitmentSecret savedChannelState.LocalCommit.Index
-                let localNextPerCommitmentPoint =
-                    let perCommitmentSecret =
-                        channelPrivKeys.CommitmentSeed.DerivePerCommitmentSecret
-                            (savedChannelState.LocalCommit.Index.NextCommitment().NextCommitment())
-                    perCommitmentSecret.PerCommitmentPoint()
-
-                let nextMsg = {
-                    RevokeAndACKMsg.ChannelId = savedChannelState.StaticChannelConfig.ChannelId()
-                    PerCommitmentSecret = localPerCommitmentSecret
-                    NextPerCommitmentPoint = localNextPerCommitmentPoint
-                }
-                
-                let localCommit1 = { LocalCommit.Index = savedChannelState.LocalCommit.Index.NextCommitment()
-                                     Spec = spec
-                                     PublishableTxs = { PublishableTxs.CommitTx = finalizedCommitTx
-                                                        HTLCTxs = finalizedTxs }
-                                     PendingHTLCSuccessTxs = successTxs }
-                let nextSavedChannelState = {
-                    savedChannelState with
-                        LocalCommit = localCommit1
-                }
-                let nextCommitments =
-                    let ourChanges1 = { cm.LocalChanges with ACKed = []}
-                    let theirChanges1 = { cm.RemoteChanges with ACKed = (cm.RemoteChanges.ACKed @ cm.ProposedRemoteChanges) }
-                    let completedOutgoingHTLCs =
-                        let t1 = savedChannelState.LocalCommit.Spec.OutgoingHTLCs
-                                 |> Map.toSeq |> Seq.map (fun (k, _) -> k) |> Set.ofSeq
-                        let t2 = localCommit1.Spec.OutgoingHTLCs
-                                 |> Map.toSeq |> Seq.map (fun (k, _) -> k) |> Set.ofSeq
-                        Set.difference t1 t2
-                    let originChannels1 = cm.OriginChannels |> Map.filter(fun k _ -> Set.contains k completedOutgoingHTLCs)
-                    {
-                        cm with
-                            LocalChanges = ourChanges1
-                            ProposedRemoteChanges = []
-                            RemoteChanges = theirChanges1
-                            OriginChannels = originChannels1
-                    }
-                return nextMsg, nextSavedChannelState, nextCommitments
-            }
 
 module RemoteForceClose =
     // The lightning spec specifies that commitment txs use version 2 bitcoin transactions.

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -485,6 +485,7 @@ module RemoteForceClose =
     let tryGetFundsFromRemoteCommitmentTx (commitments: Commitments)
                                           (localChannelPrivKeys: ChannelPrivKeys)
                                           (staticChannelConfig: StaticChannelConfig)
+                                          (remotePerCommitmentSecrets: PerCommitmentSecretStore)
                                           (transaction: Transaction)
                                               : Option<TransactionBuilder> = option {
         let! obscuredCommitmentNumber =
@@ -499,7 +500,7 @@ module RemoteForceClose =
                 localChannelPubKeys.PaymentBasepoint
                 remoteChannelPubKeys.PaymentBasepoint
         let perCommitmentSecretOpt =
-            commitments.RemotePerCommitmentSecrets.GetPerCommitmentSecret commitmentNumber
+            remotePerCommitmentSecrets.GetPerCommitmentSecret commitmentNumber
         let! perCommitmentPoint =
             match perCommitmentSecretOpt with
             | Some perCommitmentSecret -> Some <| perCommitmentSecret.PerCommitmentPoint()
@@ -617,6 +618,7 @@ module RemoteForceClose =
     let getFundsFromForceClosingTransaction (commitments: Commitments)
                                             (localChannelPrivKeys: ChannelPrivKeys)
                                             (staticChannelConfig: StaticChannelConfig)
+                                            (remotePerCommitmentSecrets: PerCommitmentSecretStore)
                                             (transaction: Transaction)
                                                 : Option<TransactionBuilder> =
         let attemptsSeq = seq {
@@ -625,6 +627,7 @@ module RemoteForceClose =
                     commitments
                     localChannelPrivKeys
                     staticChannelConfig
+                    remotePerCommitmentSecrets
                     transaction
             yield
                 tryGetFundsFromLocalCommitmentTx

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -213,8 +213,7 @@ module internal Commitments =
                     FailureCode = op.FailureCode
                 }
                 let nextCommitments = cm.AddLocalProposal(msg)
-                [ WeAcceptedOperationFailMalformedHTLC(msg, nextCommitments) ]
-                |> Ok
+                Ok (msg, nextCommitments)
             | None ->
                 op.Id |> unknownHTLCId
 

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -261,8 +261,7 @@ module internal Commitments =
                             (staticChannelConfig.LocalParams.ChannelReserveSatoshis, fees,  (-1 * missing))
                             |> cannotAffordFee
                     else
-                        return
-                            [ WeAcceptedOperationUpdateFee(fee, c1) ]
+                        return fee, c1
                 }
 
     let receiveFee (channelOptions: ChannelOptions)

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -171,9 +171,8 @@ module internal Commitments =
                     HTLCId = op.Id
                     Reason = { Data = reason }
                 }
-                let nextComitments = cm.AddLocalProposal(f)
-                [ WeAcceptedOperationFailHTLC(f, nextComitments) ]
-                |> Ok
+                let nextCommitments = cm.AddLocalProposal(f)
+                Ok (f, nextCommitments)
         | None ->
             op.Id |> unknownHTLCId
 

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -249,19 +249,22 @@ module internal Commitments =
         else
             result {
                 do! Helpers.checkUpdateFee (config) (msg) (localFeerate)
-                let c1 = cm.AddRemoteProposal(msg)
+                let nextCommitments = cm.AddRemoteProposal(msg)
                 let! reduced =
-                    c1.LocalCommit.Spec.Reduce(c1.LocalChanges.ACKed, c1.RemoteChanges.Proposed) |> expectTransactionError
+                    nextCommitments.LocalCommit.Spec.Reduce(
+                        nextCommitments.LocalChanges.ACKed,
+                        nextCommitments.RemoteChanges.Proposed
+                    ) |> expectTransactionError
                 
-                let fees = Transactions.commitTxFee(c1.RemoteParams.DustLimitSatoshis) reduced
-                let missing = reduced.ToRemote.ToMoney() - c1.RemoteParams.ChannelReserveSatoshis - fees
+                let fees = Transactions.commitTxFee(nextCommitments.RemoteParams.DustLimitSatoshis) reduced
+                let missing = reduced.ToRemote.ToMoney() - nextCommitments.RemoteParams.ChannelReserveSatoshis - fees
                 if (missing < Money.Zero) then
                     return!
-                        (c1.LocalParams.ChannelReserveSatoshis, fees,  (-1 * missing))
+                        (nextCommitments.LocalParams.ChannelReserveSatoshis, fees,  (-1 * missing))
                         |> cannotAffordFee
                 else
                     return
-                        [ WeAcceptedUpdateFee msg ]
+                        [ WeAcceptedUpdateFee(msg, nextCommitments) ]
             }
 
     let sendCommit (channelPrivKeys: ChannelPrivKeys) (n: Network) (cm: Commitments) =

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -122,8 +122,11 @@ module internal Commitments =
         | Some htlc when (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
             htlc.HTLCId |> htlcAlreadySent
         | Some htlc when (htlc.PaymentHash = op.PaymentPreimage.Hash) ->
-            let msgToSend: UpdateFulfillHTLCMsg =
-                { ChannelId = cm.ChannelId; HTLCId = op.Id; PaymentPreimage = op.PaymentPreimage }
+            let msgToSend: UpdateFulfillHTLCMsg = {
+                ChannelId = cm.ChannelId()
+                HTLCId = op.Id
+                PaymentPreimage = op.PaymentPreimage
+            }
             let newCommitments = cm.AddLocalProposal(msgToSend)
             (msgToSend, newCommitments) |> Ok
         | Some htlc ->
@@ -159,9 +162,11 @@ module internal Commitments =
                 let reason =
                     op.Reason
                     |> function Choice1Of2 b -> Sphinx.forwardErrorPacket(b, ss) | Choice2Of2 f -> Sphinx.ErrorPacket.Create(ss, f)
-                let f = { UpdateFailHTLCMsg.ChannelId = cm.ChannelId
-                          HTLCId = op.Id
-                          Reason = { Data = reason } }
+                let f = {
+                    UpdateFailHTLCMsg.ChannelId = cm.ChannelId()
+                    HTLCId = op.Id
+                    Reason = { Data = reason }
+                }
                 let nextComitments = cm.AddLocalProposal(f)
                 [ WeAcceptedOperationFailHTLC(f, nextComitments) ]
                 |> Ok
@@ -193,10 +198,12 @@ module internal Commitments =
             | Some htlc when (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
                 htlc.HTLCId |> htlcAlreadySent
             | Some _htlc ->
-                let msg = { UpdateFailMalformedHTLCMsg.ChannelId = cm.ChannelId
-                            HTLCId = op.Id
-                            Sha256OfOnion = op.Sha256OfOnion
-                            FailureCode = op.FailureCode }
+                let msg = {
+                    UpdateFailMalformedHTLCMsg.ChannelId = cm.ChannelId()
+                    HTLCId = op.Id
+                    Sha256OfOnion = op.Sha256OfOnion
+                    FailureCode = op.FailureCode
+                }
                 let nextCommitments = cm.AddLocalProposal(msg)
                 [ WeAcceptedOperationFailMalformedHTLC(msg, nextCommitments) ]
                 |> Ok
@@ -225,8 +232,10 @@ module internal Commitments =
             if (not cm.LocalParams.IsFunder) then
                 "Local is Fundee so it cannot send update fee" |> apiMisuse
             else
-                let fee = { UpdateFeeMsg.ChannelId = cm.ChannelId
-                            FeeRatePerKw = op.FeeRatePerKw }
+                let fee = {
+                    UpdateFeeMsg.ChannelId = cm.ChannelId()
+                    FeeRatePerKw = op.FeeRatePerKw
+                }
                 let c1 = cm.AddLocalProposal(fee)
                 result {
                     let! reduced =
@@ -294,9 +303,11 @@ module internal Commitments =
                             >> fst
                             >> (fun txSig -> txSig.Signature)
                             )
-                let msg = { CommitmentSignedMsg.ChannelId = cm.ChannelId
-                            Signature = !> signature.Signature
-                            HTLCSignatures = htlcSigs |> List.map (!>) }
+                let msg = {
+                    CommitmentSignedMsg.ChannelId = cm.ChannelId()
+                    Signature = !> signature.Signature
+                    HTLCSignatures = htlcSigs |> List.map (!>)
+                }
                 let nextCommitments =
                     let nextRemoteCommitInfo = {
                         WaitingForRevocation.NextRemoteCommit = {
@@ -397,9 +408,11 @@ module internal Commitments =
                             (cm.LocalCommit.Index.NextCommitment().NextCommitment())
                     perCommitmentSecret.PerCommitmentPoint()
 
-                let nextMsg = { RevokeAndACKMsg.ChannelId = cm.ChannelId
-                                PerCommitmentSecret = localPerCommitmentSecret
-                                NextPerCommitmentPoint = localNextPerCommitmentPoint }
+                let nextMsg = {
+                    RevokeAndACKMsg.ChannelId = cm.ChannelId()
+                    PerCommitmentSecret = localPerCommitmentSecret
+                    NextPerCommitmentPoint = localNextPerCommitmentPoint
+                }
                 
                 let nextCommitments =
                     let localCommit1 = { LocalCommit.Index = cm.LocalCommit.Index.NextCommitment()

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -323,7 +323,6 @@ module internal Commitments =
                                 RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
                                 TxId = remoteCommitTx.GetTxId()
                         }
-                        ReSignASAP = false
                     }
                     { cm with RemoteNextCommitInfo = RemoteNextCommitInfo.Waiting(nextRemoteCommitInfo)
                               LocalChanges = { cm.LocalChanges with Proposed = []; Signed = cm.LocalChanges.Proposed }

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -323,7 +323,6 @@ module internal Commitments =
                                 RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
                                 TxId = remoteCommitTx.GetTxId()
                         }
-                        SentAfterLocalCommitmentIndex = cm.LocalCommit.Index
                         ReSignASAP = false
                     }
                     { cm with RemoteNextCommitInfo = RemoteNextCommitInfo.Waiting(nextRemoteCommitInfo)

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -330,14 +330,12 @@ module internal Commitments =
                     HTLCSignatures = htlcSigs |> List.map (!>)
                 }
                 let nextRemoteCommitInfo = {
-                    WaitingForRevocation.NextRemoteCommit = {
-                        cm.RemoteCommit
-                        with
-                            Index = cm.RemoteCommit.Index.NextCommitment()
-                            Spec = spec
-                            RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
-                            TxId = remoteCommitTx.GetTxId()
-                    }
+                    cm.RemoteCommit
+                    with
+                        Index = cm.RemoteCommit.Index.NextCommitment()
+                        Spec = spec
+                        RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
+                        TxId = remoteCommitTx.GetTxId()
                 }
                 let nextCommitments = {
                     cm with

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -119,8 +119,10 @@ module internal Commitments =
             let maxMismatch = channelOptions.MaxFeeRateMismatchRatio
             UpdateFeeValidation.checkFeeDiffTooHigh (msg) (localFeeRate) (maxMismatch)
 
-    let sendFulfill (op: OperationFulfillHTLC) (cm: Commitments) =
-        match cm.GetHTLCCrossSigned(Direction.In, op.Id) with
+    let sendFulfill (op: OperationFulfillHTLC)
+                    (cm: Commitments)
+                    (remoteNextCommitInfo: RemoteNextCommitInfo) =
+        match cm.GetHTLCCrossSigned remoteNextCommitInfo Direction.In op.Id with
         | Some htlc when (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
             htlc.HTLCId |> htlcAlreadySent
         | Some htlc when (htlc.PaymentHash = op.PaymentPreimage.Hash) ->
@@ -138,8 +140,10 @@ module internal Commitments =
             op.Id
             |> unknownHTLCId
 
-    let receiveFulfill(msg: UpdateFulfillHTLCMsg) (cm: Commitments) =
-        match cm.GetHTLCCrossSigned(Direction.Out, msg.HTLCId) with
+    let receiveFulfill (msg: UpdateFulfillHTLCMsg)
+                       (cm: Commitments)
+                       (remoteNextCommitInfo: RemoteNextCommitInfo) =
+        match cm.GetHTLCCrossSigned remoteNextCommitInfo Direction.Out msg.HTLCId with
         | Some htlc when htlc.PaymentHash = msg.PaymentPreimage.Hash ->
             let commitments = cm.AddRemoteProposal(msg)
             let origin = cm.OriginChannels |> Map.find(msg.HTLCId)
@@ -151,8 +155,11 @@ module internal Commitments =
             msg.HTLCId
             |> unknownHTLCId
 
-    let sendFail (nodeSecret: NodeSecret) (op: OperationFailHTLC) (cm: Commitments) =
-        match cm.GetHTLCCrossSigned(Direction.In, op.Id) with
+    let sendFail (nodeSecret: NodeSecret)
+                 (op: OperationFailHTLC)
+                 (cm: Commitments)
+                 (remoteNextCommitInfo: RemoteNextCommitInfo) =
+        match cm.GetHTLCCrossSigned remoteNextCommitInfo Direction.In op.Id with
         | Some htlc when  (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
             htlc.HTLCId |> htlcAlreadySent
         | Some htlc ->
@@ -175,8 +182,10 @@ module internal Commitments =
         | None ->
             op.Id |> unknownHTLCId
 
-    let receiveFail (msg: UpdateFailHTLCMsg) (cm: Commitments) =
-        match cm.GetHTLCCrossSigned(Direction.Out, msg.HTLCId) with
+    let receiveFail (msg: UpdateFailHTLCMsg)
+                    (cm: Commitments)
+                    (remoteNextCommitInfo: RemoteNextCommitInfo) =
+        match cm.GetHTLCCrossSigned remoteNextCommitInfo Direction.Out msg.HTLCId with
         | Some htlc ->
             result {
                 let! o =
@@ -191,12 +200,14 @@ module internal Commitments =
             msg.HTLCId |> unknownHTLCId
 
 
-    let sendFailMalformed (op: OperationFailMalformedHTLC) (cm: Commitments) =
+    let sendFailMalformed (op: OperationFailMalformedHTLC)
+                          (cm: Commitments)
+                          (remoteNextCommitInfo: RemoteNextCommitInfo) =
         // BADONION bit must be set in failure code
         if (op.FailureCode.Value &&& OnionError.BADONION) = 0us then
             op.FailureCode |> invalidFailureCode
         else
-            match cm.GetHTLCCrossSigned(Direction.In, op.Id) with
+            match cm.GetHTLCCrossSigned remoteNextCommitInfo Direction.In op.Id with
             | Some htlc when (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
                 htlc.HTLCId |> htlcAlreadySent
             | Some _htlc ->
@@ -212,11 +223,13 @@ module internal Commitments =
             | None ->
                 op.Id |> unknownHTLCId
 
-    let receiveFailMalformed (msg: UpdateFailMalformedHTLCMsg) (cm: Commitments) =
+    let receiveFailMalformed (msg: UpdateFailMalformedHTLCMsg)
+                             (cm: Commitments)
+                             (remoteNextCommitInfo: RemoteNextCommitInfo) =
         if msg.FailureCode.Value &&& OnionError.BADONION = 0us then
             msg.FailureCode |> invalidFailureCode
         else
-            match cm.GetHTLCCrossSigned(Direction.Out, msg.HTLCId) with
+            match cm.GetHTLCCrossSigned remoteNextCommitInfo Direction.Out msg.HTLCId with
             | Some htlc ->
                 result {
                     let! o =
@@ -283,8 +296,11 @@ module internal Commitments =
                         [ WeAcceptedUpdateFee(msg, nextCommitments) ]
             }
 
-    let sendCommit (channelPrivKeys: ChannelPrivKeys) (n: Network) (cm: Commitments) =
-        match cm.RemoteNextCommitInfo with
+    let sendCommit (channelPrivKeys: ChannelPrivKeys)
+                   (n: Network)
+                   (cm: Commitments)
+                   (remoteNextCommitInfo: RemoteNextCommitInfo) =
+        match remoteNextCommitInfo with
         | RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint ->
             result {
                 // remote commitment will include all local changes + remote acked changes
@@ -313,21 +329,30 @@ module internal Commitments =
                     Signature = !> signature.Signature
                     HTLCSignatures = htlcSigs |> List.map (!>)
                 }
-                let nextCommitments =
-                    let nextRemoteCommitInfo = {
-                        WaitingForRevocation.NextRemoteCommit = {
-                            cm.RemoteCommit
-                            with
-                                Index = cm.RemoteCommit.Index.NextCommitment()
-                                Spec = spec
-                                RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
-                                TxId = remoteCommitTx.GetTxId()
-                        }
+                let nextRemoteCommitInfo = {
+                    WaitingForRevocation.NextRemoteCommit = {
+                        cm.RemoteCommit
+                        with
+                            Index = cm.RemoteCommit.Index.NextCommitment()
+                            Spec = spec
+                            RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
+                            TxId = remoteCommitTx.GetTxId()
                     }
-                    { cm with RemoteNextCommitInfo = RemoteNextCommitInfo.Waiting(nextRemoteCommitInfo)
-                              LocalChanges = { cm.LocalChanges with Proposed = []; Signed = cm.LocalChanges.Proposed }
-                              RemoteChanges = { cm.RemoteChanges with ACKed = []; Signed = cm.RemoteChanges.ACKed } }
-                return [ WeAcceptedOperationSign (msg, nextCommitments) ]
+                }
+                let nextCommitments = {
+                    cm with
+                        LocalChanges = {
+                            cm.LocalChanges with
+                                Proposed = []
+                                Signed = cm.LocalChanges.Proposed
+                        }
+                        RemoteChanges = {
+                            cm.RemoteChanges with
+                                ACKed = []
+                                Signed = cm.RemoteChanges.ACKed
+                        }
+                }
+                return [ WeAcceptedOperationSign (msg, nextCommitments, nextRemoteCommitInfo) ]
             }
         | RemoteNextCommitInfo.Waiting _ ->
             CanNotSignBeforeRevocation |> Error

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -341,7 +341,7 @@ module internal Commitments =
                                 Signed = cm.RemoteChanges.ACKed
                         }
                 }
-                return [ WeAcceptedOperationSign (msg, nextCommitments, nextRemoteCommitInfo) ]
+                return msg, nextCommitments, nextRemoteCommitInfo
             }
         | RemoteNextCommitInfo.Waiting _ ->
             CanNotSignBeforeRevocation |> Error

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -415,3 +415,179 @@ module internal Commitments =
                               OriginChannels = originChannels1 }
                 return [ WeAcceptedCommitmentSigned(nextMsg, nextCommitments) ;]
             }
+
+module RemoteForceClose =
+    // The lightning spec specifies that commitment txs use version 2 bitcoin transactions.
+    let TxVersionNumberOfCommitmentTxs = 2u
+
+    let check(thing: bool): Option<unit> =
+        if thing then
+            Some ()
+        else
+            None
+
+    let tryGetObscuredCommitmentNumber (fundingOutPoint: OutPoint)
+                                       (transaction: Transaction)
+                                           : Option<ObscuredCommitmentNumber> = option {
+        do! check (transaction.Version = TxVersionNumberOfCommitmentTxs)
+        let! txIn = Seq.tryExactlyOne transaction.Inputs
+        do! check (fundingOutPoint = txIn.PrevOut)
+        let! obscuredCommitmentNumber =
+            ObscuredCommitmentNumber.TryFromLockTimeAndSequence transaction.LockTime txIn.Sequence
+        return obscuredCommitmentNumber
+    }
+
+    let tryGetFundsFromRemoteCommitmentTx (commitments: Commitments)
+                                          (localChannelPrivKeys: ChannelPrivKeys)
+                                          (network: Network)
+                                          (transaction: Transaction)
+                                              : Option<TransactionBuilder> = option {
+        let! obscuredCommitmentNumber =
+            tryGetObscuredCommitmentNumber
+                commitments.FundingScriptCoin.Outpoint
+                transaction
+        let localChannelPubKeys = commitments.LocalParams.ChannelPubKeys
+        let remoteChannelPubKeys = commitments.RemoteParams.ChannelPubKeys
+        let commitmentNumber =
+            obscuredCommitmentNumber.Unobscure
+                false
+                localChannelPubKeys.PaymentBasepoint
+                remoteChannelPubKeys.PaymentBasepoint
+        let perCommitmentSecretOpt =
+            commitments.RemotePerCommitmentSecrets.GetPerCommitmentSecret commitmentNumber
+        let! perCommitmentPoint =
+            match perCommitmentSecretOpt with
+            | Some perCommitmentSecret -> Some <| perCommitmentSecret.PerCommitmentPoint()
+            | None ->
+                if commitments.RemoteCommit.Index = commitmentNumber then
+                    Some commitments.RemoteCommit.RemotePerCommitmentPoint
+                else
+                    None
+
+        let localCommitmentPubKeys =
+            perCommitmentPoint.DeriveCommitmentPubKeys localChannelPubKeys
+        let remoteCommitmentPubKeys =
+            perCommitmentPoint.DeriveCommitmentPubKeys remoteChannelPubKeys
+
+        let transactionBuilder = network.CreateTransactionBuilder()
+
+        let toRemoteScriptPubKey =
+            localCommitmentPubKeys.PaymentPubKey.RawPubKey().WitHash.ScriptPubKey
+        let toRemoteIndexOpt =
+            Seq.tryFindIndex
+                (fun (txOut: TxOut) -> txOut.ScriptPubKey = toRemoteScriptPubKey)
+                transaction.Outputs
+        let spentToRemoteOutput =
+            match toRemoteIndexOpt with
+            | None -> false
+            | Some toRemoteIndex ->
+                let localPaymentPrivKey =
+                    perCommitmentPoint.DerivePaymentPrivKey
+                        localChannelPrivKeys.PaymentBasepointSecret
+                (transactionBuilder.AddKeys (localPaymentPrivKey.RawKey()))
+                                   .AddCoins (Coin(transaction, uint32 toRemoteIndex))
+                |> ignore
+                true
+
+        let spentToLocalOutput =
+            match perCommitmentSecretOpt with
+            | None -> false
+            | Some perCommitmentSecret ->
+                let toLocalScriptPubKey =
+                    Scripts.toLocalDelayed
+                        localCommitmentPubKeys.RevocationPubKey
+                        commitments.RemoteParams.ToSelfDelay
+                        remoteCommitmentPubKeys.DelayedPaymentPubKey
+                let toLocalIndexOpt =
+                    let toLocalWitScriptPubKey = toLocalScriptPubKey.WitHash.ScriptPubKey
+                    Seq.tryFindIndex
+                        (fun (txOut: TxOut) -> txOut.ScriptPubKey = toLocalWitScriptPubKey)
+                        transaction.Outputs
+                match toLocalIndexOpt with
+                | None -> false
+                | Some toLocalIndex ->
+                    let revocationPrivKey =
+                        perCommitmentSecret.DeriveRevocationPrivKey
+                            localChannelPrivKeys.RevocationBasepointSecret
+                    transactionBuilder.Extensions.Add (CommitmentToLocalExtension())
+                    (transactionBuilder.AddKeys (revocationPrivKey.RawKey()))
+                                       .AddCoins
+                        (ScriptCoin(transaction, uint32 toLocalIndex, toLocalScriptPubKey))
+                    |> ignore
+                    true
+
+        do! check (spentToRemoteOutput || spentToLocalOutput)
+
+        return transactionBuilder
+    }
+
+    let tryGetFundsFromLocalCommitmentTx (commitments: Commitments)
+                                         (localChannelPrivKeys: ChannelPrivKeys)
+                                         (network: Network)
+                                         (transaction: Transaction)
+                                             : Option<TransactionBuilder> = option {
+        let! obscuredCommitmentNumber =
+            tryGetObscuredCommitmentNumber
+                commitments.FundingScriptCoin.Outpoint
+                transaction
+        let localChannelPubKeys = commitments.LocalParams.ChannelPubKeys
+        let remoteChannelPubKeys = commitments.RemoteParams.ChannelPubKeys
+        let commitmentNumber =
+            obscuredCommitmentNumber.Unobscure
+                true
+                localChannelPubKeys.PaymentBasepoint
+                remoteChannelPubKeys.PaymentBasepoint
+
+        let perCommitmentPoint =
+            localChannelPrivKeys.CommitmentSeed.DerivePerCommitmentPoint commitmentNumber
+        let localCommitmentPubKeys =
+            perCommitmentPoint.DeriveCommitmentPubKeys localChannelPubKeys
+        let remoteCommitmentPubKeys =
+            perCommitmentPoint.DeriveCommitmentPubKeys remoteChannelPubKeys
+
+        let transactionBuilder = network.CreateTransactionBuilder()
+
+        let toLocalScriptPubKey =
+            Scripts.toLocalDelayed
+                remoteCommitmentPubKeys.RevocationPubKey
+                commitments.LocalParams.ToSelfDelay
+                localCommitmentPubKeys.DelayedPaymentPubKey
+        let! toLocalIndex =
+            let toLocalWitScriptPubKey = toLocalScriptPubKey.WitHash.ScriptPubKey
+            Seq.tryFindIndex
+                (fun (txOut: TxOut) -> txOut.ScriptPubKey = toLocalWitScriptPubKey)
+                transaction.Outputs
+
+        let delayedPaymentPrivKey =
+            perCommitmentPoint.DeriveDelayedPaymentPrivKey
+                localChannelPrivKeys.DelayedPaymentBasepointSecret
+        transactionBuilder.Extensions.Add (CommitmentToLocalExtension())
+        (transactionBuilder.AddKeys (delayedPaymentPrivKey.RawKey()))
+                           .AddCoins
+            (ScriptCoin(transaction, uint32 toLocalIndex, toLocalScriptPubKey))
+        |> ignore
+
+        return transactionBuilder
+    }
+
+    let getFundsFromForceClosingTransaction (commitments: Commitments)
+                                            (localChannelPrivKeys: ChannelPrivKeys)
+                                            (network: Network)
+                                            (transaction: Transaction)
+                                                : Option<TransactionBuilder> =
+        let attemptsSeq = seq {
+            yield
+                tryGetFundsFromRemoteCommitmentTx
+                    commitments
+                    localChannelPrivKeys
+                    network
+                    transaction
+            yield
+                tryGetFundsFromLocalCommitmentTx
+                    commitments
+                    localChannelPrivKeys
+                    network
+                    transaction
+        }
+        Seq.tryPick (fun opt -> opt) attemptsSeq
+

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -25,20 +25,20 @@ module internal Commitments =
         let makeRemoteTxs
             (localIsFunder: bool)
             (commitTxNumber: CommitmentNumber)
+            (localChannelPubKeys: ChannelPubKeys)
+            (remoteChannelPubKeys: ChannelPubKeys)
             (localParams: LocalParams)
             (remoteParams: RemoteParams)
             (commitmentInput: ScriptCoin)
             (remotePerCommitmentPoint: PerCommitmentPoint)
             (spec) (n) =
-            let localChannelKeys = localParams.ChannelPubKeys
-            let remoteChannelKeys = remoteParams.ChannelPubKeys
-            let localCommitmentPubKeys = remotePerCommitmentPoint.DeriveCommitmentPubKeys localChannelKeys
-            let remoteCommitmentPubKeys = remotePerCommitmentPoint.DeriveCommitmentPubKeys remoteChannelKeys
+            let localCommitmentPubKeys = remotePerCommitmentPoint.DeriveCommitmentPubKeys localChannelPubKeys
+            let remoteCommitmentPubKeys = remotePerCommitmentPoint.DeriveCommitmentPubKeys remoteChannelPubKeys
             let commitTx =
                 Transactions.makeCommitTx commitmentInput 
                                           commitTxNumber
-                                          remoteChannelKeys.PaymentBasepoint
-                                          localChannelKeys.PaymentBasepoint
+                                          remoteChannelPubKeys.PaymentBasepoint
+                                          localChannelPubKeys.PaymentBasepoint
                                           (not localIsFunder)
                                           (remoteParams.DustLimitSatoshis)
                                           localCommitmentPubKeys.RevocationPubKey
@@ -66,22 +66,22 @@ module internal Commitments =
         let makeLocalTXs
             (localIsFunder: bool)
             (commitTxNumber: CommitmentNumber)
+            (localChannelPubKeys: ChannelPubKeys)
+            (remoteChannelPubKeys: ChannelPubKeys)
             (localParams: LocalParams)
             (remoteParams: RemoteParams)
             (commitmentInput: ScriptCoin)
             (localPerCommitmentPoint: PerCommitmentPoint)
             (spec: CommitmentSpec)
             n: Result<(CommitTx * HTLCTimeoutTx list * HTLCSuccessTx list), _> =
-            let localChannelKeys = localParams.ChannelPubKeys
-            let remoteChannelKeys = remoteParams.ChannelPubKeys
-            let localCommitmentPubKeys = localPerCommitmentPoint.DeriveCommitmentPubKeys localChannelKeys
-            let remoteCommitmentPubKeys = localPerCommitmentPoint.DeriveCommitmentPubKeys remoteChannelKeys
+            let localCommitmentPubKeys = localPerCommitmentPoint.DeriveCommitmentPubKeys localChannelPubKeys
+            let remoteCommitmentPubKeys = localPerCommitmentPoint.DeriveCommitmentPubKeys remoteChannelPubKeys
 
             let commitTx =
                 Transactions.makeCommitTx commitmentInput
                                           commitTxNumber
-                                          localChannelKeys.PaymentBasepoint
-                                          remoteChannelKeys.PaymentBasepoint
+                                          localChannelPubKeys.PaymentBasepoint
+                                          remoteChannelPubKeys.PaymentBasepoint
                                           localIsFunder
                                           localParams.DustLimitSatoshis
                                           remoteCommitmentPubKeys.RevocationPubKey
@@ -292,6 +292,8 @@ module internal Commitments =
                 let! (remoteCommitTx, htlcTimeoutTxs, htlcSuccessTxs) =
                     Helpers.makeRemoteTxs cm.IsFunder
                                           (cm.RemoteCommit.Index.NextCommitment())
+                                          (channelPrivKeys.ToChannelPubKeys())
+                                          (cm.RemoteChannelPubKeys)
                                           (cm.LocalParams)
                                           (cm.RemoteParams)
                                           (cm.FundingScriptCoin)
@@ -343,8 +345,8 @@ module internal Commitments =
             ReceivedCommitmentSignedWhenWeHaveNoPendingChanges |> Error
         else
             let commitmentSeed = channelPrivKeys.CommitmentSeed
-            let localChannelKeys = cm.LocalParams.ChannelPubKeys
-            let remoteChannelKeys = cm.RemoteParams.ChannelPubKeys
+            let localChannelKeys = channelPrivKeys.ToChannelPubKeys()
+            let remoteChannelKeys = cm.RemoteChannelPubKeys
             let nextI = cm.LocalCommit.Index.NextCommitment()
             result {
                 let! spec = cm.LocalCommit.Spec.Reduce(cm.LocalChanges.ACKed, cm.RemoteChanges.Proposed) |> expectTransactionError
@@ -353,6 +355,8 @@ module internal Commitments =
                     Helpers.makeLocalTXs
                         cm.IsFunder
                         nextI
+                        (channelPrivKeys.ToChannelPubKeys())
+                        remoteChannelKeys
                         cm.LocalParams
                         cm.RemoteParams
                         cm.FundingScriptCoin
@@ -478,8 +482,8 @@ module RemoteForceClose =
             tryGetObscuredCommitmentNumber
                 commitments.FundingScriptCoin.Outpoint
                 transaction
-        let localChannelPubKeys = commitments.LocalParams.ChannelPubKeys
-        let remoteChannelPubKeys = commitments.RemoteParams.ChannelPubKeys
+        let localChannelPubKeys = localChannelPrivKeys.ToChannelPubKeys()
+        let remoteChannelPubKeys = commitments.RemoteChannelPubKeys
         let commitmentNumber =
             obscuredCommitmentNumber.Unobscure
                 false
@@ -562,8 +566,8 @@ module RemoteForceClose =
             tryGetObscuredCommitmentNumber
                 commitments.FundingScriptCoin.Outpoint
                 transaction
-        let localChannelPubKeys = commitments.LocalParams.ChannelPubKeys
-        let remoteChannelPubKeys = commitments.RemoteParams.ChannelPubKeys
+        let localChannelPubKeys = localChannelPrivKeys.ToChannelPubKeys()
+        let remoteChannelPubKeys = commitments.RemoteChannelPubKeys
         let commitmentNumber =
             obscuredCommitmentNumber.Unobscure
                 true

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -118,7 +118,7 @@ module internal Commitments =
                     (savedChannelState: SavedChannelState)
                     (remoteNextCommitInfo: RemoteNextCommitInfo) =
         match savedChannelState.GetIncomingHTLCCrossSigned remoteNextCommitInfo op.Id with
-        | Some htlc when (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
+        | Some htlc when (cm.ProposedLocalChanges |> Helpers.isAlreadySent htlc) ->
             htlc.HTLCId |> htlcAlreadySent
         | Some htlc when (htlc.PaymentHash = op.PaymentPreimage.Hash) ->
             let msgToSend: UpdateFulfillHTLCMsg = {
@@ -156,7 +156,7 @@ module internal Commitments =
                  (savedChannelState: SavedChannelState)
                  (remoteNextCommitInfo: RemoteNextCommitInfo) =
         match savedChannelState.GetIncomingHTLCCrossSigned remoteNextCommitInfo op.Id with
-        | Some htlc when  (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
+        | Some htlc when  (cm.ProposedLocalChanges |> Helpers.isAlreadySent htlc) ->
             htlc.HTLCId |> htlcAlreadySent
         | Some htlc ->
             let ad = htlc.PaymentHash.ToBytes()
@@ -205,7 +205,7 @@ module internal Commitments =
             op.FailureCode |> invalidFailureCode
         else
             match savedChannelState.GetIncomingHTLCCrossSigned remoteNextCommitInfo op.Id with
-            | Some htlc when (cm.LocalChanges.Proposed |> Helpers.isAlreadySent htlc) ->
+            | Some htlc when (cm.ProposedLocalChanges |> Helpers.isAlreadySent htlc) ->
                 htlc.HTLCId |> htlcAlreadySent
             | Some _htlc ->
                 let msg = {
@@ -253,7 +253,7 @@ module internal Commitments =
                 let c1 = cm.AddLocalProposal(fee)
                 result {
                     let! reduced =
-                        savedChannelState.RemoteCommit.Spec.Reduce(c1.RemoteChanges.ACKed, c1.LocalChanges.Proposed) |> expectTransactionError
+                        savedChannelState.RemoteCommit.Spec.Reduce(c1.RemoteChanges.ACKed, c1.ProposedLocalChanges) |> expectTransactionError
                     // A node cannot spend pending incoming htlcs, and need to keep funds above the reserve required by
                     // the counter party, after paying the fee, we look from remote's point of view, so if local is funder
                     // remote doesn't pay the fees.
@@ -302,7 +302,7 @@ module internal Commitments =
         | RemoteNextCommitInfo.Revoked remoteNextPerCommitmentPoint ->
             result {
                 // remote commitment will include all local changes + remote acked changes
-                let! spec = savedChannelState.RemoteCommit.Spec.Reduce(cm.RemoteChanges.ACKed, cm.LocalChanges.Proposed) |> expectTransactionError
+                let! spec = savedChannelState.RemoteCommit.Spec.Reduce(cm.RemoteChanges.ACKed, cm.ProposedLocalChanges) |> expectTransactionError
                 let! (remoteCommitTx, htlcTimeoutTxs, htlcSuccessTxs) =
                     Helpers.makeRemoteTxs savedChannelState.StaticChannelConfig
                                           (savedChannelState.RemoteCommit.Index.NextCommitment())
@@ -333,10 +333,10 @@ module internal Commitments =
                 }
                 let nextCommitments = {
                     cm with
+                        ProposedLocalChanges = []
                         LocalChanges = {
                             cm.LocalChanges with
-                                Proposed = []
-                                Signed = cm.LocalChanges.Proposed
+                                Signed = cm.ProposedLocalChanges
                         }
                         RemoteChanges = {
                             cm.RemoteChanges with

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -381,7 +381,7 @@ module internal Commitments =
                     let remoteSigPair = seq[ (remoteChannelKeys.FundingPubKey.RawPubKey(), TransactionSignature(msg.Signature.Value, SigHash.All)) ]
                     Seq.append localSigPair remoteSigPair
                 let tmp =
-                    Transactions.checkTxFinalized signedCommitTx localCommitTx.WhichInput sigPair
+                    Transactions.checkTxFinalized signedCommitTx CommitTx.WhichInput sigPair
                     |> expectTransactionError
                 let! finalizedCommitTx = tmp
                 let sortedHTLCTXs = Helpers.sortBothHTLCs htlcTimeoutTxs htlcSuccessTxs

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -111,8 +111,10 @@ module internal Commitments =
             |> List.ofSeq
             |> List.sortBy(fun htlc -> htlc.Value.GetGlobalTransaction().Inputs.[htlc.WhichInput].PrevOut.N)
 
-        let checkUpdateFee (config: ChannelConfig) (msg: UpdateFeeMsg) (localFeeRate: FeeRatePerKw) =
-            let maxMismatch = config.ChannelOptions.MaxFeeRateMismatchRatio
+        let checkUpdateFee (channelOptions: ChannelOptions)
+                           (msg: UpdateFeeMsg)
+                           (localFeeRate: FeeRatePerKw) =
+            let maxMismatch = channelOptions.MaxFeeRateMismatchRatio
             UpdateFeeValidation.checkFeeDiffTooHigh (msg) (localFeeRate) (maxMismatch)
 
     let sendFulfill (op: OperationFulfillHTLC) (cm: Commitments) =
@@ -243,12 +245,15 @@ module internal Commitments =
                             [ WeAcceptedOperationUpdateFee(fee, c1) ]
                 }
 
-    let receiveFee (config: ChannelConfig) (localFeerate) (msg: UpdateFeeMsg) (cm: Commitments) =
+    let receiveFee (channelOptions: ChannelOptions)
+                   (localFeerate)
+                   (msg: UpdateFeeMsg)
+                   (cm: Commitments) =
         if (cm.LocalParams.IsFunder) then
             "Remote is Fundee so it cannot send update fee" |> apiMisuse
         else
             result {
-                do! Helpers.checkUpdateFee (config) (msg) (localFeerate)
+                do! Helpers.checkUpdateFee channelOptions msg localFeerate
                 let nextCommitments = cm.AddRemoteProposal(msg)
                 let! reduced =
                     nextCommitments.LocalCommit.Spec.Reduce(

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -323,7 +323,6 @@ module internal Commitments =
                                 RemotePerCommitmentPoint = remoteNextPerCommitmentPoint
                                 TxId = remoteCommitTx.GetTxId()
                         }
-                        Sent = msg
                         SentAfterLocalCommitmentIndex = cm.LocalCommit.Index
                         ReSignASAP = false
                     }

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -355,7 +355,7 @@ module internal Commitments =
                       (msg: CommitmentSignedMsg)
                       (staticChannelConfig: StaticChannelConfig)
                       (cm: Commitments)
-                          : Result<ChannelEvent list, ChannelError> =
+                          : Result<RevokeAndACKMsg * Commitments, ChannelError> =
         if cm.RemoteHasChanges() |> not then
             ReceivedCommitmentSignedWhenWeHaveNoPendingChanges |> Error
         else
@@ -459,7 +459,7 @@ module internal Commitments =
                               LocalChanges = ourChanges1
                               RemoteChanges = theirChanges1
                               OriginChannels = originChannels1 }
-                return [ WeAcceptedCommitmentSigned(nextMsg, nextCommitments) ;]
+                return nextMsg, nextCommitments
             }
 
 module RemoteForceClose =

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -224,15 +224,15 @@ module internal Commitments =
             msg.FailureCode |> invalidFailureCode
         else
             match cm.GetHTLCCrossSigned remoteNextCommitInfo Direction.Out msg.HTLCId with
-            | Some htlc ->
+            | Some _htlc ->
                 result {
-                    let! o =
+                    let! _origin =
                         match cm.OriginChannels.TryGetValue(msg.HTLCId) with
                         | true, o -> Ok o
                         | false, _ ->
                             msg.HTLCId |> htlcOriginNowKnown
                     let nextC = cm.AddRemoteProposal(msg)
-                    return [WeAcceptedFailMalformedHTLC(o, htlc, nextC)]
+                    return nextC
                 }
             | None ->
                 msg.HTLCId |> unknownHTLCId

--- a/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
+++ b/src/DotNetLightning.Core/Channel/CommitmentsModule.fs
@@ -141,8 +141,7 @@ module internal Commitments =
         match cm.GetHTLCCrossSigned remoteNextCommitInfo Direction.Out msg.HTLCId with
         | Some htlc when htlc.PaymentHash = msg.PaymentPreimage.Hash ->
             let commitments = cm.AddRemoteProposal(msg)
-            let origin = cm.OriginChannels |> Map.find(msg.HTLCId)
-            [WeAcceptedFulfillHTLC(msg, origin, htlc, commitments)] |> Ok
+            commitments |> Ok
         | Some htlc ->
             (htlc.PaymentHash, msg.PaymentPreimage)
             |> invalidPaymentPreimage

--- a/src/DotNetLightning.Core/Crypto/ShaChain.fs
+++ b/src/DotNetLightning.Core/Crypto/ShaChain.fs
@@ -1,5 +1,7 @@
 namespace DotNetLightning.Crypto
 
+open System
+
 type Node = {
     Value: byte[]
     Height: int32
@@ -16,8 +18,9 @@ module ShaChain =
     let flip (_input: byte[]) (_index: uint64): byte[] =
         failwith "Not implemented: ShaChain::flip"
 
-    let addHash (_receiver: ShaChain) (_hash: byte[]) (_index: uint64) =
-        failwith "Not implemented: ShaChain::addHash"
+    let addHash (receiver: ShaChain) (_hash: byte[]) (_index: uint64) =
+        Console.WriteLine("WARNING: Not implemented: ShaChain::addHash")
+        receiver
 
     let getHash (_receiver: ShaChain)(_index: uint64) =
         failwith "Not implemented: ShaChain::getHash"

--- a/src/DotNetLightning.Core/DomainUtils/Types.fs
+++ b/src/DotNetLightning.Core/DomainUtils/Types.fs
@@ -1,7 +1,0 @@
-namespace DotNetLightning.DomainUtils.Types
-
-type IState = interface end
-type IStateData = interface end
-type ICommand = interface end
-type IEvent = interface end
-

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -60,7 +60,6 @@
     <Compile Include="Crypto/ShaChain.fs" />
     <Compile Include="Crypto\Aezeed.fs" />
     <Compile Include="Crypto/Sphinx.fs" />
-    <Compile Include="DomainUtils/Types.fs" />
     <Compile Include="Transactions\TransactionError.fs" />
     <Compile Include="Transactions/CommitmentSpec.fs" />
     <Compile Include="Transactions/Scripts.fs" />

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -27,6 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Utils/SeqConsumer.fs" />
     <Compile Include="Utils/LNMoney.fs" />
     <Compile Include="Utils\Extensions.fs" />
     <Compile Include="Utils/UInt48.fs" />
@@ -68,6 +69,7 @@
     <Compile Include="Peer\PeerChannelEncryptor.fs" />
     <Compile Include="Peer\PeerTypes.fs" />
     <Compile Include="Peer\Peer.fs" />
+    <Compile Include="Channel\CommitmentToLocalExtension.fs" />
     <Compile Include="Channel\HTLCChannelType.fs" />
     <Compile Include="Channel\ChannelConstants.fs" />
     <Compile Include="Channel\ChannelOperations.fs" />

--- a/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
+++ b/src/DotNetLightning.Core/DotNetLightning.Core.fsproj
@@ -8,7 +8,7 @@
   <Choose>
     <When Condition="'$(Portability)'=='true'">
       <PropertyGroup>
-        <PackageId>DotNetLightning</PackageId>
+        <PackageId>DotNetLightning.Kiss</PackageId>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/src/DotNetLightning.Core/Routing/Router.fs
+++ b/src/DotNetLightning.Core/Routing/Router.fs
@@ -136,8 +136,6 @@ module Routing =
     // ----- ------
     let executeCommand (state: RouterState) (cmd: RouterCommand) =
         match state, cmd with
-        | RouterState.Normal _d, (ChannelEvent(_)) ->
-            failwith "Not implemented: Routing::executeCommand when state,cmd = Normal,ChannelEvent"
         | RouterState.Normal _d, (NetworkEvent (ChannelUpdateReceived (_update))) ->
             failwith "Not implemented: Routing::executeCommand when state,cmd = Normal,NetworkEvent ChannelUpdateRecv"
         | RouterState.Normal d, (NetworkCommand (CalculateRoute (routeRequest))) ->

--- a/src/DotNetLightning.Core/Routing/RouterTypes.fs
+++ b/src/DotNetLightning.Core/Routing/RouterTypes.fs
@@ -34,7 +34,6 @@ type RouterError =
 module internal RouterError =
     let routeFindingError msg = RouteFindingError msg |> Error
 type RouterCommand =
-    | ChannelEvent of ChannelEvent
     | NetworkEvent of NetworkEvent
     | NetworkCommand of NetworkCommand
     

--- a/src/DotNetLightning.Core/Serialization/LightningStream.fs
+++ b/src/DotNetLightning.Core/Serialization/LightningStream.fs
@@ -5,6 +5,9 @@ open System.IO
 open DotNetLightning.Utils
 open NBitcoin
 
+open ResultUtils
+open ResultUtils.Portability
+
 type Scope(openAction: Action, closeAction: Action) =
     let _close = closeAction
     do openAction.Invoke()
@@ -416,4 +419,9 @@ type LightningReaderStream(inner: Stream) =
             rest <- int32 this.Length - int32 this.Position
         result |> Seq.toArray
          
-        
+    member this.ReadShutdownScriptPubKey(): ShutdownScriptPubKey =
+        let script = this.ReadScript()
+        match ShutdownScriptPubKey.TryFromScript script with
+        | Ok shutdownScript -> shutdownScript
+        | Error errorMsg -> failwith errorMsg
+

--- a/src/DotNetLightning.Core/Serialization/LightningStream.fs
+++ b/src/DotNetLightning.Core/Serialization/LightningStream.fs
@@ -58,10 +58,6 @@ type LightningWriterStream(inner: Stream) =
     override this.Write(buffer: byte[], offset: int, count: int) =
         this.Inner.Write(buffer, offset, count)
 
-    // FIXME: how to fix the warning reported below??:
-    member this.Write(buffer: ReadOnlySpan<byte>) =
-        this.Inner.Write(buffer.ToArray(), 0, buffer.Length)
-
     member this.Write(buf: byte[]) =
         this.Write(buf, 0, buf.Length)
 
@@ -326,7 +322,7 @@ type LightningReaderStream(inner: Stream) =
 
     member this.ReadKey(): Key =
         let bytes: array<byte> = this.ReadBytes Key.BytesLength
-        Key bytes
+        new Key(bytes)
 
     member this.ReadPubKey(): PubKey =
         let bytes = this.ReadBytes PubKey.BytesLength

--- a/src/DotNetLightning.Core/Serialization/LightningStream.fs
+++ b/src/DotNetLightning.Core/Serialization/LightningStream.fs
@@ -323,6 +323,10 @@ type LightningReaderStream(inner: Stream) =
         let len = this.ReadUInt16(false)
         this.ReadBytes(int32 len)
 
+    member this.ReadChannelFlags(): ChannelFlags =
+        let flags = this.ReadUInt8()
+        ChannelFlags.FromUInt8 flags
+
     member this.ReadKey(): Key =
         let bytes: array<byte> = this.ReadBytes Key.BytesLength
         new Key(bytes)

--- a/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
@@ -520,7 +520,7 @@ type OpenChannelMsg = {
     mutable HTLCBasepoint: HtlcBasepoint
     mutable FirstPerCommitmentPoint: PerCommitmentPoint
     mutable ChannelFlags: uint8
-    mutable ShutdownScriptPubKey: OptionalField<Script>
+    mutable ShutdownScriptPubKey: OptionalField<ShutdownScriptPubKey>
 }
 with
     interface IChannelMsg
@@ -546,7 +546,7 @@ with
             this.ChannelFlags <- ls.ReadUInt8()
             this.ShutdownScriptPubKey <-
                 if (ls.Position = ls.Length) then None else
-                ls.ReadWithLen() |> Script |> Some
+                ls.ReadShutdownScriptPubKey() |> Some
         member this.Serialize(ls) =
             ls.Write(this.Chainhash, true)
             ls.Write(this.TemporaryChannelId.Value, true)
@@ -584,7 +584,7 @@ type AcceptChannelMsg = {
     mutable DelayedPaymentBasepoint: DelayedPaymentBasepoint
     mutable HTLCBasepoint: HtlcBasepoint
     mutable FirstPerCommitmentPoint: PerCommitmentPoint
-    mutable ShutdownScriptPubKey: OptionalField<Script>
+    mutable ShutdownScriptPubKey: OptionalField<ShutdownScriptPubKey>
 }
 with
     interface IChannelMsg
@@ -606,7 +606,7 @@ with
             this.FirstPerCommitmentPoint <- ls.ReadPerCommitmentPoint()
             this.ShutdownScriptPubKey <-
                 if (ls.Position = ls.Length) then None else
-                ls.ReadWithLen() |> Script |> Some
+                ls.ReadShutdownScriptPubKey() |> Some
         member this.Serialize(ls) =
             ls.Write(this.TemporaryChannelId.Value.ToBytes())
             ls.Write(this.DustLimitSatoshis.Satoshi, false)
@@ -678,14 +678,14 @@ with
 [<CLIMutable>]
 type ShutdownMsg = {
     mutable ChannelId: ChannelId
-    mutable ScriptPubKey: Script
+    mutable ScriptPubKey: ShutdownScriptPubKey
 }
 with
     interface IChannelMsg
     interface ILightningSerializable<ShutdownMsg> with
         member this.Deserialize(ls) =
             this.ChannelId <- ls.ReadUInt256(true) |> ChannelId
-            this.ScriptPubKey <- ls.ReadScript()
+            this.ScriptPubKey <- ls.ReadShutdownScriptPubKey()
         member this.Serialize(ls) =
             ls.Write(this.ChannelId.Value.ToBytes())
             ls.WriteWithLen(this.ScriptPubKey.ToBytes())

--- a/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
@@ -104,6 +104,8 @@ module internal TypeFlag =
     let ReplyChannelRange = 264us
     [<Literal>]
     let GossipTimestampFilter = 265us
+    [<Literal>]
+    let MonoHopUnidirectionalPayment = 42198us
 
 type ILightningMsg = interface end
 type ISetupMsg = inherit ILightningMsg
@@ -195,6 +197,8 @@ module ILightningSerializable =
             deserialize<ReplyChannelRangeMsg>(ls) :> ILightningMsg
         | TypeFlag.GossipTimestampFilter ->
             deserialize<GossipTimestampFilterMsg>(ls) :> ILightningMsg
+        | TypeFlag.MonoHopUnidirectionalPayment ->
+            deserialize<MonoHopUnidirectionalPaymentMsg>(ls) :> ILightningMsg
         | x ->
             raise <| FormatException(sprintf "Unknown message type %d" x)
     let serializeWithFlags (ls: LightningWriterStream) (data: ILightningMsg) =
@@ -283,6 +287,9 @@ module ILightningSerializable =
         | :? GossipTimestampFilterMsg as d ->
             ls.Write(TypeFlag.GossipTimestampFilter, false)
             (d :> ILightningSerializable<GossipTimestampFilterMsg>).Serialize(ls)
+        | :? MonoHopUnidirectionalPaymentMsg as d ->
+            ls.Write(TypeFlag.MonoHopUnidirectionalPayment, false)
+            (d :> ILightningSerializable<MonoHopUnidirectionalPaymentMsg>).Serialize(ls)
         | x -> failwithf "%A is not known lightning message. This should never happen" x
 
 module LightningMsg =
@@ -1572,3 +1579,19 @@ type GossipTimestampFilterMsg = {
             ls.Write(this.FirstTimestamp, false)
             ls.Write(this.TimestampRange, false)
             
+[<CLIMutable>]
+type MonoHopUnidirectionalPaymentMsg = {
+    mutable ChannelId: ChannelId
+    mutable Amount: LNMoney
+}
+with
+    interface IHTLCMsg
+    interface IUpdateMsg
+    interface ILightningSerializable<MonoHopUnidirectionalPaymentMsg> with
+        member this.Deserialize(ls) =
+            this.ChannelId <- ls.ReadUInt256(true) |> ChannelId
+            this.Amount <- ls.ReadUInt64(false) |> LNMoney.MilliSatoshis
+        member this.Serialize(ls) =
+            ls.Write(this.ChannelId.Value.ToBytes())
+            ls.Write(this.Amount.MilliSatoshi, false)
+

--- a/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
+++ b/src/DotNetLightning.Core/Serialization/Msgs/Msgs.fs
@@ -519,7 +519,7 @@ type OpenChannelMsg = {
     mutable DelayedPaymentBasepoint: DelayedPaymentBasepoint
     mutable HTLCBasepoint: HtlcBasepoint
     mutable FirstPerCommitmentPoint: PerCommitmentPoint
-    mutable ChannelFlags: uint8
+    mutable ChannelFlags: ChannelFlags
     mutable ShutdownScriptPubKey: OptionalField<ShutdownScriptPubKey>
 }
 with
@@ -543,7 +543,7 @@ with
             this.DelayedPaymentBasepoint <- ls.ReadDelayedPaymentBasepoint()
             this.HTLCBasepoint <- ls.ReadHtlcBasepoint()
             this.FirstPerCommitmentPoint <- ls.ReadPerCommitmentPoint()
-            this.ChannelFlags <- ls.ReadUInt8()
+            this.ChannelFlags <- ls.ReadChannelFlags()
             this.ShutdownScriptPubKey <-
                 if (ls.Position = ls.Length) then None else
                 ls.ReadShutdownScriptPubKey() |> Some
@@ -565,7 +565,7 @@ with
             ls.Write(this.DelayedPaymentBasepoint.ToBytes())
             ls.Write(this.HTLCBasepoint.ToBytes())
             ls.Write(this.FirstPerCommitmentPoint.ToBytes())
-            ls.Write(this.ChannelFlags)
+            ls.Write(this.ChannelFlags.IntoUInt8())
             ls.WriteWithLen(this.ShutdownScriptPubKey |> Option.map(fun x -> x.ToBytes()))
 
 [<CLIMutable>]

--- a/src/DotNetLightning.Core/Transactions/CommitmentSpec.fs
+++ b/src/DotNetLightning.Core/Transactions/CommitmentSpec.fs
@@ -53,6 +53,11 @@ type CommitmentSpec = {
         member this.TotalFunds =
             this.ToLocal + this.ToRemote + (this.HTLCs |> Seq.sumBy(fun h -> h.Value.Add.Amount))
 
+        member internal this.MonoHopUnidirectionalPayment(direction: Direction, update: MonoHopUnidirectionalPaymentMsg) =
+            match direction with
+            | Out -> { this with ToLocal = this.ToLocal - update.Amount; ToRemote = this.ToRemote + update.Amount }
+            | In ->  { this with ToLocal = this.ToLocal + update.Amount; ToRemote = this.ToRemote - update.Amount }
+
         member internal this.AddHTLC(direction: Direction, update: UpdateAddHTLCMsg) =
             let htlc = { DirectedHTLC.Direction = direction; Add = update }
             match direction with
@@ -82,6 +87,24 @@ type CommitmentSpec = {
                 UnknownHTLC htlcId |> Error
 
         member internal this.Reduce(localChanges: #IUpdateMsg list, remoteChanges: #IUpdateMsg list) =
+            let specMonoHopUnidirectionalPaymentLocal =
+                localChanges
+                |> List.fold(fun (acc: CommitmentSpec) updateMsg ->
+                        match box updateMsg with
+                        | :? MonoHopUnidirectionalPaymentMsg as u -> acc.MonoHopUnidirectionalPayment(Out, u)
+                        | _ -> acc
+                    )
+                    this
+
+            let specMonoHopUnidirectionalPaymentRemote =
+                remoteChanges
+                |> List.fold(fun (acc: CommitmentSpec) updateMsg ->
+                        match box updateMsg with
+                        | :? MonoHopUnidirectionalPaymentMsg as u -> acc.MonoHopUnidirectionalPayment(In, u)
+                        | _ -> acc
+                    )
+                    specMonoHopUnidirectionalPaymentLocal
+
             let spec1 =
                 localChanges
                 |> List.fold(fun (acc: CommitmentSpec) updateMsg ->
@@ -89,7 +112,7 @@ type CommitmentSpec = {
                         | :? UpdateAddHTLCMsg as u -> acc.AddHTLC(Out, u)
                         | _ -> acc
                     )
-                    this
+                    specMonoHopUnidirectionalPaymentRemote
 
             let spec2 =
                 remoteChanges

--- a/src/DotNetLightning.Core/Transactions/Scripts.fs
+++ b/src/DotNetLightning.Core/Transactions/Scripts.fs
@@ -1,6 +1,5 @@
 namespace DotNetLightning.Transactions
 
-open DotNetLightning.DomainUtils.Types
 open NBitcoin
 open NBitcoin.Crypto
 open DotNetLightning.Utils

--- a/src/DotNetLightning.Core/Transactions/Scripts.fs
+++ b/src/DotNetLightning.Core/Transactions/Scripts.fs
@@ -118,15 +118,3 @@ module Scripts =
         opList.Add(!> OpcodeType.OP_ENDIF);
         Script(opList);
 
-    let isValidFinalScriptPubKey(spk: Script) =
-        (PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(spk))
-        || (PayToScriptHashTemplate.Instance.CheckScriptPubKey(spk))
-        || (PayToWitPubKeyHashTemplate.Instance.CheckScriptPubKey(spk))
-        || (PayToWitScriptHashTemplate.Instance.CheckScriptPubKey(spk))
-        
-    let checkIsValidFinalScriptPubKey(spk: Script) =
-        if (isValidFinalScriptPubKey spk) then
-            Ok ()
-        else
-            sprintf "Invalid final script pubkey(%A). it must be one of p2pkh, p2sh, p2wpkh, p2wsh" spk
-            |> Error

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -310,21 +310,19 @@ module Transactions =
 
     let UINT32_MAX = 0xffffffffu
 
-    let private trimOfferedHTLCs (dustLimit: Money) (spec: CommitmentSpec): DirectedHTLC list =
+    let private trimOfferedHTLCs (dustLimit: Money) (spec: CommitmentSpec): list<UpdateAddHTLCMsg> =
         let htlcTimeoutFee = spec.FeeRatePerKw.CalculateFeeFromWeight(HTLC_TIMEOUT_WEIGHT)
-        spec.HTLCs
+        spec.OutgoingHTLCs
             |> Map.toList
             |> List.map snd
-            |> List.filter(fun v -> v.Direction = Out)
-            |> List.filter(fun v -> (v.Add.Amount.ToMoney()) >= (dustLimit + htlcTimeoutFee))
+            |> List.filter(fun v -> (v.Amount.ToMoney()) >= (dustLimit + htlcTimeoutFee))
 
-    let private trimReceivedHTLCs (dustLimit: Money) (spec: CommitmentSpec) : DirectedHTLC list =
+    let private trimReceivedHTLCs (dustLimit: Money) (spec: CommitmentSpec) : list<UpdateAddHTLCMsg> =
         let htlcSuccessFee = spec.FeeRatePerKw.CalculateFeeFromWeight(HTLC_SUCCESS_WEIGHT)
-        spec.HTLCs
+        spec.IncomingHTLCs
             |> Map.toList
             |> List.map snd
-            |> List.filter(fun v -> v.Direction = In)
-            |> List.filter(fun v -> (v.Add.Amount.ToMoney()) >= (dustLimit + htlcSuccessFee))
+            |> List.filter(fun v -> (v.Amount.ToMoney()) >= (dustLimit + htlcSuccessFee))
 
     let internal commitTxFee (dustLimit: Money) (spec: CommitmentSpec): Money =
         let trimmedOfferedHTLCs = trimOfferedHTLCs (dustLimit) (spec)
@@ -391,13 +389,13 @@ module Transactions =
         let htlcOfferedOutputsWithMetadata =
             trimOfferedHTLCs (localDustLimit) (spec)
             |> List.map(fun htlc ->
-                let redeem = Scripts.htlcOffered (localHTLCPubKey) (remoteHTLCPubkey) localRevocationPubKey (htlc.Add.PaymentHash)
-                (TxOut(htlc.Add.Amount.ToMoney(), redeem.WitHash.ScriptPubKey)), Some htlc.Add)
+                let redeem = Scripts.htlcOffered (localHTLCPubKey) (remoteHTLCPubkey) localRevocationPubKey (htlc.PaymentHash)
+                (TxOut(htlc.Amount.ToMoney(), redeem.WitHash.ScriptPubKey)), Some htlc)
         let htlcReceivedOutputsWithMetadata =
             trimReceivedHTLCs(localDustLimit) (spec)
             |> List.map(fun htlc ->
-                    let redeem = Scripts.htlcReceived (localHTLCPubKey) (remoteHTLCPubkey) (localRevocationPubKey) (htlc.Add.PaymentHash) (htlc.Add.CLTVExpiry.Value)
-                    TxOut(htlc.Add.Amount.ToMoney(), redeem.WitHash.ScriptPubKey), Some htlc.Add)
+                    let redeem = Scripts.htlcReceived (localHTLCPubKey) (remoteHTLCPubkey) (localRevocationPubKey) (htlc.PaymentHash) (htlc.CLTVExpiry.Value)
+                    TxOut(htlc.Amount.ToMoney(), redeem.WitHash.ScriptPubKey), Some htlc)
         
         let obscuredCommitmentNumber =
             commitmentNumber.Obscure localIsFunder localPaymentBasepoint remotePaymentBasepoint
@@ -602,7 +600,7 @@ module Transactions =
                                                                        localHTLCPubKey
                                                                        remoteHTLCPubKey
                                                                        spec.FeeRatePerKw
-                                                                       htlc.Add
+                                                                       htlc
                                                                        network
                                         )
                              |> List.sequenceResultA
@@ -616,7 +614,7 @@ module Transactions =
                                                                        localHTLCPubKey
                                                                        remoteHTLCPubKey
                                                                        spec.FeeRatePerKw
-                                                                       htlc.Add
+                                                                       htlc
                                                                        network
                                         )
                              |> List.sequenceResultA
@@ -765,8 +763,10 @@ module Transactions =
                       (spec: CommitmentSpec)
                       (network: Network)
                           : Result<ClosingTx, _> =
-        if (not spec.HTLCs.IsEmpty) then
-            HTLCNotClean (spec.HTLCs |> Map.toList |> List.map(fst)) |> Error
+        if (not spec.OutgoingHTLCs.IsEmpty) || (not spec.IncomingHTLCs.IsEmpty) then
+            HTLCNotClean
+                ((spec.OutgoingHTLCs |> Map.toList |> List.map(fst)) @ (spec.IncomingHTLCs |> Map.toList |> List.map(fst)))
+            |> Error
         else
             let toLocalAmount, toRemoteAmount =
                 if (localIsFunder) then

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -31,15 +31,14 @@ type IHTLCTx =
 
 type CommitTx = {
     Value: PSBT
-    WhichInput: int
 }
     with    
         interface ILightningTx with
             member this.Value: PSBT = 
                 this.Value
-            member this.WhichInput: int = 
-                this.WhichInput
+            member this.WhichInput: int = 0
 
+        static member WhichInput: int = 0
         member this.GetTxId() =
             this.Value.GetGlobalTransaction().GetTxId()
 
@@ -84,16 +83,17 @@ module private HTLCHelper =
         
 type HTLCSuccessTx = {
     Value: PSBT
-    WhichInput: int
     PaymentHash: PaymentHash
 }
     with
+        static member WhichInput: int = 0
+
         member this.GetRedeem() =
-            this.Value.Inputs.[this.WhichInput].WitnessScript
+            this.Value.Inputs.[HTLCSuccessTx.WhichInput].WitnessScript
             
         member this.Finalize(localPubkey, remotePubKey, paymentPreimage) =
-            let localSig = this.Value.Inputs.[this.WhichInput].PartialSigs.[localPubkey]
-            let remoteSig = this.Value.Inputs.[this.WhichInput].PartialSigs.[remotePubKey]
+            let localSig = this.Value.Inputs.[HTLCSuccessTx.WhichInput].PartialSigs.[localPubkey]
+            let remoteSig = this.Value.Inputs.[HTLCSuccessTx.WhichInput].PartialSigs.[remotePubKey]
             this.Finalize(localSig, remoteSig, paymentPreimage)
             
         member this.Finalize(localSig, remoteSig, paymentPreimage: PaymentPreimage) =
@@ -102,20 +102,21 @@ type HTLCSuccessTx = {
         interface IHTLCTx
             with
                 member this.Value = this.Value
-                member this.WhichInput = this.WhichInput
+                member this.WhichInput = HTLCSuccessTx.WhichInput
 
 type HTLCTimeoutTx = {
     Value: PSBT
-    WhichInput: int
 }
     with
+        static member WhichInput: int = 0
+
         member this.Finalize(localSig: TransactionSignature, remoteSig: TransactionSignature) =
             HTLCHelper.finalize(this, localSig, remoteSig, None)
             
         interface IHTLCTx
             with
                 member this.Value = this.Value
-                member this.WhichInput = this.WhichInput
+                member this.WhichInput = HTLCTimeoutTx.WhichInput
 
 
 type ClaimHTLCSuccessTx = ClaimHTLCSuccessTx of PSBT
@@ -419,7 +420,7 @@ module Transactions =
         let psbt =
             let p = PSBT.FromTransaction(tx, network)
             p.AddCoins(inputInfo)
-        { CommitTx.Value = psbt; WhichInput = 0 }
+        { CommitTx.Value = psbt }
 
 
     let private findScriptPubKeyIndex(tx: Transaction) (spk: Script) =
@@ -538,8 +539,7 @@ module Transactions =
 
                 PSBT.FromTransaction(tx, network)
                     .AddCoins scriptCoin
-            let whichInput = psbt.Inputs |> Seq.findIndex(fun i -> not (isNull i.WitnessScript))
-            { HTLCTimeoutTx.Value = psbt; WhichInput = whichInput } |> Ok
+            { HTLCTimeoutTx.Value = psbt } |> Ok
 
     let makeHTLCSuccessTx (commitTx: Transaction)
                           (localDustLimit: Money)
@@ -581,8 +581,7 @@ module Transactions =
 
                 PSBT.FromTransaction(tx, network)
                     .AddCoins scriptCoin
-            let whichInput = psbt.Inputs |> Seq.findIndex(fun i -> not (isNull i.WitnessScript))
-            { HTLCSuccessTx.Value = psbt; WhichInput = whichInput; PaymentHash = htlc.PaymentHash } |> Ok
+            { HTLCSuccessTx.Value = psbt; PaymentHash = htlc.PaymentHash } |> Ok
 
     let makeHTLCTxs (commitTx: Transaction)
                     (localDustLimit: Money)

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -304,6 +304,7 @@ module Transactions =
         let txb = network.CreateTransactionBuilder()
         txb.ShuffleOutputs <- false
         txb.ShuffleInputs <- false
+        txb.ShuffleRandom <- null
         txb
 
     let UINT32_MAX = 0xffffffffu

--- a/src/DotNetLightning.Core/Transactions/Transactions.fs
+++ b/src/DotNetLightning.Core/Transactions/Transactions.fs
@@ -758,8 +758,8 @@ module Transactions =
         raise <| NotImplementedException()
 
     let makeClosingTx (commitTxInput: ScriptCoin)
-                      (localDestination: Script)
-                      (remoteDestination: Script)
+                      (localDestination: ShutdownScriptPubKey)
+                      (remoteDestination: ShutdownScriptPubKey)
                       (localIsFunder: bool)
                       (dustLimit: Money)
                       (closingFee: Money)
@@ -778,9 +778,9 @@ module Transactions =
             let outputs =
                 seq {
                     if toLocalAmount >= dustLimit then
-                        yield TxOut(toLocalAmount, localDestination)
+                        yield TxOut(toLocalAmount, localDestination.ScriptPubKey())
                     if toRemoteAmount >= dustLimit then
-                        yield TxOut(toRemoteAmount, remoteDestination)
+                        yield TxOut(toRemoteAmount, remoteDestination.ScriptPubKey())
                 }
                 |> Seq.sortWith TxOut.LexicographicCompare
             let psbt = 

--- a/src/DotNetLightning.Core/Utils/Config.fs
+++ b/src/DotNetLightning.Core/Utils/Config.fs
@@ -69,8 +69,6 @@ type ChannelOptions = {
     
     /// We don't exchange more than this many signatures when negotiating the closing fee
     MaxClosingNegotiationIterations: int32
-
-    ShutdownScriptPubKey: Script option
  }
     with
 
@@ -80,7 +78,6 @@ type ChannelOptions = {
             AnnounceChannel = false
             MaxFeeRateMismatchRatio = 0.
             MaxClosingNegotiationIterations = 20
-            ShutdownScriptPubKey = None
         }
 
     static member FeeProportionalMillionths_: Lens<_, _> =

--- a/src/DotNetLightning.Core/Utils/Config.fs
+++ b/src/DotNetLightning.Core/Utils/Config.fs
@@ -54,28 +54,6 @@ type ChannelHandshakeLimits = {
         }
 
 
-type ChannelOptions = {
-    MaxFeeRateMismatchRatio: float
-    // Amount (in millionth of a satoshi) the channel will charge per transferred satoshi.
-    // This may be allowed to change at runtime in a later update, however doing so must result in
-    // update messages sent to notify all nodes of our updated relay fee.
-    FeeProportionalMillionths: uint32
-    /// We don't exchange more than this many signatures when negotiating the closing fee
-    MaxClosingNegotiationIterations: int32
- }
-    with
-
-    static member Zero =
-        {
-            FeeProportionalMillionths = 0u
-            MaxFeeRateMismatchRatio = 0.
-            MaxClosingNegotiationIterations = 20
-        }
-
-    static member FeeProportionalMillionths_: Lens<_, _> =
-        (fun cc -> cc.FeeProportionalMillionths),
-        (fun v cc -> { cc with FeeProportionalMillionths = v })
-        
 type RouterConfig() =
     member val RandomizeRouteSelection: bool = true with get, set
     member val ChannelExcludeDuration: DateTimeOffset = Unchecked.defaultof<DateTimeOffset> with get, set

--- a/src/DotNetLightning.Core/Utils/Config.fs
+++ b/src/DotNetLightning.Core/Utils/Config.fs
@@ -3,7 +3,6 @@ open System
 open NBitcoin
 open Aether
 
-
 /// Optional Channel limits which are applied during channel creation.
 /// These limits are only applied to our counterparty's limits, not our own
 type ChannelHandshakeLimits = {
@@ -61,12 +60,6 @@ type ChannelOptions = {
     // This may be allowed to change at runtime in a later update, however doing so must result in
     // update messages sent to notify all nodes of our updated relay fee.
     FeeProportionalMillionths: uint32
-    // Set to announce the channel publicly and notify all nodes that they can route via this channel.
-    // This should only be set to true for nodes which expect to be online reliably.
-    // As the node which funds a channel picks this value this will only apply for new outbound channels unless
-    // `ChannelHandshakeLimits.ForceAnnouncedChannelPreferences` is set.
-    AnnounceChannel: bool
-    
     /// We don't exchange more than this many signatures when negotiating the closing fee
     MaxClosingNegotiationIterations: int32
  }
@@ -75,7 +68,6 @@ type ChannelOptions = {
     static member Zero =
         {
             FeeProportionalMillionths = 0u
-            AnnounceChannel = false
             MaxFeeRateMismatchRatio = 0.
             MaxClosingNegotiationIterations = 20
         }
@@ -83,10 +75,6 @@ type ChannelOptions = {
     static member FeeProportionalMillionths_: Lens<_, _> =
         (fun cc -> cc.FeeProportionalMillionths),
         (fun v cc -> { cc with FeeProportionalMillionths = v })
-
-    static member AnnouncedChannel_: Lens<_, _> =
-        (fun cc -> cc.AnnounceChannel),
-        (fun v cc -> { cc with AnnounceChannel = v })
         
 type RouterConfig() =
     member val RandomizeRouteSelection: bool = true with get, set

--- a/src/DotNetLightning.Core/Utils/Config.fs
+++ b/src/DotNetLightning.Core/Utils/Config.fs
@@ -38,9 +38,6 @@ type ChannelHandshakeLimits = {
     /// Defaults to true to make the default that no announced channels are possible (which is
     /// appropriate for any nodes which are not online very reliably)
     ForceChannelAnnouncementPreference: bool
-
-    /// We don't exchange more than this many signatures when negotiating the closing fee
-    MaxClosingNegotiationIterations: int32
  }
 
     with
@@ -55,32 +52,10 @@ type ChannelHandshakeLimits = {
             MaxDustLimitSatoshis = Money.Coins(21_000_000m)
             MaxMinimumDepth = 144u |> BlockHeightOffset32
             ForceChannelAnnouncementPreference = true
-            MaxClosingNegotiationIterations = 20
         }
 
 
-/// Configuration containing all information used by Channel
-type ChannelConfig = {
-    PeerChannelConfigLimits: ChannelHandshakeLimits
-    ChannelOptions: ChannelOptions
- }
-
-    with
-    static member Zero =
-        {
-            PeerChannelConfigLimits = ChannelHandshakeLimits.Zero
-            ChannelOptions = ChannelOptions.Zero
-        }
-
-    static member PeerChannelConfigLimits_: Lens<_, _> =
-        (fun uc -> uc.PeerChannelConfigLimits),
-        (fun v uc -> { uc with PeerChannelConfigLimits = v })
-
-    static member ChannelOptions_: Lens<_, _> =
-        (fun uc -> uc.ChannelOptions),
-        (fun v uc -> { uc with ChannelOptions = v })
-
-and ChannelOptions = {
+type ChannelOptions = {
     MaxFeeRateMismatchRatio: float
     // Amount (in millionth of a satoshi) the channel will charge per transferred satoshi.
     // This may be allowed to change at runtime in a later update, however doing so must result in
@@ -92,6 +67,9 @@ and ChannelOptions = {
     // `ChannelHandshakeLimits.ForceAnnouncedChannelPreferences` is set.
     AnnounceChannel: bool
     
+    /// We don't exchange more than this many signatures when negotiating the closing fee
+    MaxClosingNegotiationIterations: int32
+
     ShutdownScriptPubKey: Script option
  }
     with
@@ -101,6 +79,7 @@ and ChannelOptions = {
             FeeProportionalMillionths = 0u
             AnnounceChannel = false
             MaxFeeRateMismatchRatio = 0.
+            MaxClosingNegotiationIterations = 20
             ShutdownScriptPubKey = None
         }
 

--- a/src/DotNetLightning.Core/Utils/Config.fs
+++ b/src/DotNetLightning.Core/Utils/Config.fs
@@ -4,19 +4,6 @@ open NBitcoin
 open Aether
 
 
-type ChannelHandshakeConfig = {
-    /// Confirmations we will wait for before considering the channel locked in.
-    /// Applied only for inbound channels (see `ChannelHandshakeLimits.MaxMinimumDepth` for the
-    /// equivalent limit applied to outbound channel)
-    MinimumDepth: BlockHeightOffset32
- }
-    with
-
-    static member Zero =
-        {
-            MinimumDepth = BlockHeightOffset32 6u
-        }
-
 /// Optional Channel limits which are applied during channel creation.
 /// These limits are only applied to our counterparty's limits, not our own
 type ChannelHandshakeLimits = {
@@ -74,7 +61,6 @@ type ChannelHandshakeLimits = {
 
 /// Configuration containing all information used by Channel
 type ChannelConfig = {
-    ChannelHandshakeConfig: ChannelHandshakeConfig
     PeerChannelConfigLimits: ChannelHandshakeLimits
     ChannelOptions: ChannelOptions
  }
@@ -82,7 +68,6 @@ type ChannelConfig = {
     with
     static member Zero =
         {
-            ChannelHandshakeConfig = ChannelHandshakeConfig.Zero
             PeerChannelConfigLimits = ChannelHandshakeLimits.Zero
             ChannelOptions = ChannelOptions.Zero
         }

--- a/src/DotNetLightning.Core/Utils/Keys.fs
+++ b/src/DotNetLightning.Core/Utils/Keys.fs
@@ -62,6 +62,9 @@ type RevocationPubKey =
         let (RevocationPubKey pubKey) = this
         pubKey
 
+    static member FromBytes(bytes: array<byte>): RevocationPubKey =
+        RevocationPubKey <| PubKey bytes
+
     member this.ToBytes(): array<byte> =
         this.RawPubKey().ToBytes()
 
@@ -153,6 +156,9 @@ type DelayedPaymentPubKey =
     member this.RawPubKey(): PubKey =
         let (DelayedPaymentPubKey pubKey) = this
         pubKey
+
+    static member FromBytes(bytes: array<byte>): DelayedPaymentPubKey =
+        DelayedPaymentPubKey <| PubKey bytes
 
     member this.ToBytes(): array<byte> =
         this.RawPubKey().ToBytes()

--- a/src/DotNetLightning.Core/Utils/LNMoney.fs
+++ b/src/DotNetLightning.Core/Utils/LNMoney.fs
@@ -39,6 +39,8 @@ type LNMoney = | LNMoney of int64 with
         let satoshi = Checked.op_Multiply (amount) (decimal lnUnit)
         LNMoney(Checked.int64 satoshi)
 
+    static member FromMoney (money: Money) =
+        LNMoney.Satoshis money.Satoshi
 
     static member Coins(coins: decimal) =
         LNMoney.FromUnit(coins * (decimal LNMoneyUnit.BTC), LNMoneyUnit.MilliSatoshi)

--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -480,6 +480,12 @@ module Primitives =
             self.Thingo.ToBytes()
 
     type ChannelFlags = {
+        // Set to announce the channel publicly and notify all nodes that they
+        // can route via this channel. This should only be set to true for
+        // nodes which expect to be online reliably. As the node which funds a
+        // channel picks this value this will only apply for new outbound
+        // channels unless
+        // `ChannelHandshakeLimits.ForceAnnouncedChannelPreferences` is set.
         AnnounceChannel: bool
     } with
         static member private AnnounceChannelMask: uint8 = 1uy

--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -338,12 +338,18 @@ module Primitives =
         member this.AsNBitcoinFeeRate() =
             this.Value |> uint64 |> (*)4UL |> Money.Satoshis |> FeeRate
 
+        member this.MismatchRatio (other: FeeRatePerKw) =
+            let local = double this.Value
+            let remote = double other.Value
+            abs (2.0 * (remote - local) / (remote + local))
+
         static member Max(a: FeeRatePerKw, b: FeeRatePerKw) =
             if (a.Value >= b.Value) then a else b
         static member (+) (a: FeeRatePerKw, b: uint32) =
             (a.Value + b) |> FeeRatePerKw
         static member (*) (a: FeeRatePerKw, b: uint32) =
             (a.Value * b) |> FeeRatePerKw
+
     /// Block Hash
     type BlockId = | BlockId of uint256 with
         member x.Value = let (BlockId v) = x in v

--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -479,3 +479,18 @@ module Primitives =
         member self.ToBytes(): array<byte> =
             self.Thingo.ToBytes()
 
+    type ChannelFlags = {
+        AnnounceChannel: bool
+    } with
+        static member private AnnounceChannelMask: uint8 = 1uy
+
+        static member FromUInt8(flags: uint8): ChannelFlags = {
+            AnnounceChannel = (flags &&& ChannelFlags.AnnounceChannelMask) = ChannelFlags.AnnounceChannelMask
+        }
+
+        member self.IntoUInt8(): uint8 =
+            if self.AnnounceChannel then
+                ChannelFlags.AnnounceChannelMask
+            else
+                0uy
+

--- a/src/DotNetLightning.Core/Utils/SeqConsumer.fs
+++ b/src/DotNetLightning.Core/Utils/SeqConsumer.fs
@@ -1,0 +1,59 @@
+namespace DotNetLightning.Utils
+
+type SeqConsumer<'SeqElement, 'T> = {
+    Consume: seq<'SeqElement> -> Option<seq<'SeqElement> * 'T>
+}
+
+type SeqConsumerBuilder<'SeqElement>() =
+    member __.Bind<'Arg, 'Return>(seqConsumer0: SeqConsumer<'SeqElement, 'Arg>,
+                                  func: 'Arg -> SeqConsumer<'SeqElement, 'Return>
+                                 ): SeqConsumer<'SeqElement, 'Return> = {
+        Consume = fun (sequence0: seq<'SeqElement>) ->
+            match seqConsumer0.Consume sequence0 with
+            | None -> None
+            | Some (sequence1, value0) ->
+                let seqConsumer1 = func value0
+                seqConsumer1.Consume sequence1
+    }
+
+    member __.Return<'T>(value: 'T)
+                            : SeqConsumer<'SeqElement, 'T> = {
+        Consume = fun (sequence: seq<'SeqElement>) -> Some (sequence, value)
+    }
+
+    member __.ReturnFrom<'T>(seqConsumer: SeqConsumer<'SeqElement, 'T>): SeqConsumer<'SeqElement, 'T> =
+        seqConsumer
+
+    member __.Zero(): SeqConsumer<'SeqElement, unit> = {
+        Consume = fun (sequence: seq<'SeqElement>) -> Some (sequence, ())
+    }
+
+module SeqConsumer =
+    let seqConsumer<'SeqElement> = SeqConsumerBuilder<'SeqElement>()
+
+    let NextInSeq<'SeqElement>(): SeqConsumer<'SeqElement, 'SeqElement> = {
+        Consume = fun (sequence: seq<'SeqElement>) ->
+            match Seq.tryHead sequence with
+            | None -> None
+            | Some value -> Some (Seq.tail sequence, value)
+    }
+
+    let AbortSeqConsumer<'SeqElement, 'T>(): SeqConsumer<'SeqElement, 'T> = {
+        Consume = fun (_sequence: seq<'SeqElement>) -> None
+    }
+
+    type ConsumeAllError =
+        | SequenceEndedTooEarly
+        | SequenceNotReadToEnd
+
+    let ConsumeAll<'SeqElement, 'T>(sequence: seq<'SeqElement>) (seqConsumer: SeqConsumer<'SeqElement, 'T>)
+                              : Result<'T, ConsumeAllError> =
+        match seqConsumer.Consume sequence with
+        | None -> Error SequenceEndedTooEarly
+        | Some (consumedSequence, value) ->
+            if Seq.isEmpty consumedSequence then
+                Ok value
+            else
+                Error SequenceNotReadToEnd
+
+

--- a/src/ResultUtils/OptionCE.fs
+++ b/src/ResultUtils/OptionCE.fs
@@ -1,0 +1,73 @@
+namespace ResultUtils
+
+open System
+
+[<AutoOpen>]
+module OptionCE =
+  type OptionBuilder() =
+    member __.Return<'T>(value: 'T): Option<'T> =
+        Some value
+
+    member __.ReturnFrom<'T>(opt: Option<'T>): Option<'T> =
+        opt
+
+    member this.Zero(): Option<unit> =
+        Some ()
+
+    member __.Bind<'T, 'U>(opt: Option<'T>, binder: 'T -> Option<'U>)
+                              : Option<'U> =
+        Option.bind binder opt
+
+    member __.Delay<'T>(continuation: unit -> Option<'T>)
+                           : unit -> Option<'T> =
+        continuation
+
+    member __.Run<'T>(continuation: unit -> Option<'T>)
+                         : Option<'T> =
+        continuation()
+
+    member this.Combine<'T>(opt: Option<unit>, binder: unit -> Option<'T>)
+                               : Option<'T> =
+        this.Bind(opt, binder)
+
+    member this.TryWith<'T>(generator: unit -> Option<'T>, handler: exn -> Option<'T>)
+                               : Option<'T> =
+        try
+            this.Run generator
+        with
+        | e -> handler e
+
+    member this.TryFinally<'T>(generator: unit -> Option<'T>, final: unit -> unit)
+                                  : Option<'T> =
+        try
+            this.Run generator
+        finally
+            final()
+
+    member this.Using<'T, 'U when 'T :> IDisposable>(resource: 'T, binder: 'T -> Option<'U>)
+                                                        : Option<'U> =
+        this.TryFinally (
+            (fun () -> binder resource),
+            (fun () ->
+                if not <| obj.ReferenceEquals(resource, null) then
+                    resource.Dispose ()
+            )
+        )
+
+    member this.While(guard: unit -> bool, generator: unit -> Option<unit>)
+                         : Option<unit> =
+      if not <| guard () then
+          this.Zero ()
+      else
+          this.Bind(this.Run generator, fun () -> this.While (guard, generator))
+
+    member this.For<'T, 'Sequence when 'Sequence :> seq<'T> >(sequence: 'Sequence, binder: 'T -> Option<unit>)
+                                                             : Option<unit> =
+        this.Using(sequence.GetEnumerator (), fun enumerator ->
+            this.While(enumerator.MoveNext, this.Delay(fun () -> binder enumerator.Current))
+        )
+
+[<AutoOpen>]
+module OptionCEExtensions =
+    let option = OptionBuilder()
+

--- a/src/ResultUtils/ResultUtils.fsproj
+++ b/src/ResultUtils/ResultUtils.fsproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="Option.fs" />
+    <Compile Include="OptionCE.fs" />
     <Compile Include="Result.fs" />
     <Compile Include="ResultCE.fs" />
     <Compile Include="ResultOp.fs" />

--- a/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
+++ b/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
@@ -97,7 +97,7 @@ let openChannelGen =
         <*> delayedPaymentBasepointGen
         <*> htlcBasepointGen
         <*> perCommitmentPointGen
-        <*> Arb.generate<uint8>
+        <*> channelFlagsGen
         <*> (Gen.optionOf shutdownScriptPubKeyGen)
 
 let acceptChannelGen =

--- a/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
+++ b/tests/DotNetLightning.Core.Tests/Generators/Msgs.fs
@@ -98,7 +98,7 @@ let openChannelGen =
         <*> htlcBasepointGen
         <*> perCommitmentPointGen
         <*> Arb.generate<uint8>
-        <*> (Gen.optionOf pushScriptGen)
+        <*> (Gen.optionOf shutdownScriptPubKeyGen)
 
 let acceptChannelGen =
     let constructor = fun a b c d e f g h i j k l m n o ->
@@ -135,7 +135,7 @@ let acceptChannelGen =
         <*> delayedPaymentBasepointGen
         <*> htlcBasepointGen
         <*> perCommitmentPointGen
-        <*> (Gen.optionOf pushScriptGen)
+        <*> (Gen.optionOf shutdownScriptPubKeyGen)
 
 let fundingCreatedGen =
     let constructor = fun a b c d ->
@@ -169,7 +169,7 @@ let fundingLockedGen = gen {
 
 let shutdownGen = gen {
     let! c = ChannelId <!> uint256Gen
-    let! sc = pushScriptGen 
+    let! sc = shutdownScriptPubKeyGen 
     return { ChannelId = c; ScriptPubKey = sc }
 }
 

--- a/tests/DotNetLightning.Core.Tests/Generators/Primitives.fs
+++ b/tests/DotNetLightning.Core.Tests/Generators/Primitives.fs
@@ -7,6 +7,7 @@ open DotNetLightning.Crypto
 open System
 open DotNetLightning.Crypto
 
+let boolGen = Gen.oneof [ gen { return true }; gen { return false } ]
 let byteGen = byte <!> Gen.choose(0, 127)
 let bytesGen = Gen.listOf(byteGen) |> Gen.map(List.toArray)
 let bytesOfNGen(n) = Gen.listOfLength n byteGen |> Gen.map(List.toArray)
@@ -70,6 +71,13 @@ let signatureGen: Gen<LNECDSASignature> = gen {
     let! h = uint256Gen
     let! k = keyGen
     return k.Sign(h, false) |> LNECDSASignature
+}
+
+let channelFlagsGen = gen {
+    let! announceChannel = boolGen
+    return {
+        AnnounceChannel = announceChannel
+    }
 }
 
 // scripts

--- a/tests/DotNetLightning.Core.Tests/Generators/Primitives.fs
+++ b/tests/DotNetLightning.Core.Tests/Generators/Primitives.fs
@@ -78,6 +78,10 @@ let pushOnlyOpcodeGen = bytesOfNGen(4) |> Gen.map(Op.GetPushOp)
 let pushOnlyOpcodesGen = Gen.listOf pushOnlyOpcodeGen
 
 let pushScriptGen = Gen.nonEmptyListOf pushOnlyOpcodeGen |> Gen.map(fun ops -> Script(ops))
+let shutdownScriptPubKeyGen = gen {
+    let! pubKey = pubKeyGen
+    return ShutdownScriptPubKey.FromPubKeyP2pkh pubKey
+}
 
 let cipherSeedGen = gen {
     let! v = Arb.generate<uint8>

--- a/tests/DotNetLightning.Core.Tests/KeyRepositoryTests.fs
+++ b/tests/DotNetLightning.Core.Tests/KeyRepositoryTests.fs
@@ -132,9 +132,9 @@ let tests =
                                           n
             
             let _remoteSigForRemoteCommit, remoteCommitTx2 = remotePrivKeys.SignWithFundingPrivKey remoteCommitTx.Value
-            let localSigForRemoteCommit, commitTx3 = localPrivKeys.SignWithFundingPrivKey remoteCommitTx2
+            let localSigForRemoteCommit, _commitTx3 = localPrivKeys.SignWithFundingPrivKey remoteCommitTx2
             
             let localSigs = seq [(localPubKeys.FundingPubKey.RawPubKey(), TransactionSignature(localSigForRemoteCommit.Signature, SigHash.All))]
-            let finalizedTx = Transactions.checkTxFinalized remoteCommitTx2 0 localSigs |> Result.deref
+            let _finalizedTx = Transactions.checkTxFinalized remoteCommitTx2 0 localSigs |> Result.deref
             ()
     ]

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -489,7 +489,9 @@ module SerializationTest =
                         DelayedPaymentBasepoint = DelayedPaymentBasepoint pubkey4
                         HTLCBasepoint = HtlcBasepoint pubkey5
                         FirstPerCommitmentPoint = PerCommitmentPoint pubkey6
-                        ChannelFlags = if randomBit then 1uy <<< 5 else 0uy
+                        ChannelFlags = {
+                            AnnounceChannel = randomBit
+                        }
                         ShutdownScriptPubKey =
                             if shutdown then
                                 Some <| ShutdownScriptPubKey.FromPubKeyP2pkh pubkey1
@@ -504,7 +506,7 @@ module SerializationTest =
                         expected <- Array.append expected (hex.DecodeData("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"))
                     expected <- Array.append expected (hex.DecodeData("02020202020202020202020202020202020202020202020202020202020202021234567890123456233403289122369832144668701144767633030896203198784335490624111800083a840000034d000c89d4c0bcc0bc031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076602531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe33703462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f703f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a"))
                     if randomBit then
-                        expected <- Array.append expected (hex.DecodeData("20"))
+                        expected <- Array.append expected (hex.DecodeData("01"))
                     else
                         expected <- Array.append expected (hex.DecodeData("00"))
                     if shutdown then

--- a/tests/DotNetLightning.Core.Tests/Serialization.fs
+++ b/tests/DotNetLightning.Core.Tests/Serialization.fs
@@ -490,7 +490,11 @@ module SerializationTest =
                         HTLCBasepoint = HtlcBasepoint pubkey5
                         FirstPerCommitmentPoint = PerCommitmentPoint pubkey6
                         ChannelFlags = if randomBit then 1uy <<< 5 else 0uy
-                        ShutdownScriptPubKey = if shutdown then Some (pubkey1.Hash.ScriptPubKey) else None
+                        ShutdownScriptPubKey =
+                            if shutdown then
+                                Some <| ShutdownScriptPubKey.FromPubKeyP2pkh pubkey1
+                            else
+                                None
                     }
                     let actual = openChannelMsg.ToBytes()
                     let mutable expected = [||]
@@ -529,7 +533,11 @@ module SerializationTest =
                         DelayedPaymentBasepoint = DelayedPaymentBasepoint pubkey4
                         HTLCBasepoint = HtlcBasepoint pubkey5
                         FirstPerCommitmentPoint = PerCommitmentPoint pubkey6
-                        ShutdownScriptPubKey = if shutdown then Some(pubkey1.Hash.ScriptPubKey) else None
+                        ShutdownScriptPubKey =
+                            if shutdown then
+                                Some <| ShutdownScriptPubKey.FromPubKeyP2pkh pubkey1
+                            else
+                                None
                     }
                     let actual = acceptChannelMsg.ToBytes()
                     let mutable expected = hex.DecodeData("020202020202020202020202020202020202020202020202020202020202020212345678901234562334032891223698321446687011447600083a840000034d000c89d4c0bcc0bc031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076602531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe33703462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f703f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a")
@@ -573,13 +581,13 @@ module SerializationTest =
                     let script = Script("OP_TRUE")
                     let spk =
                         if (scriptType = 1uy) then
-                            pubkey1.Hash.ScriptPubKey
+                            ShutdownScriptPubKey.FromPubKeyP2pkh pubkey1
                         else if (scriptType = 2uy) then
-                            script.Hash.ScriptPubKey
+                            ShutdownScriptPubKey.FromScriptP2sh script
                         else if (scriptType = 3uy) then
-                            pubkey1.WitHash.ScriptPubKey
+                            ShutdownScriptPubKey.FromPubKeyP2wpkh pubkey1
                         else
-                            script.WitHash.ScriptPubKey
+                            ShutdownScriptPubKey.FromScriptP2wsh script
                     let shutdownMsg = {
                         ShutdownMsg.ChannelId = ChannelId(uint256[| for _ in 0..31 -> 2uy|])
                         ScriptPubKey = spk

--- a/tests/DotNetLightning.Core.Tests/TransactionTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TransactionTests.fs
@@ -14,17 +14,11 @@ let n = Network.RegTest
 [<Tests>]
 let testList = [
     testCase "check pre-computed transaction weights" <| fun _ ->
-        let localRevocationPriv = [| for _ in 0..31 -> 0xccuy |] |> fun b -> new Key(b)
         let localPaymentPriv = [| for _ in 0..31 -> 0xdduy |] |> fun b -> new Key(b)
-        let remotePaymentPriv = [| for _ in 0..31 -> 0xeeuy |] |> fun b -> new Key(b)
-        let localHtlcPriv = [| for _ in 0..31 -> 0xeauy |] |> fun b -> new Key(b)
-        let remoteHtlcPriv = [| for _ in 0..31 -> 0xebuy |] |> fun b -> new Key(b)
-        let localFinalPriv = [| for _ in 0..31 -> 0xffuy |] |> fun b -> new Key(b)
         let finalSpk =
             let s = [| for _ in 0..31 -> 0xfeuy |] |> fun b -> new Key(b)
             s.PubKey.WitHash
         let localDustLimit = 546L |> Money.Satoshis
-        let toLocalDelay= 144us |> BlockHeightOffset16
         let feeRatePerKw = 1000u |> FeeRatePerKw
         
         let _ =

--- a/tests/DotNetLightning.Core.Tests/TxOutLexicographicCompareTests.fs
+++ b/tests/DotNetLightning.Core.Tests/TxOutLexicographicCompareTests.fs
@@ -11,8 +11,8 @@ let tests =
              (script0: array<byte>)
              (script1: array<byte>)
              (expected: int) =
-        let txOut0 = TxOut(Money amount0, Script script0)
-        let txOut1 = TxOut(Money amount1, Script script1)
+        let txOut0 = TxOut(Money (int64 amount0), Script script0)
+        let txOut1 = TxOut(Money (int64 amount1), Script script1)
         let result = TxOut.LexicographicCompare txOut0 txOut1
         Expect.equal
             result

--- a/tests/EventAggregator.Tests/Sample.fs
+++ b/tests/EventAggregator.Tests/Sample.fs
@@ -14,14 +14,14 @@ let tests =
       let mutable eventWasRaised = false
       let agg: IEventAggregator = ReactiveEventAggregator() :> IEventAggregator
 
-      agg.GetObservable<SampleEvent>() |> Observable.subscribe(fun se -> eventWasRaised <- true) |> ignore
+      agg.GetObservable<SampleEvent>() |> Observable.subscribe(fun _se -> eventWasRaised <- true) |> ignore
       agg.Publish<SampleEvent>({ Status = 1 })
       Expect.isTrue eventWasRaised ""
 
     testCase "Unsubscribe" <| fun _ ->
       let mutable eventWasRaised = false
       let agg = ReactiveEventAggregator() :> IEventAggregator
-      let subscription = agg.GetObservable<SampleEvent>() |> Observable.subscribe(fun se -> eventWasRaised <- true)
+      let subscription = agg.GetObservable<SampleEvent>() |> Observable.subscribe(fun _se -> eventWasRaised <- true)
       subscription.Dispose() |> ignore
       agg.Publish<SampleEvent>({ Status = 1})
       Expect.isFalse eventWasRaised ""
@@ -31,7 +31,8 @@ let tests =
       let agg = ReactiveEventAggregator() :> IEventAggregator
       agg.GetObservable<SampleEvent>()
         |> Observable.filter(fun se -> se.Status = 1)
-        |> Observable.subscribe(fun se -> eventWasRaised <- true)
+        |> Observable.subscribe(fun _se -> eventWasRaised <- true)
+        |> ignore
 
       agg.Publish<SampleEvent>({ Status = 0 })
       Expect.isFalse eventWasRaised ""


### PR DESCRIPTION
Refactor DNL's `Channel` type in order to (a) separate state which is saved to the wallet from transient state which is discarded on disconnection, (b) simplify the API to make it less confusing, less bug-prone and require less duplicated effort between DNL and geewallet.