### PR TITLE
Move and export fee mismatch calculation function

### DIFF
--- a/src/DotNetLightning.Core/Channel/ChannelError.fs
+++ b/src/DotNetLightning.Core/Channel/ChannelError.fs
@@ -255,11 +255,6 @@ module private ValidationHelper =
 /// Helpers to create channel error
 [<AutoOpen>]
 module internal ChannelError =
-    let feeRateMismatch (FeeRatePerKw remote, FeeRatePerKw local) =
-        let remote = float remote
-        let local = float local
-        abs (2.0 * (remote - local) / (remote + local))
-
     let inline feeDeltaTooHigh msg (actualDelta, maxAccepted) =
         InvalidUpdateFeeError.Create
             msg
@@ -366,7 +361,7 @@ module internal OpenChannelMsgValidation =
                        (maxFeeRateMismatchRatio: float) =
         let localFeeRatePerKw =
             feeEstimator.GetEstSatPer1000Weight(ConfirmationTarget.Background)
-        let diff = feeRateMismatch(remoteFeeRatePerKw, localFeeRatePerKw)
+        let diff = remoteFeeRatePerKw.MismatchRatio localFeeRatePerKw
         if (diff > maxFeeRateMismatchRatio) then
             sprintf
                 "Peer's feerate (%A) was unacceptably far from the estimated fee rate of %A"
@@ -600,7 +595,7 @@ module internal UpdateAddHTLCValidationWithContext =
 module internal UpdateFeeValidation =
     let checkFeeDiffTooHigh (msg: UpdateFeeMsg) (localFeeRatePerKw: FeeRatePerKw) (maxFeeRateMismatchRatio) =
         let remoteFeeRatePerKw = msg.FeeRatePerKw
-        let diff = feeRateMismatch(remoteFeeRatePerKw, localFeeRatePerKw)
+        let diff = remoteFeeRatePerKw.MismatchRatio localFeeRatePerKw
         if (diff > maxFeeRateMismatchRatio) then
             (diff, maxFeeRateMismatchRatio)
             |> feeDeltaTooHigh msg

--- a/src/DotNetLightning.Core/Utils/Primitives.fs
+++ b/src/DotNetLightning.Core/Utils/Primitives.fs
@@ -338,12 +338,18 @@ module Primitives =
         member this.AsNBitcoinFeeRate() =
             this.Value |> uint64 |> (*)4UL |> Money.Satoshis |> FeeRate
 
+        member this.MismatchRatio (other: FeeRatePerKw) =
+            let local = double this.Value
+            let remote = double other.Value
+            abs (2.0 * (remote - local) / (remote + local))
+
         static member Max(a: FeeRatePerKw, b: FeeRatePerKw) =
             if (a.Value >= b.Value) then a else b
         static member (+) (a: FeeRatePerKw, b: uint32) =
             (a.Value + b) |> FeeRatePerKw
         static member (*) (a: FeeRatePerKw, b: uint32) =
             (a.Value * b) |> FeeRatePerKw
+
     /// Block Hash
     type BlockId = | BlockId of uint256 with
         member x.Value = let (BlockId v) = x in v


### PR DESCRIPTION
Move/rename ChannelError.feeRateMismatch to FeeRatePerKw.MismatchRatio.

This function is useful outside of DotNetLightning, so we now export it
so that library consumers can use it.